### PR TITLE
Fix message tests

### DIFF
--- a/lib/assertions/is-range-error.js
+++ b/lib/assertions/is-range-error.js
@@ -7,8 +7,8 @@ module.exports = function (referee) {
         assert: function (actual) {
             return actual instanceof RangeError;
         },
-        assertMessage: "${customMessage}Expected ${actual} to be an RangeError",
-        refuteMessage: "${customMessage}Expected ${actual} not to be an RangeError",
+        assertMessage: "${customMessage}Expected ${actual} to be a RangeError",
+        refuteMessage: "${customMessage}Expected ${actual} not to be a RangeError",
         expectation: "toBeRangeError",
         values: actualMessageValues
     });

--- a/lib/assertions/is-reg-exp.js
+++ b/lib/assertions/is-reg-exp.js
@@ -7,8 +7,8 @@ module.exports = function (referee) {
         assert: function (actual) {
             return actual instanceof RegExp;
         },
-        assertMessage: "${customMessage}Expected ${actual} to be an RegExp",
-        refuteMessage: "${customMessage}Expected ${actual} not to be an RegExp",
+        assertMessage: "${customMessage}Expected ${actual} to be a RegExp",
+        refuteMessage: "${customMessage}Expected ${actual} not to be a RegExp",
         expectation: "toBeRegExp",
         values: actualMessageValues
     });

--- a/lib/assertions/is-syntax-error.js
+++ b/lib/assertions/is-syntax-error.js
@@ -7,8 +7,8 @@ module.exports = function (referee) {
         assert: function (actual) {
             return actual instanceof SyntaxError;
         },
-        assertMessage: "${customMessage}Expected ${actual} to be an SyntaxError",
-        refuteMessage: "${customMessage}Expected ${actual} not to be an SyntaxError",
+        assertMessage: "${customMessage}Expected ${actual} to be a SyntaxError",
+        refuteMessage: "${customMessage}Expected ${actual} not to be a SyntaxError",
         expectation: "toBeSyntaxError",
         values: actualMessageValues
     });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -567,8 +567,8 @@ testHelper.assertionTests("assert", "isDataView", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isDataView] Expected ${actual} to be a DataView", {});
-    msg("fail with custom message", "[assert.isDataView] Nope: Expected ${actual} not to be a DataView", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isDataView] Expected [object Object] to be a DataView", {});
+    msg("fail with custom message", "[assert.isDataView] Nope: Expected [object Object] to be a DataView", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isError", function (pass, fail, msg) {
@@ -587,8 +587,8 @@ testHelper.assertionTests("assert", "isError", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isError] Expected ${actual} to be an Error", {});
-    msg("fail with custom message", "[assert.isError] Nope: Expected ${actual} not to be an Error", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isError] Expected [object Object] to be an Error", {});
+    msg("fail with custom message", "[assert.isError] Nope: Expected [object Object] to be an Error", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isEvalError", function (pass, fail, msg) {
@@ -607,8 +607,8 @@ testHelper.assertionTests("assert", "isEvalError", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isEvalError] Expected ${actual} to be an EvalError", {});
-    msg("fail with custom message", "[assert.isEvalError] Nope: Expected ${actual} not to be an EvalError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isEvalError] Expected [object Object] to be an EvalError", {});
+    msg("fail with custom message", "[assert.isEvalError] Nope: Expected [object Object] to be an EvalError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isFloat32Array", function (pass, fail, msg) {
@@ -621,8 +621,8 @@ testHelper.assertionTests("assert", "isFloat32Array", function (pass, fail, msg)
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isFloat32Array] Expected ${actual} to be a Float32Array", {});
-    msg("fail with custom message", "[assert.isFloat32Array] Nope: Expected ${actual} not to be a Float32Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isFloat32Array] Expected [object Object] to be a Float32Array", {});
+    msg("fail with custom message", "[assert.isFloat32Array] Nope: Expected [object Object] to be a Float32Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isFloat64Array", function (pass, fail, msg) {
@@ -635,8 +635,8 @@ testHelper.assertionTests("assert", "isFloat64Array", function (pass, fail, msg)
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isFloat64Array] Expected ${actual} to be a Float64Array", {});
-    msg("fail with custom message", "[assert.isFloat64Array] Nope: Expected ${actual} not to be a Float64Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isFloat64Array] Expected [object Object] to be a Float64Array", {});
+    msg("fail with custom message", "[assert.isFloat64Array] Nope: Expected [object Object] to be a Float64Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isInfinity", function (pass, fail, msg) {
@@ -649,8 +649,8 @@ testHelper.assertionTests("assert", "isInfinity", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isInfinity] Expected ${actual} to be Infinity", {});
-    msg("fail with custom message", "[assert.isInfinity] Nope: Expected ${actual} not to be Infinity", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isInfinity] Expected [object Object] to be Infinity", {});
+    msg("fail with custom message", "[assert.isInfinity] Nope: Expected [object Object] to be Infinity", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isInt8Array", function (pass, fail, msg) {
@@ -664,8 +664,8 @@ testHelper.assertionTests("assert", "isInt8Array", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isInt8Array] Expected ${actual} to be an Int8Array", {});
-    msg("fail with custom message", "[assert.isInt8Array] Nope: Expected ${actual} not to be an Int8Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isInt8Array] Expected [object Object] to be an Int8Array", {});
+    msg("fail with custom message", "[assert.isInt8Array] Nope: Expected [object Object] to be an Int8Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isInt16Array", function (pass, fail, msg) {
@@ -679,8 +679,8 @@ testHelper.assertionTests("assert", "isInt16Array", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isInt16Array] Expected ${actual} to be an Int16Array", {});
-    msg("fail with custom message", "[assert.isInt16Array] Nope: Expected ${actual} not to be an Int16Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isInt16Array] Expected [object Object] to be an Int16Array", {});
+    msg("fail with custom message", "[assert.isInt16Array] Nope: Expected [object Object] to be an Int16Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isInt32Array", function (pass, fail, msg) {
@@ -694,8 +694,8 @@ testHelper.assertionTests("assert", "isInt32Array", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isInt32Array] Expected ${actual} to be an Int32Array", {});
-    msg("fail with custom message", "[assert.isInt32Array] Nope: Expected ${actual} not to be an Int32Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isInt32Array] Expected [object Object] to be an Int32Array", {});
+    msg("fail with custom message", "[assert.isInt32Array] Nope: Expected [object Object] to be an Int32Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isIntlCollator", function (pass, fail, msg) {
@@ -708,8 +708,8 @@ testHelper.assertionTests("assert", "isIntlCollator", function (pass, fail, msg)
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.IntlCollator] Expected ${actual} to be an Intl.Collator", {});
-    msg("fail with custom message", "[assert.IntlCollator] Nope: Expected ${actual} not to be an Intl.Collator", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isIntlCollator] Expected [object Object] to be an Intl.Collator", {});
+    msg("fail with custom message", "[assert.isIntlCollator] Nope: Expected [object Object] to be an Intl.Collator", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isIntlDateTimeFormat", function (pass, fail, msg) {
@@ -722,8 +722,8 @@ testHelper.assertionTests("assert", "isIntlDateTimeFormat", function (pass, fail
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.IntlDateTimeFormat] Expected ${actual} to be an Intl.DateTimeFormat", {});
-    msg("fail with custom message", "[assert.IntlDateTimeFormat] Nope: Expected ${actual} not to be an Intl.DateTimeFormat", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isIntlDateTimeFormat] Expected [object Object] to be an Intl.DateTimeFormat", {});
+    msg("fail with custom message", "[assert.isIntlDateTimeFormat] Nope: Expected [object Object] to be an Intl.DateTimeFormat", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isIntlNumberFormat", function (pass, fail, msg) {
@@ -736,8 +736,8 @@ testHelper.assertionTests("assert", "isIntlNumberFormat", function (pass, fail, 
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.IntlNumberFormat] Expected ${actual} to be an Intl.NumberFormat", {});
-    msg("fail with custom message", "[assert.IntlNumberFormat] Nope: Expected ${actual} not to be an Intl.NumberFormat", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isIntlNumberFormat] Expected [object Object] to be an Intl.NumberFormat", {});
+    msg("fail with custom message", "[assert.isIntlNumberFormat] Nope: Expected [object Object] to be an Intl.NumberFormat", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isMap", function (pass, fail, msg) {
@@ -750,8 +750,8 @@ testHelper.assertionTests("assert", "isMap", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isMap] Expected ${actual} to be a Map", {});
-    msg("fail with custom message", "[assert.isMap] Nope: Expected ${actual} not to be a Map", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isMap] Expected [object Object] to be a Map", {});
+    msg("fail with custom message", "[assert.isMap] Nope: Expected [object Object] to be a Map", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isPromise", function (pass, fail, msg) {
@@ -764,8 +764,8 @@ testHelper.assertionTests("assert", "isPromise", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isPromise] Expected ${actual} to be a Promise", {});
-    msg("fail with custom message", "[assert.isPromise] Nope: Expected ${actual} not to be a Promise", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isPromise] Expected [object Object] to be a Promise", {});
+    msg("fail with custom message", "[assert.isPromise] Nope: Expected [object Object] to be a Promise", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isRangeError", function (pass, fail, msg) {
@@ -779,8 +779,8 @@ testHelper.assertionTests("assert", "isRangeError", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isRangeError] Expected ${actual} to be a RangeError", {});
-    msg("fail with custom message", "[assert.isRangeError] Nope: Expected ${actual} not to be a RangeError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isRangeError] Expected [object Object] to be a RangeError", {});
+    msg("fail with custom message", "[assert.isRangeError] Nope: Expected [object Object] to be a RangeError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isReferenceError", function (pass, fail, msg) {
@@ -794,8 +794,8 @@ testHelper.assertionTests("assert", "isReferenceError", function (pass, fail, ms
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isReferenceError] Expected ${actual} to be a ReferenceError", {});
-    msg("fail with custom message", "[assert.isReferenceError] Nope: Expected ${actual} not to be a ReferenceError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isReferenceError] Expected [object Object] to be a ReferenceError", {});
+    msg("fail with custom message", "[assert.isReferenceError] Nope: Expected [object Object] to be a ReferenceError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isRegExp", function (pass, fail, msg) {
@@ -809,8 +809,8 @@ testHelper.assertionTests("assert", "isRegExp", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isRegExp] Expected ${actual} to be a RegExp", {});
-    msg("fail with custom message", "[assert.isRegExp] Nope: Expected ${actual} not to be a RegExp", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isRegExp] Expected [object Object] to be a RegExp", {});
+    msg("fail with custom message", "[assert.isRegExp] Nope: Expected [object Object] to be a RegExp", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isSet", function (pass, fail, msg) {
@@ -823,8 +823,8 @@ testHelper.assertionTests("assert", "isSet", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isSet] Expected ${actual} to be a Set", {});
-    msg("fail with custom message", "[assert.isSet] Nope: Expected ${actual} not to be a Set", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isSet] Expected [object Object] to be a Set", {});
+    msg("fail with custom message", "[assert.isSet] Nope: Expected [object Object] to be a Set", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isSymbol", function (pass, fail, msg) {
@@ -837,8 +837,8 @@ testHelper.assertionTests("assert", "isSymbol", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isSymbol] Expected ${actual} to be a Symbol", {});
-    msg("fail with custom message", "[assert.isSymbol] Nope: Expected ${actual} not to be a Symbol", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isSymbol] Expected [object Object] to be a Symbol", {});
+    msg("fail with custom message", "[assert.isSymbol] Nope: Expected [object Object] to be a Symbol", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isSyntaxError", function (pass, fail, msg) {
@@ -852,8 +852,8 @@ testHelper.assertionTests("assert", "isSyntaxError", function (pass, fail, msg) 
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isSyntaxError] Expected ${actual} to be a SyntaxError", {});
-    msg("fail with custom message", "[assert.isSyntaxError] Nope: Expected ${actual} not to be a SyntaxError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isSyntaxError] Expected [object Object] to be a SyntaxError", {});
+    msg("fail with custom message", "[assert.isSyntaxError] Nope: Expected [object Object] to be a SyntaxError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isTypeError", function (pass, fail, msg) {
@@ -867,8 +867,8 @@ testHelper.assertionTests("assert", "isTypeError", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isTypeError] Expected ${actual} to be a TypeError", {});
-    msg("fail with custom message", "[assert.isTypeError] Nope: Expected ${actual} not to be a TypeError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isTypeError] Expected [object Object] to be a TypeError", {});
+    msg("fail with custom message", "[assert.isTypeError] Nope: Expected [object Object] to be a TypeError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isURIError", function (pass, fail, msg) {
@@ -882,8 +882,8 @@ testHelper.assertionTests("assert", "isURIError", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isURIError] Expected ${actual} to be a URIError", {});
-    msg("fail with custom message", "[assert.isURIError] Nope: Expected ${actual} not to be a URIError", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isURIError] Expected [object Object] to be a URIError", {});
+    msg("fail with custom message", "[assert.isURIError] Nope: Expected [object Object] to be a URIError", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isUint16Array", function (pass, fail, msg) {
@@ -897,8 +897,8 @@ testHelper.assertionTests("assert", "isUint16Array", function (pass, fail, msg) 
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isUint16Array] Expected ${actual} to be a Uint16Array", {});
-    msg("fail with custom message", "[assert.isUint16Array] Nope: Expected ${actual} not to be a Uint16Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isUint16Array] Expected [object Object] to be a Uint16Array", {});
+    msg("fail with custom message", "[assert.isUint16Array] Nope: Expected [object Object] to be a Uint16Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isUint32Array", function (pass, fail, msg) {
@@ -912,8 +912,8 @@ testHelper.assertionTests("assert", "isUint32Array", function (pass, fail, msg) 
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isUint32Array] Expected ${actual} to be a Uint32Array", {});
-    msg("fail with custom message", "[assert.isUint32Array] Nope: Expected ${actual} not to be a Uint32Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isUint32Array] Expected [object Object] to be a Uint32Array", {});
+    msg("fail with custom message", "[assert.isUint32Array] Nope: Expected [object Object] to be a Uint32Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isUint8Array", function (pass, fail, msg) {
@@ -927,8 +927,8 @@ testHelper.assertionTests("assert", "isUint8Array", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isUint8Array] Expected ${actual} to be a Uint8Array", {});
-    msg("fail with custom message", "[assert.isUint8Array] Nope: Expected ${actual} not to be a Uint8Array", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isUint8Array] Expected [object Object] to be a Uint8Array", {});
+    msg("fail with custom message", "[assert.isUint8Array] Nope: Expected [object Object] to be a Uint8Array", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isUint8ClampedArray", function (pass, fail, msg) {
@@ -941,8 +941,8 @@ testHelper.assertionTests("assert", "isUint8ClampedArray", function (pass, fail,
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isUint8ClampedArray] Expected ${actual} to be a Uint8ClampedArray", {});
-    msg("fail with custom message", "[assert.isUint8ClampedArray] Nope: Expected ${actual} not to be a Uint8ClampedArray", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isUint8ClampedArray] Expected [object Object] to be a Uint8ClampedArray", {});
+    msg("fail with custom message", "[assert.isUint8ClampedArray] Nope: Expected [object Object] to be a Uint8ClampedArray", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isWeakMap", function (pass, fail, msg) {
@@ -956,8 +956,8 @@ testHelper.assertionTests("assert", "isWeakMap", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isWeakMap] Expected ${actual} to be a WeakMap", {});
-    msg("fail with custom message", "[assert.isWeakMap] Nope: Expected ${actual} not to be a WeakMap", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isWeakMap] Expected [object Object] to be a WeakMap", {});
+    msg("fail with custom message", "[assert.isWeakMap] Nope: Expected [object Object] to be a WeakMap", {}, "Nope");
 });
 
 testHelper.assertionTests("assert", "isWeakSet", function (pass, fail, msg) {
@@ -971,8 +971,8 @@ testHelper.assertionTests("assert", "isWeakSet", function (pass, fail, msg) {
     fail("for array", []);
     fail("for object", {});
     fail("for arguments", captureArgs());
-    msg("fail with descriptive message", "[assert.isWeakSet] Expected ${actual} to be a WeakSet", {});
-    msg("fail with custom message", "[assert.isWeakSet] Nope: Expected ${actual} not to be a WeakSet", {}, "Nope");
+    msg("fail with descriptive message", "[assert.isWeakSet] Expected [object Object] to be a WeakSet", {});
+    msg("fail with custom message", "[assert.isWeakSet] Nope: Expected [object Object] to be a WeakSet", {}, "Nope");
 });
 
 testHelper.assertionTests("refute", "isArray", function (pass, fail, msg) {

--- a/lib/test-helper.js
+++ b/lib/test-helper.js
@@ -130,9 +130,9 @@ function assertionMessageTest(type, assertion, message, args) {
             referee[type][assertion].apply(referee, args);
             throw new Error(type + "." + assertion + " expected to fail");
         } catch (e) {
-            assert.equals(e.name, "AssertionError",
+            assert.equal(e.name, "AssertionError",
                 e.name + ": " + e.message);
-            assert.equals(
+            assert.equal(
                 e.message,
                 message,
                 "Message was " + e.message + ", " + "expected " + message
@@ -154,12 +154,12 @@ function assertionMessageTest(type, assertion, message, args) {
 
         for (var i = 0, l = expected; i < l; ++i) {
             if (!isNaN(args[i]) || !isNaN(referee.format.args[i][0])) {
-                assert.calledWith(referee.format, args[i]);
+                sinon.assert.calledWith(referee.format, args[i]);
             }
         }
 
-        assert.equals(this.failListener.args[0][0].name, "AssertionError");
-        assert.equals(this.failListener.args[0][0].message, msg);
+        assert.equal(testHelper.failListener.args[0][0].name, "AssertionError");
+        assert.equal(testHelper.failListener.args[0][0].message, msg);
     };
 
     return test;
@@ -170,8 +170,6 @@ function assertionTests(type, assertion, callback) {
         setUp: testHelper.setUp,
         tearDown: testHelper.tearDown
     };
-
-    var prefix = type + "." + assertion + " should ";
 
     function pass(name) {
         var label = "should pass " + name;
@@ -193,14 +191,15 @@ function assertionTests(type, assertion, callback) {
     }
 
     function msg(name, message) {
-        tests[prefix + name] = assertionMessageTest(
+        var label = "should fail " + name;
+        var test = assertionMessageTest(
             type,
             assertion,
             message,
             slice(arguments, 2)
         );
-
-        return tests[prefix + name];
+        it(label, test);
+        return test;
     }
 
     describe(type + "." + assertion, function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The test-helper `msg` test cases wheren't executed anymore. I didn't care to bisect into why, I assume during the test framework migration this got left behind.

Unfortunately, a bunch of test cases where copy-pasted afterwards without checking whether they'd actually go red under any circumstance.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
