### PR TITLE
Add files directive to package.json to speed up installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
       "lib/test-helper.js"
     ]
   },
+  "files": [
+    "docs/",
+    "lib/",
+    "!lib/test-helper.js",
+    "!lib/**/*.test.js"
+  ],
   "devDependencies": {
     "eslint": "^4.18.1",
     "eslint-config-sinon": "^1.0.3",


### PR DESCRIPTION
Used negate expressions in `package.json` files entry, although it goes
against recommendation below, because that's the only thing that
worked. Read the github references below for details.

> "The consequences are undefined" if you try to negate any of the files
> entries (that is, "!foo.js"). Please don't. Use .npmignore.

https://github.com/npm/npm/wiki/Files-and-Ignores#details

```text
.
├── LICENSE
├── README.md
├── docs
│   └── index.md
├── lib
│   ├── expect.js
│   └── referee.js
└── package.json
```

#### How to verify

This uses [`tree`](https://en.wikipedia.org/wiki/Tree_(Unix)), on macOS install it using `brew install tree`

1. Check out this branch
1. `npm install`
1. `npm pack`
1. Unpack the `sinonjs-referee-2.0.0.tgz` just created
1. `cd package`
1. `tree .`
1. Observe that you see the same as the example above