### PR TITLE
Fix isFunction failure message differences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
   # https://github.com/nodejs/LTS
-  - "4" # ends April 2018
   - "6" # ends April 2019
   - "8" # ends December 2019
+  - "10" # ends April 2021
 
 sudo: false
 

--- a/lib/assertions/is-function.js
+++ b/lib/assertions/is-function.js
@@ -11,7 +11,9 @@ module.exports = function(referee) {
         expectation: "toBeFunction",
         values: function(actual, message) {
             return {
-                actual: String(actual).replace("\n", ""),
+                actual: String(actual)
+                    .replace("function(", "function (")
+                    .replace("\n", ""),
                 actualType: typeof actual,
                 customMessage: message
             };


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The toString representation of functions has changed slightly between Node 8 and Node 10. Node 10 retains the original whitespace between the function keyword and the opening braces while Node 8 always inserts a blank.

These differences caused `refute.isFunction` tests to fail on Node 10 while they passed on Node 8.

| Command | Node 6 & 8 | Node 10 |
|---|---|---|
| `node -p 'String(function () {})'` | `function () {}` | `function () {}` |
| `node -p 'String(function() {})'` | `function () {}` | `function() {}` |

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).