### PR TITLE
Use @sinonjs/formatio to format values

### DIFF
--- a/lib/assert-exception-unexpected-exception.test.js
+++ b/lib/assert-exception-unexpected-exception.test.js
@@ -17,7 +17,7 @@ describe("assert.exception unexpected exception", function() {
             referee.assert.match(
                 e.message,
                 "[assert.exception] Wow: Expected " +
-                    "[object Object] but threw Error " +
+                    '{ name: "TypeError" } but threw Error ' +
                     "(:()\nError: :(\n"
             );
         }
@@ -37,7 +37,7 @@ describe("assert.exception unexpected exception", function() {
             referee.assert.match(
                 e.message,
                 "[assert.exception] Wow: Expected " +
-                    "[object Object] but threw " +
+                    '{ message: "Aww", name: "Error" } but threw ' +
                     "Error (:()\nError: :(\n"
             );
         }

--- a/lib/assertions/contains.js
+++ b/lib/assertions/contains.js
@@ -9,9 +9,9 @@ module.exports = function(referee) {
             return includes(haystack, needle);
         },
         assertMessage:
-            "${customMessage}Expected [${actual}] to contain ${expected}",
+            "${customMessage}Expected ${actual} to contain ${expected}",
         refuteMessage:
-            "${customMessage}Expected [${actual}] not to contain ${expected}",
+            "${customMessage}Expected ${actual} not to contain ${expected}",
         expectation: "toContain",
         values: actualAndExpectedMessageValues
     });

--- a/lib/assertions/equals.js
+++ b/lib/assertions/equals.js
@@ -1,40 +1,12 @@
 "use strict";
 
 var samsam = require("samsam");
-var interpolateProperties = require("../interpolate-properties");
-var actualAndExpectedMessageValues = require("../actual-and-expected-message-values");
 
-// Extract/replace with separate module that does a more detailed
-// visualization of multi-line strings
-function multiLineStringDiff(referee, actual, expected, message) {
-    if (actual === expected) {
-        return true;
+function escapeNewlines(value) {
+    if (typeof value === "string") {
+        return value.replace(/\n/g, "\\n");
     }
-
-    var heading = referee.assert.equals.multiLineStringHeading;
-    var failureText = interpolateProperties(referee, heading, {
-        customMessage: message
-    });
-    var actualLines = actual.split("\n");
-    var expectedLines = expected.split("\n");
-    var lineCount = Math.max(expectedLines.length, actualLines.length);
-    var lines = [];
-
-    for (var i = 0; i < lineCount; ++i) {
-        if (expectedLines[i] !== actualLines[i]) {
-            lines.push(
-                "line " +
-                    (i + 1) +
-                    ": " +
-                    (expectedLines[i] || "") +
-                    "\nwas:    " +
-                    (actualLines[i] || "")
-            );
-        }
-    }
-
-    referee.fail("[assert.equals] " + failureText + lines.join("\n\n"));
-    return false;
+    return value;
 }
 
 module.exports = function(referee) {
@@ -42,19 +14,6 @@ module.exports = function(referee) {
         // Uses arguments[2] because the function's .length is used to determine
         // the minimum required number of arguments.
         assert: function(actual, expected) {
-            if (
-                typeof actual === "string" &&
-                typeof expected === "string" &&
-                (actual.indexOf("\n") >= 0 || expected.indexOf("\n") >= 0)
-            ) {
-                return multiLineStringDiff(
-                    referee,
-                    actual,
-                    expected,
-                    arguments[2]
-                );
-            }
-
             return samsam.deepEqual(actual, expected);
         },
 
@@ -67,7 +26,13 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}${actual} expected not to be equal to ${expected}",
         expectation: "toEqual",
-        values: actualAndExpectedMessageValues
+        values: function(actual, expected, message) {
+            return {
+                actual: escapeNewlines(actual),
+                expected: escapeNewlines(expected),
+                customMessage: message
+            };
+        }
     });
 
     referee.assert.equals.multiLineStringHeading =

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -1,11 +1,18 @@
 "use strict";
 
+var formatio = require("@sinonjs/formatio");
 var assertArgNum = require("./assert-arg-num");
 var interpolatePosArg = require("./interpolate-pos-arg");
 var interpolateProperties = require("./interpolate-properties");
 var expect = require("./expect");
 var bane = require("bane");
 var Promise = require("es6-promise").Promise;
+
+// Setup formatter the same way as Sinon does:
+var formatter = formatio.configure({
+    quoteStrings: false,
+    limitChildrenCount: 250
+});
 
 var slice = Array.prototype.slice;
 var referee = bane.createEventEmitter();
@@ -198,7 +205,7 @@ referee.fail = function(message) {
 };
 
 referee.format = function(object) {
-    return String(object);
+    return formatter.ascii(object);
 };
 
 referee.prepareMessage = function msg(message) {

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -9,12 +9,12 @@ testHelper.assertionTests("assert", "isTrue", function(pass, fail, msg) {
     fail("for false", false);
     msg(
         "represent expected value in message",
-        "[assert.isTrue] Expected [object Object] to be true",
+        "[assert.isTrue] Expected {  } to be true",
         {}
     );
     msg(
         "include custom message",
-        "[assert.isTrue] Oh: Expected [object Object] to be true",
+        "[assert.isTrue] Oh: Expected {  } to be true",
         {},
         "Oh"
     );
@@ -44,7 +44,7 @@ testHelper.assertionTests("assert", "isFalse", function(pass, fail, msg) {
     );
     msg(
         "represent expected value in message",
-        "[assert.isFalse] Expected [object Object] to be false",
+        "[assert.isFalse] Expected {  } to be false",
         {}
     );
     fail("for empty string", "");
@@ -70,13 +70,13 @@ testHelper.assertionTests("assert", "same", function(pass, fail, msg) {
     pass("when comparing undefined to undefined", undefined, undefined);
     msg(
         "include objects in message",
-        "[assert.same] Obj expected to be the same object as [object Object]",
+        "[assert.same] Obj expected to be the same object as {  }",
         "Obj",
         {}
     );
     msg(
         "include custom message",
-        "[assert.same] Back again: Obj expected to be the same object as [object Object]",
+        "[assert.same] Back again: Obj expected to be the same object as {  }",
         "Obj",
         {},
         "Back again"
@@ -96,13 +96,13 @@ testHelper.assertionTests("refute", "same", function(pass, fail, msg) {
     fail("when comparing undefined to undefined", undefined, undefined);
     msg(
         "include objects in message",
-        "[refute.same] [object Object] expected not to be the same object as [object Object]",
+        "[refute.same] { id: 42 } expected not to be the same object as { id: 42 }",
         obj,
         obj
     );
     msg(
         "include custom message",
-        "[refute.same] Sigh... [object Object] expected not to be the same object as [object Object]",
+        "[refute.same] Sigh... { id: 42 } expected not to be the same object as { id: 42 }",
         obj,
         obj,
         "Sigh..."
@@ -253,65 +253,31 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg) {
 
     msg(
         "fail with understandable message",
-        "[assert.equals] [object Object] expected to be equal to Hey",
+        "[assert.equals] {  } expected to be equal to Hey",
         {},
         "Hey"
     );
 
     msg(
         "fail with custom message",
-        "[assert.equals] Here: [object Object] expected to be equal to Hey",
+        "[assert.equals] Here: {  } expected to be equal to Hey",
         {},
         "Hey",
         "Here:"
     );
 
     msg(
-        "fail with special message for multi-line strings",
-        "[assert.equals] Expected multi-line strings to be equal:\n" +
-            "line 2: The quick brown fox jumps over the lazy god\n" +
-            "was:    The quick brown fox jumps over the lazy dog",
-        "Yo!\nThe quick brown fox jumps over the lazy dog",
-        "Yo!\nThe quick brown fox jumps over the lazy god"
+        "fail for multi-line strings",
+        "[assert.equals] Yo!\\nMultiline expected to be equal to Yo!\\nHey",
+        "Yo!\nMultiline",
+        "Yo!\nHey"
     ).expectedFormats = 0;
 
     msg(
-        "fail with custom message for multi-line strings",
-        "[assert.equals] Slick! Expected multi-line strings to be equal:\n" +
-            "line 2: The quick brown fox jumps over the lazy god\n" +
-            "was:    The quick brown fox jumps over the lazy dog",
-        "Yo!\nThe quick brown fox jumps over the lazy dog",
-        "Yo!\nThe quick brown fox jumps over the lazy god",
-        "Slick!"
-    ).expectedFormats = 0;
-
-    msg(
-        "fail with special message for multi-line strings with too short actual",
-        "[assert.equals] Expected multi-line strings to be equal:\n" +
-            "line 2: The quick brown fox jumps over the lazy god\n" +
-            "was:    ",
-        "Yo!",
-        "Yo!\nThe quick brown fox jumps over the lazy god"
-    ).expectedFormats = 0;
-
-    msg(
-        "fail with special message for multi-line strings with too long actual",
-        "[assert.equals] Expected multi-line strings to be equal:\n" +
-            "line 2: \n" +
-            "was:    The quick brown fox jumps over the lazy god",
-        "Yo!\nThe quick brown fox jumps over the lazy god",
-        "Yo!"
-    ).expectedFormats = 0;
-
-    msg(
-        "fail with all differing lines in multi-line string fail",
-        "[assert.equals] Expected multi-line strings to be equal:\n" +
-            "line 1: Yo!\n" +
-            "was:    Yo\n\n" +
-            "line 4: Hey\n" +
-            "was:    Oh noes",
-        "Yo\n2\n3\nOh noes",
-        "Yo!\n2\n3\nHey"
+        "fail for multi-line strings with more than one newline",
+        "[assert.equals] Yo!\\nMulti-\\nline expected to be equal to Yo!\\nHey",
+        "Yo!\nMulti-\nline",
+        "Yo!\nHey"
     ).expectedFormats = 0;
 
     msg(
@@ -446,14 +412,14 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg) {
 
     msg(
         "fail with understandable message",
-        "[refute.equals] [object Object] expected not to be equal to [object Object]",
+        "[refute.equals] {  } expected not to be equal to {  }",
         {},
         {}
     );
 
     msg(
         "fail with custom message",
-        "[refute.equals] Eh? [object Object] expected not to be equal to [object Object]",
+        "[refute.equals] Eh? {  } expected not to be equal to {  }",
         {},
         {},
         "Eh?"
@@ -513,12 +479,12 @@ testHelper.assertionTests("assert", "isString", function(pass, fail, msg) {
     fail("for object", {});
     msg(
         "fail with descriptive message",
-        "[assert.isString] Expected [object Object] (object) to be string",
+        "[assert.isString] Expected {  } (object) to be string",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isString] Snap: Expected [object Object] (object) to be string",
+        "[assert.isString] Snap: Expected {  } (object) to be string",
         {},
         "Snap"
     );
@@ -563,12 +529,12 @@ testHelper.assertionTests("refute", "isObject", function(pass, fail, msg) {
     pass("for null", null);
     msg(
         "fail with descriptive message",
-        "[refute.isObject] [object Object] expected to be null or not an object",
+        "[refute.isObject] {  } expected to be null or not an object",
         {}
     );
     msg(
         "fail with custom message",
-        "[refute.isObject] Oh no! [object Object] expected to be null or not an object",
+        "[refute.isObject] Oh no! {  } expected to be null or not an object",
         {},
         "Oh no!"
     );
@@ -729,12 +695,12 @@ testHelper.assertionTests("assert", "isArray", function(pass, fail, msg) {
     fail("for array like", arrayLike);
     msg(
         "fail with descriptive message",
-        "[assert.isArray] Expected [object Object] to be array",
+        "[assert.isArray] Expected {  } to be array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isArray] Nope: Expected [object Object] to be array",
+        "[assert.isArray] Nope: Expected {  } to be array",
         {},
         "Nope"
     );
@@ -751,12 +717,12 @@ testHelper.assertionTests("assert", "isArrayBuffer", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isArrayBuffer] Expected [object Object] to be an ArrayBuffer",
+        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isArrayBuffer] Nope: Expected [object Object] to be an ArrayBuffer",
+        "[assert.isArrayBuffer] Nope: Expected {  } to be an ArrayBuffer",
         {},
         "Nope"
     );
@@ -777,12 +743,12 @@ testHelper.assertionTests("assert", "isDataView", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isDataView] Expected [object Object] to be a DataView",
+        "[assert.isDataView] Expected {  } to be a DataView",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isDataView] Nope: Expected [object Object] to be a DataView",
+        "[assert.isDataView] Nope: Expected {  } to be a DataView",
         {},
         "Nope"
     );
@@ -801,12 +767,12 @@ testHelper.assertionTests("assert", "isDate", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isDate] Expected [object Object] to be a Date",
+        "[assert.isDate] Expected {  } to be a Date",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isDate] Nope: Expected [object Object] to be a Date",
+        "[assert.isDate] Nope: Expected {  } to be a Date",
         {},
         "Nope"
     );
@@ -830,12 +796,12 @@ testHelper.assertionTests("assert", "isError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isError] Expected [object Object] to be an Error",
+        "[assert.isError] Expected {  } to be an Error",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isError] Nope: Expected [object Object] to be an Error",
+        "[assert.isError] Nope: Expected {  } to be an Error",
         {},
         "Nope"
     );
@@ -859,12 +825,12 @@ testHelper.assertionTests("assert", "isEvalError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isEvalError] Expected [object Object] to be an EvalError",
+        "[assert.isEvalError] Expected {  } to be an EvalError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isEvalError] Nope: Expected [object Object] to be an EvalError",
+        "[assert.isEvalError] Nope: Expected {  } to be an EvalError",
         {},
         "Nope"
     );
@@ -886,12 +852,12 @@ testHelper.assertionTests("assert", "isFloat32Array", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isFloat32Array] Expected [object Object] to be a Float32Array",
+        "[assert.isFloat32Array] Expected {  } to be a Float32Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isFloat32Array] Nope: Expected [object Object] to be a Float32Array",
+        "[assert.isFloat32Array] Nope: Expected {  } to be a Float32Array",
         {},
         "Nope"
     );
@@ -913,12 +879,12 @@ testHelper.assertionTests("assert", "isFloat64Array", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isFloat64Array] Expected [object Object] to be a Float64Array",
+        "[assert.isFloat64Array] Expected {  } to be a Float64Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isFloat64Array] Nope: Expected [object Object] to be a Float64Array",
+        "[assert.isFloat64Array] Nope: Expected {  } to be a Float64Array",
         {},
         "Nope"
     );
@@ -936,12 +902,12 @@ testHelper.assertionTests("assert", "isInfinity", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isInfinity] Expected [object Object] to be Infinity",
+        "[assert.isInfinity] Expected {  } to be Infinity",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isInfinity] Nope: Expected [object Object] to be Infinity",
+        "[assert.isInfinity] Nope: Expected {  } to be Infinity",
         {},
         "Nope"
     );
@@ -960,12 +926,12 @@ testHelper.assertionTests("assert", "isInt8Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isInt8Array] Expected [object Object] to be an Int8Array",
+        "[assert.isInt8Array] Expected {  } to be an Int8Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isInt8Array] Nope: Expected [object Object] to be an Int8Array",
+        "[assert.isInt8Array] Nope: Expected {  } to be an Int8Array",
         {},
         "Nope"
     );
@@ -984,12 +950,12 @@ testHelper.assertionTests("assert", "isInt16Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isInt16Array] Expected [object Object] to be an Int16Array",
+        "[assert.isInt16Array] Expected {  } to be an Int16Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isInt16Array] Nope: Expected [object Object] to be an Int16Array",
+        "[assert.isInt16Array] Nope: Expected {  } to be an Int16Array",
         {},
         "Nope"
     );
@@ -1008,12 +974,12 @@ testHelper.assertionTests("assert", "isInt32Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isInt32Array] Expected [object Object] to be an Int32Array",
+        "[assert.isInt32Array] Expected {  } to be an Int32Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isInt32Array] Nope: Expected [object Object] to be an Int32Array",
+        "[assert.isInt32Array] Nope: Expected {  } to be an Int32Array",
         {},
         "Nope"
     );
@@ -1035,12 +1001,12 @@ testHelper.assertionTests("assert", "isIntlCollator", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isIntlCollator] Expected [object Object] to be an Intl.Collator",
+        "[assert.isIntlCollator] Expected {  } to be an Intl.Collator",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isIntlCollator] Nope: Expected [object Object] to be an Intl.Collator",
+        "[assert.isIntlCollator] Nope: Expected {  } to be an Intl.Collator",
         {},
         "Nope"
     );
@@ -1062,12 +1028,12 @@ testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isIntlDateTimeFormat] Expected [object Object] to be an Intl.DateTimeFormat",
+        "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isIntlDateTimeFormat] Nope: Expected [object Object] to be an Intl.DateTimeFormat",
+        "[assert.isIntlDateTimeFormat] Nope: Expected {  } to be an Intl.DateTimeFormat",
         {},
         "Nope"
     );
@@ -1089,12 +1055,12 @@ testHelper.assertionTests("assert", "isIntlNumberFormat", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isIntlNumberFormat] Expected [object Object] to be an Intl.NumberFormat",
+        "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isIntlNumberFormat] Nope: Expected [object Object] to be an Intl.NumberFormat",
+        "[assert.isIntlNumberFormat] Nope: Expected {  } to be an Intl.NumberFormat",
         {},
         "Nope"
     );
@@ -1112,12 +1078,12 @@ testHelper.assertionTests("assert", "isMap", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isMap] Expected [object Object] to be a Map",
+        "[assert.isMap] Expected {  } to be a Map",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isMap] Nope: Expected [object Object] to be a Map",
+        "[assert.isMap] Nope: Expected {  } to be a Map",
         {},
         "Nope"
     );
@@ -1135,12 +1101,12 @@ testHelper.assertionTests("assert", "isPromise", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isPromise] Expected [object Object] to be a Promise",
+        "[assert.isPromise] Expected {  } to be a Promise",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isPromise] Nope: Expected [object Object] to be a Promise",
+        "[assert.isPromise] Nope: Expected {  } to be a Promise",
         {},
         "Nope"
     );
@@ -1159,12 +1125,12 @@ testHelper.assertionTests("assert", "isRangeError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isRangeError] Expected [object Object] to be a RangeError",
+        "[assert.isRangeError] Expected {  } to be a RangeError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isRangeError] Nope: Expected [object Object] to be a RangeError",
+        "[assert.isRangeError] Nope: Expected {  } to be a RangeError",
         {},
         "Nope"
     );
@@ -1187,12 +1153,12 @@ testHelper.assertionTests("assert", "isReferenceError", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isReferenceError] Expected [object Object] to be a ReferenceError",
+        "[assert.isReferenceError] Expected {  } to be a ReferenceError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isReferenceError] Nope: Expected [object Object] to be a ReferenceError",
+        "[assert.isReferenceError] Nope: Expected {  } to be a ReferenceError",
         {},
         "Nope"
     );
@@ -1211,12 +1177,12 @@ testHelper.assertionTests("assert", "isRegExp", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isRegExp] Expected [object Object] to be a RegExp",
+        "[assert.isRegExp] Expected {  } to be a RegExp",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isRegExp] Nope: Expected [object Object] to be a RegExp",
+        "[assert.isRegExp] Nope: Expected {  } to be a RegExp",
         {},
         "Nope"
     );
@@ -1234,12 +1200,12 @@ testHelper.assertionTests("assert", "isSet", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isSet] Expected [object Object] to be a Set",
+        "[assert.isSet] Expected {  } to be a Set",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isSet] Nope: Expected [object Object] to be a Set",
+        "[assert.isSet] Nope: Expected {  } to be a Set",
         {},
         "Nope"
     );
@@ -1257,12 +1223,12 @@ testHelper.assertionTests("assert", "isSymbol", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isSymbol] Expected [object Object] to be a Symbol",
+        "[assert.isSymbol] Expected {  } to be a Symbol",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isSymbol] Nope: Expected [object Object] to be a Symbol",
+        "[assert.isSymbol] Nope: Expected {  } to be a Symbol",
         {},
         "Nope"
     );
@@ -1281,12 +1247,12 @@ testHelper.assertionTests("assert", "isSyntaxError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isSyntaxError] Expected [object Object] to be a SyntaxError",
+        "[assert.isSyntaxError] Expected {  } to be a SyntaxError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isSyntaxError] Nope: Expected [object Object] to be a SyntaxError",
+        "[assert.isSyntaxError] Nope: Expected {  } to be a SyntaxError",
         {},
         "Nope"
     );
@@ -1305,12 +1271,12 @@ testHelper.assertionTests("assert", "isTypeError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isTypeError] Expected [object Object] to be a TypeError",
+        "[assert.isTypeError] Expected {  } to be a TypeError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isTypeError] Nope: Expected [object Object] to be a TypeError",
+        "[assert.isTypeError] Nope: Expected {  } to be a TypeError",
         {},
         "Nope"
     );
@@ -1329,12 +1295,12 @@ testHelper.assertionTests("assert", "isURIError", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isURIError] Expected [object Object] to be a URIError",
+        "[assert.isURIError] Expected {  } to be a URIError",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isURIError] Nope: Expected [object Object] to be a URIError",
+        "[assert.isURIError] Nope: Expected {  } to be a URIError",
         {},
         "Nope"
     );
@@ -1353,12 +1319,12 @@ testHelper.assertionTests("assert", "isUint16Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isUint16Array] Expected [object Object] to be a Uint16Array",
+        "[assert.isUint16Array] Expected {  } to be a Uint16Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isUint16Array] Nope: Expected [object Object] to be a Uint16Array",
+        "[assert.isUint16Array] Nope: Expected {  } to be a Uint16Array",
         {},
         "Nope"
     );
@@ -1377,12 +1343,12 @@ testHelper.assertionTests("assert", "isUint32Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isUint32Array] Expected [object Object] to be a Uint32Array",
+        "[assert.isUint32Array] Expected {  } to be a Uint32Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isUint32Array] Nope: Expected [object Object] to be a Uint32Array",
+        "[assert.isUint32Array] Nope: Expected {  } to be a Uint32Array",
         {},
         "Nope"
     );
@@ -1401,12 +1367,12 @@ testHelper.assertionTests("assert", "isUint8Array", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isUint8Array] Expected [object Object] to be a Uint8Array",
+        "[assert.isUint8Array] Expected {  } to be a Uint8Array",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isUint8Array] Nope: Expected [object Object] to be a Uint8Array",
+        "[assert.isUint8Array] Nope: Expected {  } to be a Uint8Array",
         {},
         "Nope"
     );
@@ -1428,12 +1394,12 @@ testHelper.assertionTests("assert", "isUint8ClampedArray", function(
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isUint8ClampedArray] Expected [object Object] to be a Uint8ClampedArray",
+        "[assert.isUint8ClampedArray] Expected {  } to be a Uint8ClampedArray",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isUint8ClampedArray] Nope: Expected [object Object] to be a Uint8ClampedArray",
+        "[assert.isUint8ClampedArray] Nope: Expected {  } to be a Uint8ClampedArray",
         {},
         "Nope"
     );
@@ -1452,12 +1418,12 @@ testHelper.assertionTests("assert", "isWeakMap", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isWeakMap] Expected [object Object] to be a WeakMap",
+        "[assert.isWeakMap] Expected {  } to be a WeakMap",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isWeakMap] Nope: Expected [object Object] to be a WeakMap",
+        "[assert.isWeakMap] Nope: Expected {  } to be a WeakMap",
         {},
         "Nope"
     );
@@ -1476,12 +1442,12 @@ testHelper.assertionTests("assert", "isWeakSet", function(pass, fail, msg) {
     fail("for arguments", captureArgs());
     msg(
         "fail with descriptive message",
-        "[assert.isWeakSet] Expected [object Object] to be a WeakSet",
+        "[assert.isWeakSet] Expected {  } to be a WeakSet",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isWeakSet] Nope: Expected [object Object] to be a WeakSet",
+        "[assert.isWeakSet] Nope: Expected {  } to be a WeakSet",
         {},
         "Nope"
     );
@@ -1507,12 +1473,12 @@ testHelper.assertionTests("refute", "isArray", function(pass, fail, msg) {
     pass("for array like", arrayLike);
     msg(
         "fail with descriptive message",
-        "[refute.isArray] Expected 1,2 not to be array",
+        "[refute.isArray] Expected [1, 2] not to be array",
         [1, 2]
     );
     msg(
         "fail with custom message",
-        "[refute.isArray] Hmm: Expected 1,2 not to be array",
+        "[refute.isArray] Hmm: Expected [1, 2] not to be array",
         [1, 2],
         "Hmm"
     );
@@ -1538,12 +1504,12 @@ testHelper.assertionTests("assert", "isArrayLike", function(pass, fail, msg) {
     pass("for array like", arrayLike);
     msg(
         "fail with descriptive message",
-        "[assert.isArrayLike] Expected [object Object] to be array like",
+        "[assert.isArrayLike] Expected {  } to be array like",
         {}
     );
     msg(
         "fail with custom message",
-        "[assert.isArrayLike] Here! Expected [object Object] to be array like",
+        "[assert.isArrayLike] Here! Expected {  } to be array like",
         {},
         "Here!"
     );
@@ -1569,12 +1535,12 @@ testHelper.assertionTests("refute", "isArrayLike", function(pass, fail, msg) {
     fail("for array like", arrayLike);
     msg(
         "fail with descriptive message",
-        "[refute.isArrayLike] Expected 1,2 not to be array like",
+        "[refute.isArrayLike] Expected [1, 2] not to be array like",
         [1, 2]
     );
     msg(
         "fail with custom message",
-        "[refute.isArrayLike] Hey: Expected 1,2 not to be array like",
+        "[refute.isArrayLike] Hey: Expected [1, 2] not to be array like",
         [1, 2],
         "Hey"
     );
@@ -2004,14 +1970,14 @@ testHelper.assertionTests("assert", "keys", function(pass, fail, msg) {
 
     msg(
         "fail with message",
-        "[assert.keys] Expected [object Object] to have exact keys a,b",
+        '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]',
         { a: 1, b: 2, c: 3 },
         ["a", "b"]
     );
 
     msg(
         "fail with custom message",
-        "[assert.keys] Too bad: Expected [object Object] to have exact keys a,b",
+        '[assert.keys] Too bad: Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]',
         { a: 1, b: 2, c: 3 },
         ["a", "b"],
         "Too bad"
@@ -2052,14 +2018,14 @@ testHelper.assertionTests("refute", "keys", function(pass, fail, msg) {
 
     msg(
         "fail with message",
-        "[refute.keys] Expected not to have exact keys a,b,c",
+        '[refute.keys] Expected not to have exact keys ["a", "b", "c"]',
         { a: 1, b: 2, c: 3 },
         ["a", "b", "c"]
     );
 
     msg(
         "fail with custom message",
-        "[refute.keys] Too bad: Expected not to have exact keys a,b,c",
+        '[refute.keys] Too bad: Expected not to have exact keys ["a", "b", "c"]',
         { a: 1, b: 2, c: 3 },
         ["a", "b", "c"],
         "Too bad"
@@ -2118,7 +2084,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with message when not throwing",
-        "[assert.exception] Expected [object Object] but no exception was thrown",
+        '[assert.exception] Expected { name: "TypeError" } but no exception was thrown',
         function() {},
         { name: "TypeError" }
     ).expectedFormats = 1;
@@ -2132,7 +2098,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with matcher and custom message",
-        "[assert.exception] Hmm: Expected [object Object] but no exception was thrown",
+        '[assert.exception] Hmm: Expected { name: "TypeError" } but no exception was thrown',
         function() {},
         { name: "TypeError" },
         "Hmm"
@@ -2252,14 +2218,14 @@ testHelper.assertionTests("assert", "tagName", function(pass, fail, msg) {
 
     msg(
         "fail if object does not have tagName property",
-        "[assert.tagName] Expected [object Object] to have tagName property",
+        "[assert.tagName] Expected {  } to have tagName property",
         {},
         "li"
     );
 
     msg(
         "fail with custom message if object does not have tagName property",
-        "[assert.tagName] Yikes! Expected [object Object] to have tagName property",
+        "[assert.tagName] Yikes! Expected {  } to have tagName property",
         {},
         "li",
         "Yikes!"
@@ -2312,14 +2278,14 @@ testHelper.assertionTests("refute", "tagName", function(pass, fail, msg) {
 
     msg(
         "fail if object does not have tagName property",
-        "[refute.tagName] Expected [object Object] to have tagName property",
+        "[refute.tagName] Expected {  } to have tagName property",
         {},
         "li"
     );
 
     msg(
         "fail with custom message if object does not have tagName property",
-        "[refute.tagName] Yes: Expected [object Object] to have tagName property",
+        "[refute.tagName] Yes: Expected {  } to have tagName property",
         {},
         "li",
         "Yes"
@@ -2359,14 +2325,14 @@ testHelper.assertionTests("assert", "className", function(pass, fail, msg) {
 
     msg(
         "fail when element does not include class name",
-        "[assert.className] Expected object's className to include item but was ",
+        "[assert.className] Expected object's className to include item but was (empty string)",
         { className: "" },
         "item"
     );
 
     msg(
         "fail with custom message when element does not include class name",
-        "[assert.className] Come on! Expected object's className to include item but was ",
+        "[assert.className] Come on! Expected object's className to include item but was (empty string)",
         { className: "" },
         "item",
         "Come on!"
@@ -2570,13 +2536,13 @@ testHelper.assertionTests("assert", "hasPrototype", function(pass, fail, msg) {
     pass("when not directly inheriting", specializedThing, MyThing.prototype);
     msg(
         "with descriptive message",
-        "[assert.hasPrototype] Expected [object Object] to have [object Object] on its prototype chain",
+        "[assert.hasPrototype] Expected {  } to have [MyThing] {  } on its prototype chain",
         otherThing,
         MyThing.prototype
     );
     msg(
         "with custom message",
-        "[assert.hasPrototype] Oh: Expected [object Object] to have [object Object] on its prototype chain",
+        "[assert.hasPrototype] Oh: Expected {  } to have [MyThing] {  } on its prototype chain",
         otherThing,
         MyThing.prototype,
         "Oh"
@@ -2603,13 +2569,13 @@ testHelper.assertionTests("refute", "hasPrototype", function(pass, fail, msg) {
     pass("when object does not inherit", otherThing, MyThing.prototype);
     msg(
         "with descriptive message",
-        "[refute.hasPrototype] Expected [object Object] not to have [object Object] on its prototype chain",
+        "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain",
         myThing,
         MyThing.prototype
     );
     msg(
         "with descriptive message",
-        "[refute.hasPrototype] Oh: Expected [object Object] not to have [object Object] on its prototype chain",
+        "[refute.hasPrototype] Oh: Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain",
         myThing,
         MyThing.prototype,
         "Oh"
@@ -2625,7 +2591,7 @@ testHelper.assertionTests("assert", "contains", function(pass, fail, msg) {
     fail("when array does not contain value", [0, 1, 2], 3);
     msg(
         "with descriptive message",
-        "[assert.contains] Expected [0,1,2] to contain 3",
+        "[assert.contains] Expected [0, 1, 2] to contain 3",
         [0, 1, 2],
         3
     );
@@ -2644,7 +2610,7 @@ testHelper.assertionTests("refute", "contains", function(pass, fail, msg) {
     pass("when array does not contain value", [0, 1, 2], 3);
     msg(
         "with descriptive message",
-        "[refute.contains] Expected [0,1,2] not to contain 2",
+        "[refute.contains] Expected [0, 1, 2] not to contain 2",
         [0, 1, 2],
         2
     );

--- a/lib/test-helper.js
+++ b/lib/test-helper.js
@@ -4,13 +4,18 @@ var referee = require("./referee");
 var sinon = require("sinon");
 var sandbox = sinon.sandbox.create();
 var assert = require("assert");
+var formatio = require("@sinonjs/formatio");
+
+var formatter = formatio.configure({
+    quoteStrings: false
+});
 
 var testHelper = {
     setUp: function() {
         sandbox.spy(referee, "fail");
 
         referee.format = sandbox.spy(function(object) {
-            return String(object);
+            return formatter.ascii(object);
         });
 
         testHelper.okListener = sandbox.spy();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
-      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "@sinonjs/formatio": "^2.0.0",
     "array-from": "2.1.1",
     "bane": "^1.x",
     "es6-promise": "^4.2.4",


### PR DESCRIPTION
The current formatting algorithm is literally `String(value)` which is not very helpful most of the time.

This change makes use of `@sinonjs/formatio` instead and replaces the custom multiline formatting logic with a simple newline escape helper. A follow up PR will add `actual` and `expected` properties onto Referee exceptions which allows the test runners to show diffs depending on the reporter in use (see discussion on https://github.com/sinonjs/referee/issues/20).

Note that the way formatio is used is very similar to the sinon core format helper. We might want to unify the logic by having a common formatter instance in `@sinonjs/commons`.