### PR TITLE
Implement isTruthy() and isFalsy()

### DIFF
--- a/lib/buster-assertions.js
+++ b/lib/buster-assertions.js
@@ -476,6 +476,26 @@
         values: actualMessageValues
     });
 
+    ba.add("isTruthy", {
+        assert: function (actual) {
+            return !!actual;
+        },
+        assertMessage: "${1}Expected ${0} to be truthy",
+        refuteMessage: "${1}Expected ${0} to not be truthy",
+        expectation: "toBeTruthy",
+        values: actualMessageValues
+    });
+
+    ba.add("isFalsy", {
+        assert: function (actual) {
+            return !actual;
+        },
+        assertMessage: "${1}Expected ${0} to be falsy",
+        refuteMessage: "${1}Expected ${0} to not be falsy",
+        expectation: "toBeFalsy",
+        values: actualMessageValues
+    });
+
     ba.add("isString", {
         assert: function (actual) {
             return typeof actual == "string";

--- a/test/buster-assertions-test.js
+++ b/test/buster-assertions-test.js
@@ -175,6 +175,37 @@
         fail("for undefined", undefined);
     });
 
+    testHelper.assertionTests("assert", "isTruthy", function (pass, fail, msg) {
+        pass("for true", true);
+        fail("for false", false);
+        msg("represent expected value in message",
+            "[assert.isTruthy] Expected false to be truthy", false);
+        msg("include custom message",
+            "[assert.isTruthy] Oh: Expected false to be truthy", false, "Oh");
+        pass("for object", {});
+        pass("for array", []);
+        pass("for string", "32");
+        pass("for number", 32);
+        msg("fail if not passed arguments",
+            "[assert.isTruthy] Expected to receive at least 1 argument");
+    });
+
+    testHelper.assertionTests("assert", "isFalsy", function (pass, fail, msg, callbacks) {
+        pass("for false", false);
+        fail("for true", true);
+        msg("fail with message",
+            "[assert.isFalsy] Expected true to be falsy", true);
+        msg("fail with custom message",
+            "[assert.isFalsy] Nooo! Expected true to be falsy", true, "Nooo!");
+        msg("represent expected value in message",
+            "[assert.isFalsy] Expected [object Object] to be falsy", {});
+        pass("for empty string", "");
+        pass("for 0", 0);
+        pass("for NaN", NaN);
+        pass("for null", null);
+        pass("for undefined", undefined);
+    });
+
     var obj = { id: 42 };
     var obj2 = { id: 42 };
 

--- a/test/buster-assertions/expect-test.js
+++ b/test/buster-assertions/expect-test.js
@@ -102,5 +102,9 @@ buster.util.testCase("ExpectTest", {
         expect({ tagName: "ol" }).not().toHaveTagName("li");
         expect({ className: "a b c" }).toHaveClassName("b");
         expect({ className: "a b c" }).not().toHaveClassName("d");
+        expect(true).toBeTruthy();
+        expect(false).not().toBeTruthy();
+        expect(false).toBeFalsy();
+        expect(true).not().toBeFalsy();
     }
 });


### PR DESCRIPTION
Copy behaviour of related Jasmine matchers, see github issue busterjs/buster#91.

I may implement the other Jasmine matchers, but will probably do some of them by aliasing them to existing expectations.
