### PR TITLE
Remove UMD wrapper and (most of) lodash

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 coverage/
+dist/
 docs/
+site/

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,7 +1,6 @@
 extends: 'eslint-config-sinon'
 
 env:
-  amd: true
   browser: true
   node: true
 
@@ -9,7 +8,7 @@ plugins:
   - ie11
 
 rules:
-  strict: [error, 'function']
+  strict: [error, 'global']
 
   ie11/no-collection-args: error
   ie11/no-for-in-const: error

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .idea
 site
 coverage/
+dist/

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -3,7 +3,7 @@
 var objectAssign = require("object-assign");
 var arrayFrom = require("array.from");
 
-var expect = function (actual) {
+function expect(actual) {
     var expectation = objectAssign(Object.create(expect.expectation), {
         actual: actual,
         assertMode: true
@@ -14,11 +14,11 @@ var expect = function (actual) {
     });
 
     return expectation;
-};
+}
 
 expect.expectation = Object.create(null);
 
-expect.wrapAssertion = function (assertion, expectation, referee) {
+expect.wrapAssertion = function wrapAssertion(assertion, expectation, referee) {
     expect.expectation[expectation] = function () {
         var args = [this.actual].concat(arrayFrom(arguments));
         var type = this.assertMode ? "assert" : "refute";
@@ -45,7 +45,7 @@ expect.wrapAssertion = function (assertion, expectation, referee) {
     };
 };
 
-expect.init = function (referee) {
+expect.init = function init(referee) {
     Object.keys(referee.assert).forEach(function (name) {
         var expectationName = referee.assert[name].expectationName;
         if (expectationName) {

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,14 +1,18 @@
 "use strict";
 
 var _ = require("lodash");
+var objectAssign = require("object-assign");
 
 var expect = function (actual) {
-    var expectation = _.extend(Object.create(expect.expectation), {
+    var expectation = objectAssign(Object.create(expect.expectation), {
         actual: actual,
         assertMode: true
     });
-    expectation.not = Object.create(expectation);
-    expectation.not.assertMode = false;
+
+    expectation.not = objectAssign(Object.create(expectation), {
+        assertMode: false
+    });
+
     return expectation;
 };
 

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var _ = require("lodash");
 var objectAssign = require("object-assign");
 var arrayFrom = require("array.from");
 
@@ -47,7 +46,7 @@ expect.wrapAssertion = function (assertion, expectation, referee) {
 };
 
 expect.init = function (referee) {
-    _.each(_.keys(referee.assert), function (name) {
+    Object.keys(referee.assert).forEach(function (name) {
         var expectationName = referee.assert[name].expectationName;
         if (expectationName) {
             expect.wrapAssertion(name, expectationName, referee);

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -2,20 +2,17 @@
 
 var _ = require("lodash");
 
-function F() {}
-var create = function (object) { F.prototype = object; return new F(); };
-
 var expect = function (actual) {
-    var expectation = _.extend(create(expect.expectation), {
+    var expectation = _.extend(Object.create(expect.expectation), {
         actual: actual,
         assertMode: true
     });
-    expectation.not = create(expectation);
+    expectation.not = Object.create(expectation);
     expectation.not.assertMode = false;
     return expectation;
 };
 
-expect.expectation = {};
+expect.expectation = Object.create(null);
 
 expect.wrapAssertion = function (assertion, expectation, referee) {
     expect.expectation[expectation] = function () {

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -2,6 +2,7 @@
 
 var _ = require("lodash");
 var objectAssign = require("object-assign");
+var arrayFrom = require("array.from");
 
 var expect = function (actual) {
     var expectation = objectAssign(Object.create(expect.expectation), {
@@ -20,7 +21,7 @@ expect.expectation = Object.create(null);
 
 expect.wrapAssertion = function (assertion, expectation, referee) {
     expect.expectation[expectation] = function () {
-        var args = [this.actual].concat(_.toArray(arguments));
+        var args = [this.actual].concat(arrayFrom(arguments));
         var type = this.assertMode ? "assert" : "refute";
         var callFunc;
 

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,78 +1,63 @@
-(function (root, factory) {
-    "use strict";
+"use strict";
 
-    if (typeof define === "function" && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(["lodash"], factory);
-    } else if (typeof module === "object" && module.exports) {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(require("lodash"));
-    } else {
-        // Browser globals (root is window)
-        root.expect = factory(root._);
-    }
-}(typeof self !== "undefined" ? self : this, function (_) {
-    "use strict";
+var _ = require("lodash");
 
-    function F() {}
-    var create = function (object) { F.prototype = object; return new F(); };
+function F() {}
+var create = function (object) { F.prototype = object; return new F(); };
 
-    var expect = function (actual) {
-        var expectation = _.extend(create(expect.expectation), {
-            actual: actual,
-            assertMode: true
-        });
-        expectation.not = create(expectation);
-        expectation.not.assertMode = false;
-        return expectation;
-    };
+var expect = function (actual) {
+    var expectation = _.extend(create(expect.expectation), {
+        actual: actual,
+        assertMode: true
+    });
+    expectation.not = create(expectation);
+    expectation.not.assertMode = false;
+    return expectation;
+};
 
-    expect.expectation = {};
+expect.expectation = {};
 
-    expect.wrapAssertion = function (assertion, expectation, referee) {
-        expect.expectation[expectation] = function () {
-            var args = [this.actual].concat(_.toArray(arguments));
-            var type = this.assertMode ? "assert" : "refute";
-            var callFunc;
+expect.wrapAssertion = function (assertion, expectation, referee) {
+    expect.expectation[expectation] = function () {
+        var args = [this.actual].concat(_.toArray(arguments));
+        var type = this.assertMode ? "assert" : "refute";
+        var callFunc;
 
-            if (assertion === "assert") {
-                callFunc = this.assertMode ? referee.assert : referee.refute;
-            } else if (assertion === "refute") {
-                callFunc = this.assertMode ? referee.refute : referee.assert;
-            } else {
-                callFunc = referee[type][assertion];
-            }
+        if (assertion === "assert") {
+            callFunc = this.assertMode ? referee.assert : referee.refute;
+        } else if (assertion === "refute") {
+            callFunc = this.assertMode ? referee.refute : referee.assert;
+        } else {
+            callFunc = referee[type][assertion];
+        }
 
-            try {
-                return callFunc.apply(referee.expect, args);
-            } catch (e) {
-                e.message = (e.message || "").replace(
-                    "[" + type + "." + assertion + "]",
-                    "[expect." + (this.assertMode ? "" : "not.") +
-                        expectation + "]"
-                );
-                throw e;
-            }
-        };
-    };
-
-    expect.init = function (referee) {
-        _.each(_.keys(referee.assert), function (name) {
-            var expectationName = referee.assert[name].expectationName;
-            if (expectationName) {
-                expect.wrapAssertion(name, expectationName, referee);
-            }
-        });
-
-        expect.wrapAssertion("assert", "toBeTruthy", referee);
-        expect.wrapAssertion("refute", "toBeFalsy", referee);
-
-        if (expect.expectation.toBeNear) {
-            expect.expectation.toBeCloseTo = expect.expectation.toBeNear;
+        try {
+            return callFunc.apply(referee.expect, args);
+        } catch (e) {
+            e.message = (e.message || "").replace(
+                "[" + type + "." + assertion + "]",
+                "[expect." + (this.assertMode ? "" : "not.") +
+                    expectation + "]"
+            );
+            throw e;
         }
     };
+};
 
-    return expect;
-}));
+expect.init = function (referee) {
+    _.each(_.keys(referee.assert), function (name) {
+        var expectationName = referee.assert[name].expectationName;
+        if (expectationName) {
+            expect.wrapAssertion(name, expectationName, referee);
+        }
+    });
+
+    expect.wrapAssertion("assert", "toBeTruthy", referee);
+    expect.wrapAssertion("refute", "toBeFalsy", referee);
+
+    if (expect.expectation.toBeNear) {
+        expect.expectation.toBeCloseTo = expect.expectation.toBeNear;
+    }
+};
+
+module.exports = expect;

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -1,9 +1,9 @@
 "use strict";
 
 var expect = require("./expect");
-var _ = require("lodash");
 var samsam = require("samsam");
 var bane = require("bane");
+var includes = require("lodash.includes");
 var isArguments = require("lodash.isarguments");
 var Promise = require("es6-promise").Promise;
 
@@ -633,7 +633,7 @@ referee.add("hasPrototype", {
 
 referee.add("contains", {
     assert: function (haystack, needle) {
-        return _.include(haystack, needle);
+        return includes(haystack, needle);
     },
     assertMessage: "${customMessage}Expected [${actual}] to contain ${expected}",
     refuteMessage: "${customMessage}Expected [${actual}] not to contain ${expected}",
@@ -680,7 +680,7 @@ referee.add("className", {
         var actual = element.className.split(" ");
         var i, l;
         for (i = 0, l = expected.length; i < l; i++) {
-            if (!_.include(actual, expected[i])) { return false; }
+            if (!includes(actual, expected[i])) { return false; }
         }
 
         return true;

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -29,7 +29,7 @@ function interpolatePosArg(message, values) {
 }
 
 function interpolateProperties(message, properties) {
-    return reduce.call(_.keys(properties), function (str, name) {
+    return reduce.call(Object.keys(properties), function (str, name) {
         var formattedValue = name === "customMessage"
             ? referee.prepareMessage(properties[name])
             : referee.format(properties[name]);

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -4,6 +4,7 @@ var expect = require("./expect");
 var _ = require("lodash");
 var samsam = require("samsam");
 var bane = require("bane");
+var isArguments = require("lodash.isarguments");
 var Promise = require("es6-promise").Promise;
 
 var toString = Object.prototype.toString;
@@ -483,7 +484,7 @@ function isArrayLike(object) {
     return Array.isArray(object) ||
         (!!object && typeof object.length === "number" &&
         typeof object.splice === "function") ||
-        _.isArguments(object);
+        isArguments(object);
 }
 
 referee.isArrayLike = isArrayLike;

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -480,7 +480,7 @@ referee.add("isArray", {
 });
 
 function isArrayLike(object) {
-    return _.isArray(object) ||
+    return Array.isArray(object) ||
         (!!object && typeof object.length === "number" &&
         typeof object.splice === "function") ||
         _.isArguments(object);

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -8,6 +8,7 @@ var Promise = require("es6-promise").Promise;
 
 var toString = Object.prototype.toString;
 var slice = Array.prototype.slice;
+var reduce = Array.prototype.reduce;
 var referee = bane.createEventEmitter();
 
 referee.countAssertion = function countAssertion() {
@@ -22,13 +23,13 @@ function interpolate(string, prop, value) {
 // Interpolate positional arguments. Replaces occurences of ${<index>} in
 // the string with the corresponding entry in values[<index>]
 function interpolatePosArg(message, values) {
-    return _.reduce(values, function (msg, value, index) {
+    return reduce.call(values, function (msg, value, index) {
         return interpolate(msg, index, referee.format(value));
     }, message);
 }
 
 function interpolateProperties(message, properties) {
-    return _.reduce(_.keys(properties), function (str, name) {
+    return reduce.call(_.keys(properties), function (str, name) {
         var formattedValue = name === "customMessage"
             ? referee.prepareMessage(properties[name])
             : referee.format(properties[name]);

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -1,734 +1,710 @@
-(function (root, factory) {
-    "use strict";
+"use strict";
 
-    if (typeof define === "function" && define.amd) {
-        // AMD. Register as an anonymous module.
-        define("referee", ["expect", "lodash", "samsam", "bane", "es6-promise"], factory);
-    } else if (typeof module === "object" && module.exports) {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(
-            require("./expect"),
-            require("lodash"),
-            require("samsam"),
-            require("bane"),
-            require("es6-promise").Promise
-        );
-    } else {
-        // Browser globals (root is window)
-        root.referee = factory(
-            root.expect,
-            root._,
-            root.samsam,
-            root.bane,
-            root.Promise
-        );
+var expect = require("./expect");
+var _ = require("lodash");
+var samsam = require("samsam");
+var bane = require("bane");
+var Promise = require("es6-promise").Promise;
+
+var toString = Object.prototype.toString;
+var slice = Array.prototype.slice;
+var referee = bane.createEventEmitter();
+
+referee.countAssertion = function countAssertion() {
+    if (typeof referee.count !== "number") { referee.count = 0; }
+    referee.count += 1;
+};
+
+function interpolate(string, prop, value) {
+    return string.replace(new RegExp("\\$\\{" + prop + "\\}", "g"), value);
+}
+
+// Interpolate positional arguments. Replaces occurences of ${<index>} in
+// the string with the corresponding entry in values[<index>]
+function interpolatePosArg(message, values) {
+    return _.reduce(values, function (msg, value, index) {
+        return interpolate(msg, index, referee.format(value));
+    }, message);
+}
+
+function interpolateProperties(message, properties) {
+    return _.reduce(_.keys(properties), function (str, name) {
+        var formattedValue = name === "customMessage"
+            ? referee.prepareMessage(properties[name])
+            : referee.format(properties[name]);
+        return interpolate(str, name, formattedValue);
+    }, message || "");
+}
+
+// Internal helper. Used throughout to fail assertions if they receive
+// too few arguments. The name is provided for a helpful error message.
+function assertArgNum(name, args, num, fail) {
+    fail = fail || referee.fail;
+    if (args.length < num) {
+        fail("[" + name + "] Expected to receive at least " +
+                    num + " argument" + (num > 1 ? "s" : ""));
+        return false;
     }
-}(typeof self !== "undefined" ? self : this, function (expect, _, samsam, bane, PromiseModule) {
-    "use strict";
+    return true;
+}
 
-    var Promise = PromiseModule.Promise || PromiseModule;
-    var toString = Object.prototype.toString;
-    var slice = Array.prototype.slice;
-    var referee = bane.createEventEmitter();
+function createAssertion(type, name, func, minArgs, messageValues, pass, fail) {
 
-    referee.countAssertion = function countAssertion() {
-        if (typeof referee.count !== "number") { referee.count = 0; }
-        referee.count += 1;
-    };
+    var assertion = function () {
 
-    function interpolate(string, prop, value) {
-        return string.replace(new RegExp("\\$\\{" + prop + "\\}", "g"), value);
-    }
+        var fullName = type + "." + name;
+        var failed = false;
 
-    // Interpolate positional arguments. Replaces occurences of ${<index>} in
-    // the string with the corresponding entry in values[<index>]
-    function interpolatePosArg(message, values) {
-        return _.reduce(values, function (msg, value, index) {
-            return interpolate(msg, index, referee.format(value));
-        }, message);
-    }
-
-    function interpolateProperties(message, properties) {
-        return _.reduce(_.keys(properties), function (str, name) {
-            var formattedValue = name === "customMessage"
-                ? referee.prepareMessage(properties[name])
-                : referee.format(properties[name]);
-            return interpolate(str, name, formattedValue);
-        }, message || "");
-    }
-
-    // Internal helper. Used throughout to fail assertions if they receive
-    // too few arguments. The name is provided for a helpful error message.
-    function assertArgNum(name, args, num, fail) {
-        fail = fail || referee.fail;
-        if (args.length < num) {
-            fail("[" + name + "] Expected to receive at least " +
-                        num + " argument" + (num > 1 ? "s" : ""));
-            return false;
-        }
-        return true;
-    }
-
-    function createAssertion(type, name, func, minArgs, messageValues, pass, fail) {
-
-        var assertion = function () {
-
-            var fullName = type + "." + name;
-            var failed = false;
-
-            if (!assertArgNum(fullName, arguments, minArgs || func.length, fail)) {
-                return;
-            }
-
-            var args = slice.call(arguments, 0);
-            var namedValues = {};
-
-            if (typeof messageValues === "function") {
-                var replacedValues = messageValues.apply(this, args);
-                if (typeof (replacedValues) === "object") {
-                    namedValues = replacedValues;
-                } else {
-                    args = replacedValues;
-                }
-            }
-
-            var ctx = {
-                fail: function (msg) {
-                    failed = true;
-                    delete this.fail;
-                    var message = referee[type][name][msg] || msg;
-                    message = interpolatePosArg(message, args);
-                    message = interpolateProperties(message, this);
-                    message = interpolateProperties(message, namedValues);
-                    fail("[" + type + "." + name + "] " + message);
-                    return false;
-                }
-            };
-
-            if (!func.apply(ctx, arguments) && !failed) {
-                // when a function returns false and hasn't already failed with a custom message,
-                // fail with default message
-                ctx.fail("message");
-            }
-
-            if (!failed) {
-                pass(["pass", fullName].concat(args));
-            }
-        };
-
-        return assertion;
-    }
-
-    // Internal helper. Not the most elegant of functions, but it takes
-    // care of all the nitty-gritty of assertion functions: counting,
-    // verifying parameter count, interpolating messages with actual
-    // values and so on.
-    function defineAssertion(type, name, func, minArgs, messageValues) {
-
-        referee[type][name] = function () {
-            referee.countAssertion();
-            var assertion = createAssertion(type, name, func, minArgs, messageValues, referee.pass, referee.fail);
-            assertion.apply(null, arguments);
-        };
-        referee[type][name].test = function () {
-            var args = arguments;
-            return new Promise(function (resolve, reject) {
-                var assertion = createAssertion(type, name, func, minArgs, messageValues, resolve, reject);
-                assertion.apply(null, args);
-            });
-        };
-    }
-
-    function assert(actual, message) {
-        referee.countAssertion();
-        if (!assertArgNum("assert", arguments, 1)) { return; }
-
-        if (!actual) {
-            var v = referee.format(actual);
-            referee.fail(message || "[assert] Expected " + v + " to be truthy");
-        } else {
-            referee.emit("pass", "assert", message || "", actual);
-        }
-    }
-
-    referee.assert = assert;
-
-    assert.toString = function () {
-        return "referee.assert()";
-    };
-
-    function refute(actual, message) {
-        referee.countAssertion();
-        if (!assertArgNum("refute", arguments, 1)) { return; }
-
-        if (actual) {
-            var v = referee.format(actual);
-            referee.fail(message || "[refute] Expected " + v + " to be falsy");
-        } else {
-            referee.emit("pass", "refute", message || "", actual);
-        }
-    }
-    referee.refute = refute;
-
-    referee.add = function (name, opt) {
-        var refuteArgs;
-
-        if (opt.refute) {
-            refuteArgs = opt.refute.length;
-        } else {
-            refuteArgs = opt.assert.length;
-            opt.refute = function () {
-                return !opt.assert.apply(this, arguments);
-            };
+        if (!assertArgNum(fullName, arguments, minArgs || func.length, fail)) {
+            return;
         }
 
-        var values = opt.values;
-        defineAssertion("assert", name, opt.assert, opt.assert.length, values);
-        defineAssertion("refute", name, opt.refute, refuteArgs, values);
+        var args = slice.call(arguments, 0);
+        var namedValues = {};
 
-        assert[name].message = opt.assertMessage;
-        refute[name].message = opt.refuteMessage;
-
-        if (opt.expectation) {
-            if (referee.expect && referee.expect.wrapAssertion) {
-                referee.expect.wrapAssertion(name, opt.expectation, referee);
+        if (typeof messageValues === "function") {
+            var replacedValues = messageValues.apply(this, args);
+            if (typeof (replacedValues) === "object") {
+                namedValues = replacedValues;
             } else {
-                assert[name].expectationName = opt.expectation;
-                refute[name].expectationName = opt.expectation;
+                args = replacedValues;
             }
+        }
+
+        var ctx = {
+            fail: function (msg) {
+                failed = true;
+                delete this.fail;
+                var message = referee[type][name][msg] || msg;
+                message = interpolatePosArg(message, args);
+                message = interpolateProperties(message, this);
+                message = interpolateProperties(message, namedValues);
+                fail("[" + type + "." + name + "] " + message);
+                return false;
+            }
+        };
+
+        if (!func.apply(ctx, arguments) && !failed) {
+            // when a function returns false and hasn't already failed with a custom message,
+            // fail with default message
+            ctx.fail("message");
+        }
+
+        if (!failed) {
+            pass(["pass", fullName].concat(args));
         }
     };
 
-    referee.count = 0;
+    return assertion;
+}
 
-    referee.pass = function (message) {
-        referee.emit.apply(referee, message);
+// Internal helper. Not the most elegant of functions, but it takes
+// care of all the nitty-gritty of assertion functions: counting,
+// verifying parameter count, interpolating messages with actual
+// values and so on.
+function defineAssertion(type, name, func, minArgs, messageValues) {
+
+    referee[type][name] = function () {
+        referee.countAssertion();
+        var assertion = createAssertion(type, name, func, minArgs, messageValues, referee.pass, referee.fail);
+        assertion.apply(null, arguments);
     };
+    referee[type][name].test = function () {
+        var args = arguments;
+        return new Promise(function (resolve, reject) {
+            var assertion = createAssertion(type, name, func, minArgs, messageValues, resolve, reject);
+            assertion.apply(null, args);
+        });
+    };
+}
 
-    referee.fail = function (message) {
-        var exception = new Error(message);
-        exception.name = "AssertionError";
+function assert(actual, message) {
+    referee.countAssertion();
+    if (!assertArgNum("assert", arguments, 1)) { return; }
+
+    if (!actual) {
+        var v = referee.format(actual);
+        referee.fail(message || "[assert] Expected " + v + " to be truthy");
+    } else {
+        referee.emit("pass", "assert", message || "", actual);
+    }
+}
+
+referee.assert = assert;
+
+assert.toString = function () {
+    return "referee.assert()";
+};
+
+function refute(actual, message) {
+    referee.countAssertion();
+    if (!assertArgNum("refute", arguments, 1)) { return; }
+
+    if (actual) {
+        var v = referee.format(actual);
+        referee.fail(message || "[refute] Expected " + v + " to be falsy");
+    } else {
+        referee.emit("pass", "refute", message || "", actual);
+    }
+}
+referee.refute = refute;
+
+referee.add = function (name, opt) {
+    var refuteArgs;
+
+    if (opt.refute) {
+        refuteArgs = opt.refute.length;
+    } else {
+        refuteArgs = opt.assert.length;
+        opt.refute = function () {
+            return !opt.assert.apply(this, arguments);
+        };
+    }
+
+    var values = opt.values;
+    defineAssertion("assert", name, opt.assert, opt.assert.length, values);
+    defineAssertion("refute", name, opt.refute, refuteArgs, values);
+
+    assert[name].message = opt.assertMessage;
+    refute[name].message = opt.refuteMessage;
+
+    if (opt.expectation) {
+        if (referee.expect && referee.expect.wrapAssertion) {
+            referee.expect.wrapAssertion(name, opt.expectation, referee);
+        } else {
+            assert[name].expectationName = opt.expectation;
+            refute[name].expectationName = opt.expectation;
+        }
+    }
+};
+
+referee.count = 0;
+
+referee.pass = function (message) {
+    referee.emit.apply(referee, message);
+};
+
+referee.fail = function (message) {
+    var exception = new Error(message);
+    exception.name = "AssertionError";
+
+    try {
+        throw exception;
+    } catch (e) {
+        referee.emit("failure", e);
+    }
+
+    if (typeof referee.throwOnFailure !== "boolean" ||
+            referee.throwOnFailure) {
+        throw exception;
+    }
+};
+
+referee.format = function (object) { return String(object); };
+
+referee.prepareMessage = function msg(message) {
+    if (!message) {
+        return "";
+    }
+    return message + (/[.:!?]$/.test(message) ? " " : ": ");
+};
+
+function actualAndExpectedMessageValues(actual, expected, message) {
+    return {
+        actual: actual,
+        expected: expected,
+        customMessage: message
+    };
+}
+
+function actualMessageValues(actual, message) {
+    return {
+        actual: actual,
+        customMessage: message
+    };
+}
+
+function actualAndTypeOfMessageValues(actual, message) {
+    return {
+        actual: actual,
+        actualType: typeof actual,
+        customMessage: message
+    };
+}
+
+referee.add("same", {
+    assert: function (actual, expected) {
+        return samsam.identical(actual, expected);
+    },
+    refute: function (actual, expected) {
+        return !samsam.identical(actual, expected);
+    },
+    assertMessage: "${customMessage}${actual} expected to be the same object as ${expected}",
+    refuteMessage: "${customMessage}${actual} expected not to be the same object as ${expected}",
+    expectation: "toBe",
+    values: actualAndExpectedMessageValues
+});
+
+// Extract/replace with separate module that does a more detailed
+// visualization of multi-line strings
+function multiLineStringDiff(actual, expected, message) {
+    if (actual === expected) { return true; }
+
+    var heading = assert.equals.multiLineStringHeading;
+    var failureText = interpolateProperties(heading, { customMessage: message });
+    var actualLines = actual.split("\n");
+    var expectedLines = expected.split("\n");
+    var lineCount = Math.max(expectedLines.length, actualLines.length);
+    var lines = [];
+
+    for (var i = 0; i < lineCount; ++i) {
+        if (expectedLines[i] !== actualLines[i]) {
+            lines.push("line " + (i + 1) + ": " + (expectedLines[i] || "") +
+                       "\nwas:    " + (actualLines[i] || ""));
+        }
+    }
+
+    referee.fail("[assert.equals] " + failureText + lines.join("\n\n"));
+    return false;
+}
+
+referee.add("equals", {
+    // Uses arguments[2] because the function's .length is used to determine
+    // the minimum required number of arguments.
+    assert: function (actual, expected) {
+        if (typeof actual === "string" && typeof expected === "string" &&
+                (actual.indexOf("\n") >= 0 ||
+                 expected.indexOf("\n") >= 0)) {
+            return multiLineStringDiff(actual, expected, arguments[2]);
+        }
+
+        return samsam.deepEqual(actual, expected);
+    },
+
+    refute: function (actual, expected) {
+        return !samsam.deepEqual(actual, expected);
+    },
+
+    assertMessage: "${customMessage}${actual} expected to be equal to ${expected}",
+    refuteMessage: "${customMessage}${actual} expected not to be equal to ${expected}",
+    expectation: "toEqual",
+    values: actualAndExpectedMessageValues
+});
+
+assert.equals.multiLineStringHeading = "${customMessage}Expected multi-line strings " +
+    "to be equal:\n";
+
+referee.add("greater", {
+    assert: function (actual, expected) {
+        return actual > expected;
+    },
+
+    assertMessage: "${customMessage}Expected ${actual} to be greater than ${expected}",
+    refuteMessage: "${customMessage}Expected ${actual} to be less than or equal to ${expected}",
+    expectation: "toBeGreaterThan",
+    values: actualAndExpectedMessageValues
+});
+
+referee.add("less", {
+    assert: function (actual, expected) {
+        return actual < expected;
+    },
+
+    assertMessage: "${customMessage}Expected ${actual} to be less than ${expected}",
+    refuteMessage: "${customMessage}Expected ${actual} to be greater than or equal to ${expected}",
+    expectation: "toBeLessThan",
+    values: actualAndExpectedMessageValues
+});
+
+referee.add("defined", {
+    assert: function (actual) {
+        return typeof actual !== "undefined";
+    },
+    assertMessage: "${customMessage}Expected to be defined",
+    refuteMessage: "${customMessage}Expected ${actual} (${actualType}) not to be defined",
+    expectation: "toBeDefined",
+    values: actualAndTypeOfMessageValues
+});
+
+referee.add("isNull", {
+    assert: function (actual) {
+        return actual === null;
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be null",
+    refuteMessage: "${customMessage}Expected not to be null",
+    expectation: "toBeNull",
+    values: actualMessageValues
+});
+
+
+referee.match = function (actual, matcher) {
+    try {
+        return samsam.match(actual, matcher);
+    } catch (e) {
+        throw new Error("Matcher (" + referee.format(matcher) +
+                        ") was not a string, a number, a function, " +
+                        "a boolean or an object");
+    }
+};
+
+referee.add("match", {
+    assert: function (actual, matcher) {
+        var passed;
 
         try {
-            throw exception;
+            passed = referee.match(actual, matcher);
         } catch (e) {
-            referee.emit("failure", e);
+            this.exceptionMessage = e.message;
+            return this.fail("exceptionMessage");
         }
 
-        if (typeof referee.throwOnFailure !== "boolean" ||
-                referee.throwOnFailure) {
-            throw exception;
+        return passed;
+    },
+
+    refute: function (actual, matcher) {
+        var passed;
+
+        try {
+            passed = referee.match(actual, matcher);
+        } catch (e) {
+            this.exceptionMessage = e.message;
+            return this.fail("exceptionMessage");
         }
-    };
 
-    referee.format = function (object) { return String(object); };
+        return !passed;
+    },
 
-    referee.prepareMessage = function msg(message) {
-        if (!message) {
-            return "";
-        }
-        return message + (/[.:!?]$/.test(message) ? " " : ": ");
-    };
+    assertMessage: "${customMessage}${actual} expected to match ${expected}",
+    refuteMessage: "${customMessage}${actual} expected not to match ${expected}",
+    expectation: "toMatch",
+    values: actualAndExpectedMessageValues
+});
 
-    function actualAndExpectedMessageValues(actual, expected, message) {
+assert.match.exceptionMessage = refute.match.exceptionMessage = "${customMessage}${exceptionMessage}";
+
+referee.add("isObject", {
+    assert: function (actual) {
+        return typeof actual === "object" && !!actual;
+    },
+    assertMessage: "${customMessage}${actual} (${actualType}) expected to be object and not null",
+    refuteMessage: "${customMessage}${actual} expected to be null or not an object",
+    expectation: "toBeObject",
+    values: actualAndTypeOfMessageValues
+});
+
+referee.add("isFunction", {
+    assert: function (actual) {
+        return typeof actual === "function";
+    },
+    assertMessage: "${customMessage}${actual} (${actualType}) expected to be function",
+    refuteMessage: "${customMessage}${actual} expected not to be function",
+    expectation: "toBeFunction",
+    values: function (actual, message) {
         return {
-            actual: actual,
-            expected: expected,
-            customMessage: message
-        };
-    }
-
-    function actualMessageValues(actual, message) {
-        return {
-            actual: actual,
-            customMessage: message
-        };
-    }
-
-    function actualAndTypeOfMessageValues(actual, message) {
-        return {
-            actual: actual,
+            actual: String(actual).replace("\n", ""),
             actualType: typeof actual,
             customMessage: message
         };
     }
+});
 
-    referee.add("same", {
-        assert: function (actual, expected) {
-            return samsam.identical(actual, expected);
-        },
-        refute: function (actual, expected) {
-            return !samsam.identical(actual, expected);
-        },
-        assertMessage: "${customMessage}${actual} expected to be the same object as ${expected}",
-        refuteMessage: "${customMessage}${actual} expected not to be the same object as ${expected}",
-        expectation: "toBe",
-        values: actualAndExpectedMessageValues
-    });
+referee.add("isTrue", {
+    assert: function (actual) {
+        return actual === true;
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be true",
+    refuteMessage: "${customMessage}Expected ${actual} to not be true",
+    expectation: "toBeTrue",
+    values: actualMessageValues
+});
 
-    // Extract/replace with separate module that does a more detailed
-    // visualization of multi-line strings
-    function multiLineStringDiff(actual, expected, message) {
-        if (actual === expected) { return true; }
+referee.add("isFalse", {
+    assert: function (actual) {
+        return actual === false;
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be false",
+    refuteMessage: "${customMessage}Expected ${actual} to not be false",
+    expectation: "toBeFalse",
+    values: actualMessageValues
+});
 
-        var heading = assert.equals.multiLineStringHeading;
-        var failureText = interpolateProperties(heading, { customMessage: message });
-        var actualLines = actual.split("\n");
-        var expectedLines = expected.split("\n");
-        var lineCount = Math.max(expectedLines.length, actualLines.length);
-        var lines = [];
+referee.add("isString", {
+    assert: function (actual) {
+        return typeof actual === "string";
+    },
+    assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be string",
+    refuteMessage: "${customMessage}Expected ${actual} not to be string",
+    expectation: "toBeString",
+    values: actualAndTypeOfMessageValues
+});
 
-        for (var i = 0; i < lineCount; ++i) {
-            if (expectedLines[i] !== actualLines[i]) {
-                lines.push("line " + (i + 1) + ": " + (expectedLines[i] || "") +
-                           "\nwas:    " + (actualLines[i] || ""));
-            }
-        }
+referee.add("isBoolean", {
+    assert: function (actual) {
+        return typeof actual === "boolean";
+    },
+    assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be boolean",
+    refuteMessage: "${customMessage}Expected ${actual} not to be boolean",
+    expectation: "toBeBoolean",
+    values: actualAndTypeOfMessageValues
+});
 
-        referee.fail("[assert.equals] " + failureText + lines.join("\n\n"));
-        return false;
+referee.add("isNumber", {
+    assert: function (actual) {
+        return typeof actual === "number" && !isNaN(actual);
+    },
+    assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be a non-NaN number",
+    refuteMessage: "${customMessage}Expected ${actual} to be NaN or a non-number value",
+    expectation: "toBeNumber",
+    values: actualAndTypeOfMessageValues
+});
+
+referee.add("isNaN", {
+    assert: function (actual) {
+        return typeof actual === "number" && isNaN(actual);
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be NaN",
+    refuteMessage: "${customMessage}Expected not to be NaN",
+    expectation: "toBeNaN",
+    values: actualAndTypeOfMessageValues
+});
+
+referee.add("isArray", {
+    assert: function (actual) {
+        return toString.call(actual) === "[object Array]";
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be array",
+    refuteMessage: "${customMessage}Expected ${actual} not to be array",
+    expectation: "toBeArray",
+    values: actualAndTypeOfMessageValues
+});
+
+function isArrayLike(object) {
+    return _.isArray(object) ||
+        (!!object && typeof object.length === "number" &&
+        typeof object.splice === "function") ||
+        _.isArguments(object);
+}
+
+referee.isArrayLike = isArrayLike;
+
+referee.add("isArrayLike", {
+    assert: function (actual) {
+        return isArrayLike(actual);
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be array like",
+    refuteMessage: "${customMessage}Expected ${actual} not to be array like",
+    expectation: "toBeArrayLike",
+    values: actualAndTypeOfMessageValues
+});
+
+function exactKeys(object, keys) {
+    var keyMap = {};
+    var keyCnt = 0;
+    for (var i = 0; i < keys.length; i++) {
+        keyMap[keys[i]] = true;
+        keyCnt += 1;
     }
-
-    referee.add("equals", {
-        // Uses arguments[2] because the function's .length is used to determine
-        // the minimum required number of arguments.
-        assert: function (actual, expected) {
-            if (typeof actual === "string" && typeof expected === "string" &&
-                    (actual.indexOf("\n") >= 0 ||
-                     expected.indexOf("\n") >= 0)) {
-                return multiLineStringDiff(actual, expected, arguments[2]);
-            }
-
-            return samsam.deepEqual(actual, expected);
-        },
-
-        refute: function (actual, expected) {
-            return !samsam.deepEqual(actual, expected);
-        },
-
-        assertMessage: "${customMessage}${actual} expected to be equal to ${expected}",
-        refuteMessage: "${customMessage}${actual} expected not to be equal to ${expected}",
-        expectation: "toEqual",
-        values: actualAndExpectedMessageValues
-    });
-
-    assert.equals.multiLineStringHeading = "${customMessage}Expected multi-line strings " +
-        "to be equal:\n";
-
-    referee.add("greater", {
-        assert: function (actual, expected) {
-            return actual > expected;
-        },
-
-        assertMessage: "${customMessage}Expected ${actual} to be greater than ${expected}",
-        refuteMessage: "${customMessage}Expected ${actual} to be less than or equal to ${expected}",
-        expectation: "toBeGreaterThan",
-        values: actualAndExpectedMessageValues
-    });
-
-    referee.add("less", {
-        assert: function (actual, expected) {
-            return actual < expected;
-        },
-
-        assertMessage: "${customMessage}Expected ${actual} to be less than ${expected}",
-        refuteMessage: "${customMessage}Expected ${actual} to be greater than or equal to ${expected}",
-        expectation: "toBeLessThan",
-        values: actualAndExpectedMessageValues
-    });
-
-    referee.add("defined", {
-        assert: function (actual) {
-            return typeof actual !== "undefined";
-        },
-        assertMessage: "${customMessage}Expected to be defined",
-        refuteMessage: "${customMessage}Expected ${actual} (${actualType}) not to be defined",
-        expectation: "toBeDefined",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isNull", {
-        assert: function (actual) {
-            return actual === null;
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be null",
-        refuteMessage: "${customMessage}Expected not to be null",
-        expectation: "toBeNull",
-        values: actualMessageValues
-    });
-
-
-    referee.match = function (actual, matcher) {
-        try {
-            return samsam.match(actual, matcher);
-        } catch (e) {
-            throw new Error("Matcher (" + referee.format(matcher) +
-                            ") was not a string, a number, a function, " +
-                            "a boolean or an object");
-        }
-    };
-
-    referee.add("match", {
-        assert: function (actual, matcher) {
-            var passed;
-
-            try {
-                passed = referee.match(actual, matcher);
-            } catch (e) {
-                this.exceptionMessage = e.message;
-                return this.fail("exceptionMessage");
-            }
-
-            return passed;
-        },
-
-        refute: function (actual, matcher) {
-            var passed;
-
-            try {
-                passed = referee.match(actual, matcher);
-            } catch (e) {
-                this.exceptionMessage = e.message;
-                return this.fail("exceptionMessage");
-            }
-
-            return !passed;
-        },
-
-        assertMessage: "${customMessage}${actual} expected to match ${expected}",
-        refuteMessage: "${customMessage}${actual} expected not to match ${expected}",
-        expectation: "toMatch",
-        values: actualAndExpectedMessageValues
-    });
-
-    assert.match.exceptionMessage = refute.match.exceptionMessage = "${customMessage}${exceptionMessage}";
-
-    referee.add("isObject", {
-        assert: function (actual) {
-            return typeof actual === "object" && !!actual;
-        },
-        assertMessage: "${customMessage}${actual} (${actualType}) expected to be object and not null",
-        refuteMessage: "${customMessage}${actual} expected to be null or not an object",
-        expectation: "toBeObject",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isFunction", {
-        assert: function (actual) {
-            return typeof actual === "function";
-        },
-        assertMessage: "${customMessage}${actual} (${actualType}) expected to be function",
-        refuteMessage: "${customMessage}${actual} expected not to be function",
-        expectation: "toBeFunction",
-        values: function (actual, message) {
-            return {
-                actual: String(actual).replace("\n", ""),
-                actualType: typeof actual,
-                customMessage: message
-            };
-        }
-    });
-
-    referee.add("isTrue", {
-        assert: function (actual) {
-            return actual === true;
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be true",
-        refuteMessage: "${customMessage}Expected ${actual} to not be true",
-        expectation: "toBeTrue",
-        values: actualMessageValues
-    });
-
-    referee.add("isFalse", {
-        assert: function (actual) {
-            return actual === false;
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be false",
-        refuteMessage: "${customMessage}Expected ${actual} to not be false",
-        expectation: "toBeFalse",
-        values: actualMessageValues
-    });
-
-    referee.add("isString", {
-        assert: function (actual) {
-            return typeof actual === "string";
-        },
-        assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be string",
-        refuteMessage: "${customMessage}Expected ${actual} not to be string",
-        expectation: "toBeString",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isBoolean", {
-        assert: function (actual) {
-            return typeof actual === "boolean";
-        },
-        assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be boolean",
-        refuteMessage: "${customMessage}Expected ${actual} not to be boolean",
-        expectation: "toBeBoolean",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isNumber", {
-        assert: function (actual) {
-            return typeof actual === "number" && !isNaN(actual);
-        },
-        assertMessage: "${customMessage}Expected ${actual} (${actualType}) to be a non-NaN number",
-        refuteMessage: "${customMessage}Expected ${actual} to be NaN or a non-number value",
-        expectation: "toBeNumber",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isNaN", {
-        assert: function (actual) {
-            return typeof actual === "number" && isNaN(actual);
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be NaN",
-        refuteMessage: "${customMessage}Expected not to be NaN",
-        expectation: "toBeNaN",
-        values: actualAndTypeOfMessageValues
-    });
-
-    referee.add("isArray", {
-        assert: function (actual) {
-            return toString.call(actual) === "[object Array]";
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be array",
-        refuteMessage: "${customMessage}Expected ${actual} not to be array",
-        expectation: "toBeArray",
-        values: actualAndTypeOfMessageValues
-    });
-
-    function isArrayLike(object) {
-        return _.isArray(object) ||
-            (!!object && typeof object.length === "number" &&
-            typeof object.splice === "function") ||
-            _.isArguments(object);
-    }
-
-    referee.isArrayLike = isArrayLike;
-
-    referee.add("isArrayLike", {
-        assert: function (actual) {
-            return isArrayLike(actual);
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be array like",
-        refuteMessage: "${customMessage}Expected ${actual} not to be array like",
-        expectation: "toBeArrayLike",
-        values: actualAndTypeOfMessageValues
-    });
-
-    function exactKeys(object, keys) {
-        var keyMap = {};
-        var keyCnt = 0;
-        for (var i = 0; i < keys.length; i++) {
-            keyMap[keys[i]] = true;
-            keyCnt += 1;
-        }
-        for (var key in object) {
-            if (object.hasOwnProperty(key)) {
-                if (!keyMap[key]) {
-                    return false;
-                }
-                keyCnt -= 1;
-            }
-        }
-        return keyCnt === 0;
-    }
-
-    referee.add("keys", {
-        assert: function (actual, keys) {
-            return exactKeys(actual, keys);
-        },
-        assertMessage: "${customMessage}Expected ${actualObject} to have exact keys ${keys}",
-        refuteMessage: "${customMessage}Expected not to have exact keys ${keys}",
-        expectation: "toHaveKeys",
-        values: function (actual, keys, message) {
-            return {
-                actualObject: actual,
-                keys: keys,
-                customMessage: message
-            };
-        }
-    });
-
-    function captureException(callback) {
-        try { callback(); } catch (e) { return e; }
-        return null;
-    }
-
-    referee.captureException = captureException;
-
-    referee.add("exception", {
-        assert: function (callback) {
-            var matcher = arguments[1];
-            var customMessage = arguments[2];
-
-            if (typeof matcher === "string") {
-                customMessage = matcher;
-                matcher = undefined;
-            }
-
-            this.expected = matcher;
-            this.customMessage = customMessage;
-
-            var err = captureException(callback);
-
-            if (err) {
-                this.actualExceptionType = err.name;
-                this.actualExceptionMessage = err.message;
-                this.actualExceptionStack = err.stack;
-            }
-
-            if (!err) {
-                if (typeof matcher === "object") {
-                    return this.fail("typeNoExceptionMessage");
-                }
-                return this.fail("message");
-
-            }
-
-            if (typeof matcher === "object" && !referee.match(err, matcher)) {
-                return this.fail("typeFailMessage");
-            }
-
-            if (typeof matcher === "function" && matcher(err) !== true) {
-                return this.fail("matchFailMessage");
-            }
-
-            return true;
-        },
-
-        refute: function (callback) {
-            var err = captureException(callback);
-
-            if (err) {
-                this.customMessage = arguments[1];
-                this.actualExceptionType = err.name;
-                this.actualExceptionMessage = err.message;
+    for (var key in object) {
+        if (object.hasOwnProperty(key)) {
+            if (!keyMap[key]) {
                 return false;
             }
-
-            return true;
-        },
-
-        expectation: "toThrow",
-        assertMessage: "${customMessage}Expected exception",
-        refuteMessage: "${customMessage}Expected not to throw but threw ${actualExceptionType} (${actualExceptionMessage})"
-    });
-
-    assert.exception.typeNoExceptionMessage = "${customMessage}Expected ${expected} but no exception was thrown";
-    assert.exception.typeFailMessage = "${customMessage}Expected ${expected} but threw ${actualExceptionType} (${actualExceptionMessage})\n${actualExceptionStack}";
-    assert.exception.matchFailMessage = "${customMessage}Expected thrown ${actualExceptionType} (${actualExceptionMessage}) to pass matcher function";
-
-
-    referee.add("near", {
-        assert: function (actual, expected, delta) {
-            return Math.abs(actual - expected) <= delta;
-        },
-        assertMessage: "${customMessage}Expected ${actual} to be equal to ${expected} +/- ${delta}",
-        refuteMessage: "${customMessage}Expected ${actual} not to be equal to ${expected} +/- ${delta}",
-        expectation: "toBeNear",
-        values: function (actual, expected, delta, message) {
-            return {
-                actual: actual,
-                expected: expected,
-                delta: delta,
-                customMessage: message
-            };
+            keyCnt -= 1;
         }
-    });
+    }
+    return keyCnt === 0;
+}
 
-    referee.add("hasPrototype", {
-        assert: function (actual, protoObj) {
-            return protoObj.isPrototypeOf(actual);
-        },
-        assertMessage: "${customMessage}Expected ${actual} to have ${expected} on its prototype chain",
-        refuteMessage: "${customMessage}Expected ${actual} not to have ${expected} on its " +
-            "prototype chain",
-        expectation: "toHavePrototype",
-        values: actualAndExpectedMessageValues
-    });
+referee.add("keys", {
+    assert: function (actual, keys) {
+        return exactKeys(actual, keys);
+    },
+    assertMessage: "${customMessage}Expected ${actualObject} to have exact keys ${keys}",
+    refuteMessage: "${customMessage}Expected not to have exact keys ${keys}",
+    expectation: "toHaveKeys",
+    values: function (actual, keys, message) {
+        return {
+            actualObject: actual,
+            keys: keys,
+            customMessage: message
+        };
+    }
+});
 
-    referee.add("contains", {
-        assert: function (haystack, needle) {
-            return _.include(haystack, needle);
-        },
-        assertMessage: "${customMessage}Expected [${actual}] to contain ${expected}",
-        refuteMessage: "${customMessage}Expected [${actual}] not to contain ${expected}",
-        expectation: "toContain",
-        values: actualAndExpectedMessageValues
-    });
+function captureException(callback) {
+    try { callback(); } catch (e) { return e; }
+    return null;
+}
 
-    referee.add("tagName", {
-        assert: function (element, tagName) {
-            // Uses arguments[2] because the function's .length is used to
-            // determine the minimum required number of arguments.
-            if (!element.tagName) {
-                return this.fail("noTagNameMessage");
-            }
+referee.captureException = captureException;
 
-            return tagName.toLowerCase &&
-                tagName.toLowerCase() === element.tagName.toLowerCase();
-        },
-        assertMessage: "${customMessage}Expected tagName to be ${expected} but was ${actual}",
-        refuteMessage: "${customMessage}Expected tagName not to be ${actual}",
-        expectation: "toHaveTagName",
-        values: function (element, tagName, message) {
-            return {
-                actualElement: element,
-                actual: element.tagName,
-                expected: tagName,
-                customMessage: message
-            };
+referee.add("exception", {
+    assert: function (callback) {
+        var matcher = arguments[1];
+        var customMessage = arguments[2];
+
+        if (typeof matcher === "string") {
+            customMessage = matcher;
+            matcher = undefined;
         }
-    });
 
-    assert.tagName.noTagNameMessage = "${customMessage}Expected ${actualElement} to have tagName " +
-        "property";
-    refute.tagName.noTagNameMessage = "${customMessage}Expected ${actualElement} to have tagName " +
-        "property";
+        this.expected = matcher;
+        this.customMessage = customMessage;
 
-    referee.add("className", {
-        assert: function (element, name) {
-            if (typeof element.className === "undefined") {
-                return this.fail("noClassNameMessage");
-            }
+        var err = captureException(callback);
 
-            var expected = typeof name === "string" ? name.split(" ") : name;
-            var actual = element.className.split(" ");
-            var i, l;
-            for (i = 0, l = expected.length; i < l; i++) {
-                if (!_.include(actual, expected[i])) { return false; }
-            }
-
-            return true;
-        },
-        assertMessage: "${customMessage}Expected object's className to include ${expected} " +
-            "but was ${actual}",
-        refuteMessage: "${customMessage}Expected object's className not to include ${expected}",
-        expectation: "toHaveClassName",
-        values: function (element, className, message) {
-            return {
-                actualElement: element,
-                actual: element.className,
-                expected: className,
-                customMessage: message
-            };
+        if (err) {
+            this.actualExceptionType = err.name;
+            this.actualExceptionMessage = err.message;
+            this.actualExceptionStack = err.stack;
         }
-    });
 
-    assert.className.noClassNameMessage = "${customMessage}Expected object to have " +
-        "className property";
-    refute.className.noClassNameMessage = "${customMessage}Expected object to have " +
-        "className property";
+        if (!err) {
+            if (typeof matcher === "object") {
+                return this.fail("typeNoExceptionMessage");
+            }
+            return this.fail("message");
 
-    referee.expect = function () {
-        expect.init(referee);
-        return expect.apply(referee, arguments);
-    };
+        }
 
-    return referee;
-}));
+        if (typeof matcher === "object" && !referee.match(err, matcher)) {
+            return this.fail("typeFailMessage");
+        }
+
+        if (typeof matcher === "function" && matcher(err) !== true) {
+            return this.fail("matchFailMessage");
+        }
+
+        return true;
+    },
+
+    refute: function (callback) {
+        var err = captureException(callback);
+
+        if (err) {
+            this.customMessage = arguments[1];
+            this.actualExceptionType = err.name;
+            this.actualExceptionMessage = err.message;
+            return false;
+        }
+
+        return true;
+    },
+
+    expectation: "toThrow",
+    assertMessage: "${customMessage}Expected exception",
+    refuteMessage: "${customMessage}Expected not to throw but threw ${actualExceptionType} (${actualExceptionMessage})"
+});
+
+assert.exception.typeNoExceptionMessage = "${customMessage}Expected ${expected} but no exception was thrown";
+assert.exception.typeFailMessage = "${customMessage}Expected ${expected} but threw ${actualExceptionType} (${actualExceptionMessage})\n${actualExceptionStack}";
+assert.exception.matchFailMessage = "${customMessage}Expected thrown ${actualExceptionType} (${actualExceptionMessage}) to pass matcher function";
+
+
+referee.add("near", {
+    assert: function (actual, expected, delta) {
+        return Math.abs(actual - expected) <= delta;
+    },
+    assertMessage: "${customMessage}Expected ${actual} to be equal to ${expected} +/- ${delta}",
+    refuteMessage: "${customMessage}Expected ${actual} not to be equal to ${expected} +/- ${delta}",
+    expectation: "toBeNear",
+    values: function (actual, expected, delta, message) {
+        return {
+            actual: actual,
+            expected: expected,
+            delta: delta,
+            customMessage: message
+        };
+    }
+});
+
+referee.add("hasPrototype", {
+    assert: function (actual, protoObj) {
+        return protoObj.isPrototypeOf(actual);
+    },
+    assertMessage: "${customMessage}Expected ${actual} to have ${expected} on its prototype chain",
+    refuteMessage: "${customMessage}Expected ${actual} not to have ${expected} on its " +
+        "prototype chain",
+    expectation: "toHavePrototype",
+    values: actualAndExpectedMessageValues
+});
+
+referee.add("contains", {
+    assert: function (haystack, needle) {
+        return _.include(haystack, needle);
+    },
+    assertMessage: "${customMessage}Expected [${actual}] to contain ${expected}",
+    refuteMessage: "${customMessage}Expected [${actual}] not to contain ${expected}",
+    expectation: "toContain",
+    values: actualAndExpectedMessageValues
+});
+
+referee.add("tagName", {
+    assert: function (element, tagName) {
+        // Uses arguments[2] because the function's .length is used to
+        // determine the minimum required number of arguments.
+        if (!element.tagName) {
+            return this.fail("noTagNameMessage");
+        }
+
+        return tagName.toLowerCase &&
+            tagName.toLowerCase() === element.tagName.toLowerCase();
+    },
+    assertMessage: "${customMessage}Expected tagName to be ${expected} but was ${actual}",
+    refuteMessage: "${customMessage}Expected tagName not to be ${actual}",
+    expectation: "toHaveTagName",
+    values: function (element, tagName, message) {
+        return {
+            actualElement: element,
+            actual: element.tagName,
+            expected: tagName,
+            customMessage: message
+        };
+    }
+});
+
+assert.tagName.noTagNameMessage = "${customMessage}Expected ${actualElement} to have tagName " +
+    "property";
+refute.tagName.noTagNameMessage = "${customMessage}Expected ${actualElement} to have tagName " +
+    "property";
+
+referee.add("className", {
+    assert: function (element, name) {
+        if (typeof element.className === "undefined") {
+            return this.fail("noClassNameMessage");
+        }
+
+        var expected = typeof name === "string" ? name.split(" ") : name;
+        var actual = element.className.split(" ");
+        var i, l;
+        for (i = 0, l = expected.length; i < l; i++) {
+            if (!_.include(actual, expected[i])) { return false; }
+        }
+
+        return true;
+    },
+    assertMessage: "${customMessage}Expected object's className to include ${expected} " +
+        "but was ${actual}",
+    refuteMessage: "${customMessage}Expected object's className not to include ${expected}",
+    expectation: "toHaveClassName",
+    values: function (element, className, message) {
+        return {
+            actualElement: element,
+            actual: element.className,
+            expected: className,
+            customMessage: message
+        };
+    }
+});
+
+assert.className.noClassNameMessage = "${customMessage}Expected object to have " +
+    "className property";
+refute.className.noClassNameMessage = "${customMessage}Expected object to have " +
+    "className property";
+
+referee.expect = function () {
+    expect.init(referee);
+    return expect.apply(referee, arguments);
+};
+
+module.exports = referee;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,6 +2775,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,15 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
+    "array.from": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array.from/-/array.from-1.0.3.tgz",
+      "integrity": "sha1-y1hqrZIGfzQSKfQeDtZDKB26Vrc=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -839,7 +848,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
@@ -943,7 +951,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -956,7 +963,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
       "requires": {
         "is-callable": "1.1.3",
         "is-date-object": "1.0.1",
@@ -1372,8 +1378,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1416,8 +1421,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1571,7 +1575,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -1826,8 +1829,7 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
     "is-ci": {
       "version": "1.1.0",
@@ -1858,8 +1860,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -2047,7 +2048,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "1.0.1"
       }
@@ -2073,8 +2073,7 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5079,8 +5078,7 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,6 +2775,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2764,11 +2764,6 @@
         }
       }
     },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5015,8 +5015,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,24 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -367,6 +385,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "cache-base": {
@@ -811,6 +835,16 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -874,6 +908,12 @@
         "webidl-conversions": "4.0.2"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -897,6 +937,30 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es6-promise": {
@@ -1064,11 +1128,32 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
+      "integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
     },
     "execa": {
       "version": "0.9.0",
@@ -1284,6 +1369,12 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1310,10 +1401,22 @@
         "map-cache": "0.2.2"
       }
     },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -1464,6 +1567,15 @@
         "har-schema": "2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1561,6 +1673,12 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -1696,6 +1814,21 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
@@ -1721,6 +1854,12 @@
           "dev": true
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "1.0.2",
@@ -1904,6 +2043,15 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -1920,6 +2068,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -2268,6 +2422,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -2585,6 +2745,26 @@
         }
       }
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -2670,10 +2850,25 @@
         "yallist": "2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
+      "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.3"
+      }
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -2684,6 +2879,12 @@
       "requires": {
         "object-visit": "1.0.1"
       }
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
     },
     "micromatch": {
       "version": "3.1.9",
@@ -3124,6 +3325,18 @@
         "text-encoding": "0.6.4"
       }
     },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
     "normalize-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
@@ -3137,6 +3350,34 @@
       "dev": true,
       "requires": {
         "which": "1.3.0"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.2.tgz",
+      "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "chalk": "2.3.1",
+        "cross-spawn": "5.1.0",
+        "memorystream": "0.3.1",
+        "minimatch": "3.0.4",
+        "ps-tree": "1.1.0",
+        "read-pkg": "3.0.0",
+        "shell-quote": "1.6.1",
+        "string.prototype.padend": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
       }
     },
     "npm-run-path": {
@@ -4836,6 +5077,12 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -5060,6 +5307,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
@@ -5075,6 +5328,32 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
+      }
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
       }
     },
     "performance-now": {
@@ -5179,6 +5458,15 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
+    "ps-tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
+      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
+      "dev": true,
+      "requires": {
+        "event-stream": "3.3.4"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5242,6 +5530,17 @@
             "is-buffer": "1.1.6"
           }
         }
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "readable-stream": {
@@ -5428,6 +5727,99 @@
         "glob": "7.1.2"
       }
     },
+    "rollup": {
+      "version": "0.56.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.3.tgz",
+      "integrity": "sha512-/iH4RfioboHgBjo7TbQcdMad/ifVGY/ToOB1AsW7oZHUhfhm+low6QlrImUSaJO1JqklOpWEKlD+b3MZYLuptA==",
+      "dev": true
+    },
+    "rollup-plugin-commonjs": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.3.0.tgz",
+      "integrity": "sha512-PYs3OiYgENFYEmI3vOEm5nrp3eY90YZqd5vGmQqeXmhJsAWFIrFdROCvOasqJ1HgeTvqyYo9IGXnFDyoboNcgQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.0",
+        "estree-walker": "0.5.1",
+        "magic-string": "0.22.4",
+        "resolve": "1.5.0",
+        "rollup-pluginutils": "2.0.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+      "dev": true,
+      "requires": {
+        "estree-walker": "0.3.1",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        }
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -5436,6 +5828,12 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "run-s": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/run-s/-/run-s-0.0.0.tgz",
+      "integrity": "sha1-WZkSviDAC6dphlXJk20HXTG3F1Q=",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -5547,6 +5945,18 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -5783,6 +6193,47 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5910,6 +6361,15 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
     "stream-to-observable": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
@@ -5927,6 +6387,17 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -5971,6 +6442,12 @@
           "dev": true
         }
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -6357,6 +6834,16 @@
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -6367,6 +6854,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "url": "https://github.com/sinonjs/referee"
   },
   "scripts": {
+    "build": "run-s build:dist-folder build:bundle",
+    "build:bundle": "rollup -c > dist/referee.js",
+    "build:dist-folder": "mkdirp dist",
     "lint": "eslint .",
     "precommit": "lint-staged",
-    "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
+    "prepublishOnly": "npm run build && mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "mocha 'lib/**/*.test.js'",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
   },
@@ -33,6 +36,7 @@
     ]
   },
   "files": [
+    "dist/",
     "docs/",
     "lib/",
     "!lib/test-helper.js",
@@ -45,8 +49,13 @@
     "eslint-plugin-mocha": "^4.11.0",
     "husky": "^0.14.3",
     "lint-staged": "^7.0.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.0.0",
+    "npm-run-all": "^4.1.2",
     "nyc": "^11.4.1",
+    "rollup": "^0.56.3",
+    "rollup-plugin-commonjs": "^8.3.0",
+    "run-s": "0.0.0",
     "sinon": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bane": "^1.x",
     "es6-promise": "^4.2.4",
     "lodash": "^3.x",
+    "object-assign": "^4.1.1",
     "samsam": "^1.x"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "array.from": "^1.0.3",
     "bane": "^1.x",
     "es6-promise": "^4.2.4",
     "lodash": "^3.x",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bane": "^1.x",
     "es6-promise": "^4.2.4",
     "lodash": "^3.x",
+    "lodash.isarguments": "^3.1.0",
     "object-assign": "^4.1.1",
     "samsam": "^1.x"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "array.from": "^1.0.3",
     "bane": "^1.x",
     "es6-promise": "^4.2.4",
-    "lodash": "^3.x",
     "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",
     "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bane": "^1.x",
     "es6-promise": "^4.2.4",
     "lodash": "^3.x",
+    "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",
     "object-assign": "^4.1.1",
     "samsam": "^1.x"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var commonjs = require("rollup-plugin-commonjs");
+
+module.exports = {
+    entry: "lib/referee.js",
+    format: "umd",
+    moduleName: "referee",
+    plugins: [
+        commonjs({sourceMap: false})
+    ]
+};


### PR DESCRIPTION
This PR removes the UMD wrapper around the source files, and instead provides a `dist/` folder with a UMD wrapped bundled version of `referee`.

Additionally, it removes `lodash` dependency, in favour of using native methods, polyfills and using standalone lodash methods. This should make the library slightly faster to install, and in modern runtimes also faster to use.

Reviewers are advised to read commits in turn, instead of all at once.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run prepublish` (this runs `build`)
4. Observe that there is a new `dist/` folder, with a UMD wrapped version
5. If you're still here, try using the `dist` version in a project