### PR TITLE
Add isDate assertion

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,7 @@ prepended to the failure message.
 * [`isArrayLike()`](#isarraylike)
 * [`isBoolean()`](#isboolean)
 * [`isDataView()`](#isdataview)
+* [`isDate()`](#isdate)
 * [`isError()`](#iserror)
 * [`isEvalError()`](#isevalerror)
 * [`isFalse()`](#isfalse)
@@ -646,6 +647,28 @@ assert.isDataView({});                               // Fails
 ```js
 assert.isDataView.message = "Expected ${actual} to be a DataView";
 refute.isDataView.message = "Expected ${actual} not to be a DataView";
+```
+
+
+### `isDate()`
+
+```js
+assert.isDate(actual[, message])
+```
+
+Fails if `actual` is not an instance of `Date`.
+
+```js
+assert.isDate(new Date());  // Passes
+assert.isDate(12345678);    // Fails
+assert.isDate("apple pie"); // Fails
+```
+
+#### Messages
+
+```js
+assert.isDate.message = "Expected ${actual} to be a Date";
+refute.isDate.message = "Expected ${actual} not to be a Date";
 ```
 
 

--- a/lib/assertions/is-date.js
+++ b/lib/assertions/is-date.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var actualMessageValues = require("../actual-message-values");
+
+module.exports = function (referee) {
+    referee.add("isDate", {
+        assert: function (actual) {
+            return actual instanceof Date;
+        },
+        assertMessage: "${customMessage}Expected ${actual} to be a Date",
+        refuteMessage: "${customMessage}Expected ${actual} not to be a Date",
+        expectation: "toBeDate",
+        values: actualMessageValues
+    });
+};

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -92,6 +92,10 @@ describe("expect", function () {
         expect(false).not.toBeObject();
         expect(function () {}).toBeFunction();
         expect({}).not.toBeFunction();
+        expect(new RegExp("[a-z]")).toBeRegExp();
+        expect({}).not.toBeRegExp();
+        expect(new Date()).toBeDate();
+        expect({}).not.toBeDate();
         expect(null).toBeDefined();
         expect(undefined).not.toBeDefined();
         expect(null).toBeNull();

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -193,6 +193,7 @@ require("./assertions/is-array-buffer")(referee);
 require("./assertions/is-array-like")(referee);
 require("./assertions/is-boolean")(referee);
 require("./assertions/is-data-view")(referee);
+require("./assertions/is-date")(referee);
 require("./assertions/is-error")(referee);
 require("./assertions/is-eval-error")(referee);
 require("./assertions/is-false")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -571,6 +571,21 @@ testHelper.assertionTests("assert", "isDataView", function (pass, fail, msg) {
     msg("fail with custom message", "[assert.isDataView] Nope: Expected [object Object] to be a DataView", {}, "Nope");
 });
 
+testHelper.assertionTests("assert", "isDate", function (pass, fail, msg) {
+    function captureArgs() {
+        return arguments;
+    }
+
+    pass("for Date", new Date());
+    fail("for RegExp", new RegExp("[a-z]"));
+    fail("for string", "123");
+    fail("for array", []);
+    fail("for object", {});
+    fail("for arguments", captureArgs());
+    msg("fail with descriptive message", "[assert.isDate] Expected [object Object] to be a Date", {});
+    msg("fail with custom message", "[assert.isDate] Nope: Expected [object Object] to be a Date", {}, "Nope");
+});
+
 testHelper.assertionTests("assert", "isError", function (pass, fail, msg) {
     function captureArgs() {
         return arguments;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

While converting a test suite to referee I noticed that there is no `isDate` assertion while other built in types can be asserted this way (e.g. `isRegExp`, `isError`, ...).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
