### PR TITLE
Change signature of assert.exception().

### DIFF
--- a/lib/buster-assertions.js
+++ b/lib/buster-assertions.js
@@ -583,7 +583,7 @@
 
     ba.captureException = captureException;
 
-    assert.exception = function (callback, exception, message) {
+    assert.exception = function (callback, expected, message) {
         countAssertion();
         if (!assertEnoughArguments("assert.exception", arguments, 1)) return
 
@@ -591,34 +591,64 @@
             return;
         }
 
+        var pass = false, expectedName = '', failMessage = "exceptionMessageMismatchMessage";
         var err = captureException(callback);
         message = msg(message);
 
         if (!err) {
-            if (exception) {
+            if (expected) {
                 return fail.call({}, "assert", "exception", "typeNoExceptionMessage",
-                                 message, exception);
+                                 message, expected.name);
             } else {
                 return fail.call({}, "assert", "exception", "message",
-                                 message, exception);
+                                 message, expected);
             }
         }
 
-        if (exception && err.name != exception) {
+        if (expected) {
+            expectedName = expected.name || expected;
+            // Test the exception message against a string
+            if (typeof expected === "string") {
+                pass = (err.message === expected);
+            // Test the exception message against a RegExp
+            } else if (expected instanceof RegExp) {
+                pass = expected.test(err.message);
+            } else if (typeof expected === "function") {
+                if (expected.name === "") {
+                    // If expected is an anonymous function, pass it the exception
+                    // and expect it to return true for pass.
+                    failMessage = "callbackReturnedFalseMessage";
+                    pass = (expected.call({}, err) === true);
+                } else {
+                    // If expected is a named function, consider it a contructer
+                    // and expect the exception to be of the same type.
+                    failMessage = "typeFailMessage";
+                    pass = (err instanceof expected);
+                }
+            }
+        } else {
+            // No specific checks are required, only that an exception was
+            // thrown, and if we reach this point then one was.
+            pass = true;
+        }
+
+        if (pass) {
+            ba.emit("pass", "assert.exception", message, callback, expected);
+        } else {
             if (typeof window != "undefined" && typeof console != "undefined") {
                 console.log(err);
             }
 
-            return fail.call({}, "assert", "exception", "typeFailMessage",
-                             message, exception, err.name, err.message);
+            return fail.call({}, "assert", "exception", failMessage,
+                             message, expectedName, err.name, err.message);
         }
-
-        ba.emit("pass", "assert.exception", message, callback, exception);
     };
 
     assert.exception.typeNoExceptionMessage = "${0}Expected ${1} but no exception was thrown";
     assert.exception.message = "${0}Expected exception";
     assert.exception.typeFailMessage = "${0}Expected ${1} but threw ${2} (${3})";
+    assert.exception.exceptionMessageMismatchMessage = "${0}Expected exception message to match ${1} but threw ${2} (${3})";
+    assert.exception.callbackReturnedFalseMessage = "${0}Expected ${1} to return true for ${2} (${3})";
     assert.exception.expectationName = "toThrow";
 
     refute.exception = function (callback) {

--- a/test/buster-assertions-test.js
+++ b/test/buster-assertions-test.js
@@ -1067,34 +1067,94 @@
 
         pass("when callback throws expected type", function () {
             throw new TypeError("Oh hmm");
-        }, "TypeError");
+        }, TypeError);
 
         fail("when callback does not throw expected type", function () {
             throw new Error();
-        }, "TypeError");
+        }, TypeError);
 
         fail("when callback does not throw and specific type is expected",
-             function () {}, "TypeError");
+             function () {}, TypeError);
+
+        pass("when exception message matches provided string", function () {
+            throw new TypeError("Oh hmm");
+        }, "Oh hmm");
+
+        fail("when exception message does not match provided string", function () {
+            throw new TypeError("Oh hai");
+        }, "Oh hmm");
+
+        pass("when exception message matches provided RegExp", function () {
+            throw new TypeError("Oh hmm");
+        }, /hmm/);
+
+        fail("when exception message does not match provided RegExp", function () {
+            throw new TypeError("Oh hai");
+        }, /hmm/);
+
+        pass("when provided callback returns true", function () {
+            throw new TypeError("Oh hmm");
+        }, function(err) { return err.message === "Oh hmm";});
+
+        fail("when provided callback returns false", function () {
+            throw new TypeError("Oh hai");
+        }, function(err) { return false; });
 
         msg("fail with message when not throwing",
             "[assert.exception] Expected TypeError but no exception was thrown",
-            function () {}, "TypeError").expectedFormats = 0;
+            function () {}, TypeError).expectedFormats = 0;
 
         msg("fail with custom message",
             "[assert.exception] Hmm: Expected TypeError but no exception was thrown",
-            function () {}, "TypeError", "Hmm").expectedFormats = 0;
+            function () {}, TypeError, "Hmm").expectedFormats = 0;
 
         msg("fail with message when throwing wrong kind of exception",
             "[assert.exception] Expected TypeError but threw Error (:()",
             function () {
                 throw new Error(":(");
-            }, "TypeError").expectedFormats = 0;
+            }, TypeError).expectedFormats = 0;
 
         msg("fail with custom message when throwing wrong kind of exception",
             "[assert.exception] Wow: Expected TypeError but threw Error (:()",
             function () {
                 throw new Error(":(");
-            }, "TypeError", "Wow").expectedFormats = 0;
+            }, TypeError, "Wow").expectedFormats = 0;
+
+        msg("fail with message when exception message does not match string",
+            "[assert.exception] Expected exception message to match :) but threw Error (:()",
+            function () {
+                throw new Error(":(");
+            }, ":)").expectedFormats = 0;
+
+        msg("fail with custom message when exception message does not match string",
+            "[assert.exception] Wow: Expected exception message to match :) but threw Error (:()",
+            function () {
+                throw new Error(":(");
+            }, ":)", "Wow").expectedFormats = 0;
+
+        msg("fail with message when exception message does not match RegExp",
+            "[assert.exception] Expected exception message to match /bar/ but threw Error (foo)",
+            function () {
+                throw new Error("foo");
+            }, /bar/).expectedFormats = 0;
+
+        msg("fail with custom message when exception message does not match RegExp",
+            "[assert.exception] Wow: Expected exception message to match /bar/ but threw Error (foo)",
+            function () {
+                throw new Error("foo");
+            }, /bar/, "Wow").expectedFormats = 0;
+
+        msg("fail with message when callback returns false",
+            "[assert.exception] Expected function (err) { return false; } to return true for Error (foo)",
+            function () {
+                throw new Error("foo");
+            }, function(err) { return false; }).expectedFormats = 0;
+
+        msg("fail with custom message when callback returns false",
+            "[assert.exception] Wow: Expected function (err) { return false; } to return true for Error (foo)",
+            function () {
+                throw new Error("foo");
+            }, function(err) { return false; }, "Wow").expectedFormats = 0;
 
         msg("if not passed arguments",
             "[assert.exception] Expected to receive at least 1 argument");

--- a/test/buster-assertions/expect-test.js
+++ b/test/buster-assertions/expect-test.js
@@ -90,7 +90,10 @@ buster.util.testCase("ExpectTest", {
         expect(42).not.toBeNull();
         expect(obj).toMatch({ id: 42 });
         expect(obj).not.toMatch({ id: 37 });
-        expect(function () { throw new TypeError("Oops"); }).toThrow("TypeError");
+        expect(function () { throw new TypeError("Oops"); }).toThrow(TypeError);
+        expect(function () { throw new TypeError("Oops"); }).toThrow("Oops");
+        expect(function () { throw new TypeError("Oops"); }).toThrow(/Oo/);
+        expect(function () { throw new TypeError("Oops"); }).toThrow(function(err) { return err.message === "Oops";});
         expect(function () {}).not.toThrow();
         expect({ tagName: "li" }).toHaveTagName("li");
         expect({ tagName: "ol" }).not.toHaveTagName("li");


### PR DESCRIPTION
Allows exceptions messages to be tested against a string or RegExp,
exception type to be tested, or exception to be verified against a user
provided callback.

Examples below with corresponding messages.

```
assert.exception(function() { throw new Error("foo"); }, TypeError);
// [assert.exception] Expected TypeError but threw Error (foo)

assert.exception(function() { throw new Error("foo"); }, "bar");
// [assert.exception] Expected exception message to match bar but threw Error (foo)

assert.exception(function() { throw new Error("foo"); }, /bar/);
// [assert.exception] Expected exception message to match /bar/ but threw Error (foo)

assert.exception(function() { throw new Error("foo"); }, function(err) { return err.message === "bar"; });
// Expected function (err) { return err.message === "bar"; } to return true for Error (foo)
```
