### PR TITLE
Make assert.exception fail/pass when expected exception type is given as string

### DIFF
--- a/lib/referee.js
+++ b/lib/referee.js
@@ -497,7 +497,9 @@
 
         if (typeof matcher === "string") {
             message = matcher;
-            matcher = undefined;
+            matcher = function(err) {
+                return referee.match(err, message);
+            };
         }
 
         var err = captureException(callback);

--- a/test/referee-test.js
+++ b/test/referee-test.js
@@ -1097,7 +1097,7 @@
         }
         Class.prototype.methodA = function() {};
         Class.prototype.methodB = function() {};
-        
+
         fail("when keys are exact", {a: 1, b: 2, c: 3}, ['a', 'b', 'c']);
         pass("when keys are missing", {a: 1, b: 2, c: 3}, ['a', 'b']);
         pass("when keys are excess", {a: 1, b: 2, c: 3}, ['a', 'b', 'c', 'd']);
@@ -1123,6 +1123,14 @@
         fail("when callback does not throw expected name", function () {
             throw new Error();
         }, { name: "TypeError" });
+
+        pass("when callback throws expected name (as string)", function () {
+            throw new TypeError("Oh hmm");
+        }, "TypeError");
+
+        fail("when callback does not throw expected name (as string)", function () {
+            throw new Error();
+        }, "TypeError");
 
         fail("when thrown message does not match", function () {
             throw new Error("Aright");


### PR DESCRIPTION
Attempt to fix busterjs/buster#387 simply
