### PR TITLE
Fix #23: replace dynamic requires with boring repeating calls

### DIFF
--- a/lib/referee.js
+++ b/lib/referee.js
@@ -181,63 +181,59 @@ referee.prepareMessage = function msg(message) {
     return message + (/[.:!?]$/.test(message) ? " " : ": ");
 };
 
-[
-    "./assertions/defined",
-    "./assertions/class-name",
-    "./assertions/contains",
-    "./assertions/equals",
-    "./assertions/exception",
-    "./assertions/greater",
-    "./assertions/has-prototype",
-    "./assertions/is-array",
-    "./assertions/is-array-buffer",
-    "./assertions/is-array-like",
-    "./assertions/is-boolean",
-    "./assertions/is-data-view",
-    "./assertions/is-error",
-    "./assertions/is-eval-error",
-    "./assertions/is-false",
-    "./assertions/is-float-32-array",
-    "./assertions/is-float-64-array",
-    "./assertions/is-function",
-    "./assertions/is-infinity",
-    "./assertions/is-int-8-array",
-    "./assertions/is-int-16-array",
-    "./assertions/is-int-32-array",
-    "./assertions/is-intl-collator",
-    "./assertions/is-intl-date-time-format",
-    "./assertions/is-intl-number-format",
-    "./assertions/is-map",
-    "./assertions/is-nan",
-    "./assertions/is-null",
-    "./assertions/is-number",
-    "./assertions/is-object",
-    "./assertions/is-promise",
-    "./assertions/is-range-error",
-    "./assertions/is-reference-error",
-    "./assertions/is-reg-exp",
-    "./assertions/is-set",
-    "./assertions/is-string",
-    "./assertions/is-symbol",
-    "./assertions/is-syntax-error",
-    "./assertions/is-true",
-    "./assertions/is-type-error",
-    "./assertions/is-uri-error",
-    "./assertions/is-u-int-16-array",
-    "./assertions/is-u-int-32-array",
-    "./assertions/is-u-int-8-array",
-    "./assertions/is-u-int-8-clamped-array",
-    "./assertions/is-weak-map",
-    "./assertions/is-weak-set",
-    "./assertions/keys",
-    "./assertions/less",
-    "./assertions/match",
-    "./assertions/near",
-    "./assertions/same",
-    "./assertions/tag-name"
-].forEach(function (config) {
-    require(config)(referee);
-});
+require("./assertions/defined")(referee);
+require("./assertions/class-name")(referee);
+require("./assertions/contains")(referee);
+require("./assertions/equals")(referee);
+require("./assertions/exception")(referee);
+require("./assertions/greater")(referee);
+require("./assertions/has-prototype")(referee);
+require("./assertions/is-array")(referee);
+require("./assertions/is-array-buffer")(referee);
+require("./assertions/is-array-like")(referee);
+require("./assertions/is-boolean")(referee);
+require("./assertions/is-data-view")(referee);
+require("./assertions/is-error")(referee);
+require("./assertions/is-eval-error")(referee);
+require("./assertions/is-false")(referee);
+require("./assertions/is-float-32-array")(referee);
+require("./assertions/is-float-64-array")(referee);
+require("./assertions/is-function")(referee);
+require("./assertions/is-infinity")(referee);
+require("./assertions/is-int-8-array")(referee);
+require("./assertions/is-int-16-array")(referee);
+require("./assertions/is-int-32-array")(referee);
+require("./assertions/is-intl-collator")(referee);
+require("./assertions/is-intl-date-time-format")(referee);
+require("./assertions/is-intl-number-format")(referee);
+require("./assertions/is-map")(referee);
+require("./assertions/is-nan")(referee);
+require("./assertions/is-null")(referee);
+require("./assertions/is-number")(referee);
+require("./assertions/is-object")(referee);
+require("./assertions/is-promise")(referee);
+require("./assertions/is-range-error")(referee);
+require("./assertions/is-reference-error")(referee);
+require("./assertions/is-reg-exp")(referee);
+require("./assertions/is-set")(referee);
+require("./assertions/is-string")(referee);
+require("./assertions/is-symbol")(referee);
+require("./assertions/is-syntax-error")(referee);
+require("./assertions/is-true")(referee);
+require("./assertions/is-type-error")(referee);
+require("./assertions/is-uri-error")(referee);
+require("./assertions/is-u-int-16-array")(referee);
+require("./assertions/is-u-int-32-array")(referee);
+require("./assertions/is-u-int-8-array")(referee);
+require("./assertions/is-u-int-8-clamped-array")(referee);
+require("./assertions/is-weak-map")(referee);
+require("./assertions/is-weak-set")(referee);
+require("./assertions/keys")(referee);
+require("./assertions/less")(referee);
+require("./assertions/match")(referee);
+require("./assertions/near")(referee);
+require("./assertions/same")(referee);
+require("./assertions/tag-name")(referee);
 
 referee.expect = function () {
     expect.init(referee);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix #23 by replacing dynamic requires with boring repeating code.

#### Background
It seems proxyquireify that is used when running commonjs code in a browser has problems with this way of importing code. I tried making the code a bit more boring (easier to parse) and that worked.

#### How to verify - mandatory
1. Check out this branch
2. `npm link`
3. Go to the `sinon` folder
4. In the `sinon` folder, do `npm link @sinonjs/referee` to use the local version
5. `npm run test-headless`

#### Checklist for author

- [ ] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
