### PR TITLE
assert.json and assert.matchJson

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,8 @@ prepended to the failure message.
 * [`contains()`](#contains)
 * [`tagName()`](#tagname)
 * [`className()`](#classname)
+* [`json()`](#json)
+* [`matchJson()`](#matchjson)
 
 * [`isArray()`](#isarray)
 * [`isArrayBuffer()`](#isarraybuffer)
@@ -1415,6 +1417,59 @@ refute.className.noClassNameMessage = "Expected object to have className propert
 refute.className.message = "Expected object's className not to include ${expected}";
 ```
 
+### `json()`
+
+```js
+assert.json(actual, json[, message])
+```
+
+Fails if `actual` is not valid JSON or the parsed JSON is not equal to `json`. Uses the same comparison algorithm as [`equals()`](#equals).
+
+```js
+var serialized = JSON.stringify({ is: 42 });
+
+assert.json(serialized, { is: 42 }); // Passes
+assert.json(serialized, { or: 42 }); // Fails
+assert.json(serialized, { is: 7 });  // Fails
+assert.json("no-json", {});          // Fails
+```
+
+#### Messages
+
+```js
+assert.json.message = "Expected ${actual} to equal ${expected}";
+assert.json.jsonParseExceptionMessage = "Expected ${actual} to be valid JSON";
+refute.json.message = "Expected ${actual} not to equal ${expected}";
+refute.json.jsonParseExceptionMessage = "Expected ${actual} to be valid JSON";
+```
+
+### `matchJson()`
+
+```js
+assert.matchJson(actual, json[, message])
+```
+
+Fails if `actual` is not valid JSON or the parsed JSON does not match `json`. Uses the same matcher algorithm as [`match()`](#match).
+
+```js
+var serialized = JSON.stringify({ is: 42, and: 3 });
+
+assert.matchJson(serialized, { is: 42 }); // Passes
+assert.matchJson(serialized, { and: 3 }); // Passes
+assert.matchJson(serialized, { or: 42 }); // Fails
+assert.matchJson(serialized, { is: 7 });  // Fails
+assert.matchJson("no-json", {});          // Fails
+```
+
+#### Messages
+
+```js
+assert.json.message = "Expected ${actual} to match ${expected}";
+assert.json.jsonParseExceptionMessage = "Expected ${actual} to be valid JSON";
+refute.json.message = "Expected ${actual} not to match ${expected}";
+refute.json.jsonParseExceptionMessage = "Expected ${actual} to be valid JSON";
+```
+
 ## Custom assertions
 
 Custom, domain-specific assertions helps improve clarity and reveal intent in tests. They also facilitate much better feedback when they fail. You can add custom assertions that behave exactly like the built-in ones (i.e. with counting, message formatting, expectations and
@@ -1683,6 +1738,22 @@ expect(actual).toHaveClassName(expected)
 ```
 
 See [`className()`](#classname)
+
+### `expect.toEqualJson()`
+
+```js
+expect(actual).toEqualJson(expected)
+```
+
+See [`json()`](#json)
+
+### `expect.toMatchJson()`
+
+```js
+expect(actual).toMatchJson(expected)
+```
+
+See [`matchJson()`](#matchJson)
 
 ### `expect.toHaveBeenCalled()`
 

--- a/lib/assertions/json.js
+++ b/lib/assertions/json.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var samsam = require("samsam");
+
+module.exports = function (referee) {
+    referee.add("json", {
+        assert: function (actual, expected) {
+            var parsed;
+            try {
+                parsed = JSON.parse(actual);
+            } catch (e) {
+                return this.fail("jsonParseExceptionMessage");
+            }
+            return samsam.deepEqual(parsed, expected);
+        },
+        assertMessage: "${customMessage}Expected ${actual} to equal ${expected}",
+        refuteMessage: "${customMessage}Expected ${actual} not to equal ${expected}",
+        expectation: "toEqualJson",
+        values: function (actual, expected, message) {
+            return {
+                actual: actual,
+                expected: JSON.stringify(expected),
+                customMessage: message
+            };
+        }
+    });
+
+    referee.assert.json.jsonParseExceptionMessage = "${customMessage}Expected ${actual} to be valid JSON";
+    referee.refute.json.jsonParseExceptionMessage = referee.assert.json.jsonParseExceptionMessage;
+};

--- a/lib/assertions/match-json.js
+++ b/lib/assertions/match-json.js
@@ -1,0 +1,33 @@
+"use strict";
+
+module.exports = function (referee) {
+    referee.add("matchJson", {
+        assert: function (actual, matcher) {
+            var parsed;
+            try {
+                parsed = JSON.parse(actual);
+            } catch (e) {
+                return this.fail("jsonParseExceptionMessage");
+            }
+            try {
+                return referee.match(parsed, matcher);
+            } catch (e) {
+                this.exceptionMessage = e.message;
+                return this.fail("exceptionMessage");
+            }
+        },
+        assertMessage: "${customMessage}Expected ${actual} to match ${expected}",
+        refuteMessage: "${customMessage}Expected ${actual} not to match ${expected}",
+        expectation: "toMatchJson",
+        values: function (actual, matcher, message) {
+            return {
+                actual: actual,
+                expected: JSON.stringify(matcher),
+                customMessage: message
+            };
+        }
+    });
+
+    referee.assert.matchJson.jsonParseExceptionMessage = "${customMessage}Expected ${actual} to be valid JSON";
+    referee.refute.matchJson.jsonParseExceptionMessage = referee.assert.json.jsonParseExceptionMessage;
+};

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -118,6 +118,8 @@ describe("expect", function () {
         expect(2).not.toBeLessThan(1);
         expect([0, 1, 2]).toContain(1);
         expect([0, 1, 2]).not.toContain(3);
+        expect("{\"key\":\"value\"}").toEqualJson({ key: "value" });
+        expect("{\"key\":\"value\"}").not.toEqualJson({ key: "different" });
         referee.assert(true, "Avoid 'no assertions'");
     });
 });

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -120,6 +120,8 @@ describe("expect", function () {
         expect([0, 1, 2]).not.toContain(3);
         expect("{\"key\":\"value\"}").toEqualJson({ key: "value" });
         expect("{\"key\":\"value\"}").not.toEqualJson({ key: "different" });
+        expect("{\"key\":\"value\",\"and\":42}").toMatchJson({ key: "value" });
+        expect("{\"key\":\"value\",\"and\":42}").not.toMatchJson({ key: "different" });
         referee.assert(true, "Avoid 'no assertions'");
     });
 });

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -234,6 +234,7 @@ require("./assertions/match")(referee);
 require("./assertions/near")(referee);
 require("./assertions/same")(referee);
 require("./assertions/tag-name")(referee);
+require("./assertions/json")(referee);
 
 referee.expect = function () {
     expect.init(referee);

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -235,6 +235,7 @@ require("./assertions/near")(referee);
 require("./assertions/same")(referee);
 require("./assertions/tag-name")(referee);
 require("./assertions/json")(referee);
+require("./assertions/match-json")(referee);
 
 referee.expect = function () {
     expect.init(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -1745,3 +1745,27 @@ testHelper.assertionTests("refute", "contains", function (pass, fail, msg) {
     pass("when array contains different object with same value",
         [thing], someOtherThing);
 });
+
+testHelper.assertionTests("assert", "json", function (pass, fail, msg) {
+    pass("when json string equals object", "{\"key\":\"value\"}", { key: "value" });
+    fail("when json string does not equal object", "{\"key\":\"value\"}", { key: "different" });
+    msg("with descriptive message",
+        "[assert.json] Expected {\"key\":\"value\"} to equal {\"key\":\"different\"}",
+        "{\"key\":\"value\"}", { key: "different" });
+    fail("when json string cannot be parsed", "{something:not parsable}", {});
+    msg("with descriptive message on parse error",
+        "[assert.json] Expected {something:not parsable} to be valid JSON",
+        "{something:not parsable}", {});
+});
+
+testHelper.assertionTests("refute", "json", function (pass, fail, msg) {
+    fail("when json string equals object", "{\"key\":\"value\"}", { key: "value" });
+    pass("when json string does not equal object", "{\"key\":\"value\"}", { key: "different" });
+    msg("with descriptive message",
+        "[refute.json] Expected {\"key\":\"value\"} not to equal {\"key\":\"value\"}",
+        "{\"key\":\"value\"}", { key: "value" });
+    fail("when json string cannot be parsed", "{something:not parsable}", {});
+    msg("with descriptive message on parse error",
+        "[refute.json] Expected {something:not parsable} to be valid JSON",
+        "{something:not parsable}", {});
+});

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -1769,3 +1769,27 @@ testHelper.assertionTests("refute", "json", function (pass, fail, msg) {
         "[refute.json] Expected {something:not parsable} to be valid JSON",
         "{something:not parsable}", {});
 });
+
+testHelper.assertionTests("assert", "matchJson", function (pass, fail, msg) {
+    pass("when json string matches object", "{\"key\":\"value\",\"and\":42}", { key: "value" });
+    fail("when json string does not equal object", "{\"key\":\"value\",\"and\":42}", { key: "different" });
+    msg("with descriptive message",
+        "[assert.matchJson] Expected {\"key\":\"value\",\"and\":42} to match {\"key\":\"different\"}",
+        "{\"key\":\"value\",\"and\":42}", { key: "different" });
+    fail("when json string cannot be parsed", "{something:not parsable}", {});
+    msg("with descriptive message on parse error",
+        "[assert.matchJson] Expected {something:not parsable} to be valid JSON",
+        "{something:not parsable}", {});
+});
+
+testHelper.assertionTests("refute", "matchJson", function (pass, fail, msg) {
+    fail("when json string equals object", "{\"key\":\"value\",\"and\":42}", { key: "value" });
+    pass("when json string does not equal object", "{\"key\":\"value\",\"and\":42}", { key: "different" });
+    msg("with descriptive message",
+        "[refute.matchJson] Expected {\"key\":\"value\",\"and\":42} not to match {\"key\":\"value\"}",
+        "{\"key\":\"value\",\"and\":42}", { key: "value" });
+    fail("when json string cannot be parsed", "{something:not parsable}", {});
+    msg("with descriptive message on parse error",
+        "[refute.matchJson] Expected {something:not parsable} to be valid JSON",
+        "{something:not parsable}", {});
+});


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This allows to compare a JSON string with an object, making it easier to read in the tests, and isn't sensitive to the ordering of properties.

#### Background (Problem in detail)  - optional

I often find myself comparing JSON strings with `assert.equals`, or parsing a JSON string, fish out a property and assert the value. Sometimes a small code change results in a re-ordering of properties in the JSON serialization and a bunch of tests fail, even though the actual properties havn't changed.

#### Solution  - optional

The two new assertions allow to directly compare a JSON string with an object and provide good exception messages on parse errors or assertion failures:

- `assert.json(jsonString, value)` parses `jsonString` and compares it with `value`
- `assert.matchJson(jsonString, value` parses `jsonString` and matches it with `value` using the `referee.match` implementation.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

Documentation for this is outstanding. I wanted to collect feedback before putting more effort into this. I can either add the documentation to this PR, or make a new one.