### PR TITLE
Set code, actual and expected properties on errors

### DIFF
--- a/demo/diff.test.js
+++ b/demo/diff.test.js
@@ -1,0 +1,20 @@
+/*
+ * Demo error messages and diff rendering with Mocha.
+ */
+"use strict";
+
+var assert = require("..").assert;
+
+describe("diff", function() {
+    it("multiline string", function() {
+        assert.equals("foo\nbar\ndoo\n", "bar\ndoo\nxyz\n");
+    });
+
+    it("objects", function() {
+        assert.equals({ foo: 42 }, { foo: 66 });
+    });
+
+    it("matchJson", function() {
+        assert.matchJson('{"foo":42,"bar":true}', { foo: 42, bar: false });
+    });
+});

--- a/lib/assertions/equals.js
+++ b/lib/assertions/equals.js
@@ -22,14 +22,16 @@ module.exports = function(referee) {
         },
 
         assertMessage:
-            "${customMessage}${actual} expected to be equal to ${expected}",
+            "${customMessage}${escapedActual} expected to be equal to ${escapedExpected}",
         refuteMessage:
-            "${customMessage}${actual} expected not to be equal to ${expected}",
+            "${customMessage}${escapedActual} expected not to be equal to ${escapedExpected}",
         expectation: "toEqual",
         values: function(actual, expected, message) {
             return {
-                actual: escapeNewlines(actual),
-                expected: escapeNewlines(expected),
+                escapedActual: escapeNewlines(actual),
+                escapedExpected: escapeNewlines(expected),
+                actual: actual,
+                expected: expected,
                 customMessage: message
             };
         }

--- a/lib/assertions/is-array-buffer.js
+++ b/lib/assertions/is-array-buffer.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 var toString = Object.prototype.toString;
 
 module.exports = function(referee) {
@@ -13,6 +13,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be an ArrayBuffer",
         expectation: "toBeArrayBuffer",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-array-like.js
+++ b/lib/assertions/is-array-like.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var isArguments = require("lodash.isarguments");
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     function isArrayLike(object) {
@@ -24,6 +24,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be array like",
         expectation: "toBeArrayLike",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-array.js
+++ b/lib/assertions/is-array.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     referee.add("isArray", {
@@ -10,6 +10,6 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be array",
         refuteMessage: "${customMessage}Expected ${actual} not to be array",
         expectation: "toBeArray",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-boolean.js
+++ b/lib/assertions/is-boolean.js
@@ -1,16 +1,21 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
-
 module.exports = function(referee) {
     referee.add("isBoolean", {
         assert: function(actual) {
             return typeof actual === "boolean";
         },
         assertMessage:
-            "${customMessage}Expected ${actual} (${actualType}) to be boolean",
-        refuteMessage: "${customMessage}Expected ${actual} not to be boolean",
+            "${customMessage}Expected ${value} (${actual}) to be boolean",
+        refuteMessage: "${customMessage}Expected ${value} not to be boolean",
         expectation: "toBeBoolean",
-        values: actualAndTypeOfMessageValues
+        values: function(actual, message) {
+            return {
+                value: actual,
+                actual: typeof actual,
+                expected: "boolean",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-data-view.js
+++ b/lib/assertions/is-data-view.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 var toString = Object.prototype.toString;
 
 module.exports = function(referee) {
@@ -12,6 +12,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be a DataView",
         expectation: "toBeDataView",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-error.js
+++ b/lib/assertions/is-error.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     referee.add("isError", {
@@ -10,6 +10,6 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be an Error",
         refuteMessage: "${customMessage}Expected ${actual} not to be an Error",
         expectation: "toBeError",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-eval-error.js
+++ b/lib/assertions/is-eval-error.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     referee.add("isEvalError", {
@@ -11,6 +11,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be an EvalError",
         expectation: "toBeEvalError",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-float-32-array.js
+++ b/lib/assertions/is-float-32-array.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     referee.add("isFloat32Array", {
@@ -12,6 +12,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be a Float32Array",
         expectation: "toBeFloat32Array",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-float-64-array.js
+++ b/lib/assertions/is-float-64-array.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var actualMessageValues = require("../actual-message-values");
 
 module.exports = function(referee) {
     referee.add("isFloat64Array", {
@@ -12,6 +12,6 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}Expected ${actual} not to be a Float64Array",
         expectation: "toBeFloat64Array",
-        values: actualAndTypeOfMessageValues
+        values: actualMessageValues
     });
 };

--- a/lib/assertions/is-function.js
+++ b/lib/assertions/is-function.js
@@ -6,15 +6,16 @@ module.exports = function(referee) {
             return typeof actual === "function";
         },
         assertMessage:
-            "${customMessage}${actual} (${actualType}) expected to be function",
-        refuteMessage: "${customMessage}${actual} expected not to be function",
+            "${customMessage}${value} (${actual}) expected to be function",
+        refuteMessage: "${customMessage}${value} expected not to be function",
         expectation: "toBeFunction",
         values: function(actual, message) {
             return {
-                actual: String(actual)
+                value: String(actual)
                     .replace("function(", "function (")
                     .replace("\n", ""),
-                actualType: typeof actual,
+                actual: typeof actual,
+                expected: "function",
                 customMessage: message
             };
         }

--- a/lib/assertions/is-infinity.js
+++ b/lib/assertions/is-infinity.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var actualMessageValues = require("../actual-message-values");
-
 module.exports = function(referee) {
     referee.add("isInfinity", {
         assert: function(actual) {
@@ -10,6 +8,12 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be Infinity",
         refuteMessage: "${customMessage}Expected ${actual} not to be Infinity",
         expectation: "toBeInfinity",
-        values: actualMessageValues
+        values: function(actual, message) {
+            return {
+                actual: actual,
+                expected: Infinity,
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-nan.js
+++ b/lib/assertions/is-nan.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
-
 module.exports = function(referee) {
     referee.add("isNaN", {
         assert: function(actual) {
@@ -10,6 +8,12 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be NaN",
         refuteMessage: "${customMessage}Expected not to be NaN",
         expectation: "toBeNaN",
-        values: actualAndTypeOfMessageValues
+        values: function(actual, message) {
+            return {
+                actual: actual,
+                expected: "NaN",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-null.js
+++ b/lib/assertions/is-null.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var actualMessageValues = require("../actual-message-values");
-
 module.exports = function(referee) {
     referee.add("isNull", {
         assert: function(actual) {
@@ -10,6 +8,12 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be null",
         refuteMessage: "${customMessage}Expected not to be null",
         expectation: "toBeNull",
-        values: actualMessageValues
+        values: function(actual, message) {
+            return {
+                actual: actual,
+                expected: null,
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-number.js
+++ b/lib/assertions/is-number.js
@@ -1,17 +1,22 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
-
 module.exports = function(referee) {
     referee.add("isNumber", {
         assert: function(actual) {
             return typeof actual === "number" && !isNaN(actual);
         },
         assertMessage:
-            "${customMessage}Expected ${actual} (${actualType}) to be a non-NaN number",
+            "${customMessage}Expected ${value} (${actual}) to be a non-NaN number",
         refuteMessage:
-            "${customMessage}Expected ${actual} to be NaN or a non-number value",
+            "${customMessage}Expected ${value} to be NaN or a non-number value",
         expectation: "toBeNumber",
-        values: actualAndTypeOfMessageValues
+        values: function(actual, message) {
+            return {
+                value: actual,
+                actual: typeof actual,
+                expected: "number",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-object.js
+++ b/lib/assertions/is-object.js
@@ -1,17 +1,22 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
-
 module.exports = function(referee) {
     referee.add("isObject", {
         assert: function(actual) {
             return typeof actual === "object" && !!actual;
         },
         assertMessage:
-            "${customMessage}${actual} (${actualType}) expected to be object and not null",
+            "${customMessage}${value} (${actual}) expected to be object and not null",
         refuteMessage:
-            "${customMessage}${actual} expected to be null or not an object",
+            "${customMessage}${value} expected to be null or not an object",
         expectation: "toBeObject",
-        values: actualAndTypeOfMessageValues
+        values: function(actual, message) {
+            return {
+                value: actual,
+                actual: typeof actual,
+                expected: "object",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-string.js
+++ b/lib/assertions/is-string.js
@@ -1,16 +1,21 @@
 "use strict";
 
-var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
-
 module.exports = function(referee) {
     referee.add("isString", {
         assert: function(actual) {
             return typeof actual === "string";
         },
         assertMessage:
-            "${customMessage}Expected ${actual} (${actualType}) to be string",
-        refuteMessage: "${customMessage}Expected ${actual} not to be string",
+            "${customMessage}Expected ${value} (${actual}) to be string",
+        refuteMessage: "${customMessage}Expected ${value} not to be string",
         expectation: "toBeString",
-        values: actualAndTypeOfMessageValues
+        values: function(actual, message) {
+            return {
+                value: actual,
+                actual: typeof actual,
+                expected: "string",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/is-symbol.js
+++ b/lib/assertions/is-symbol.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var actualMessageValues = require("../actual-message-values");
-
 module.exports = function(referee) {
     referee.add("isSymbol", {
         assert: function(actual) {
@@ -10,6 +8,12 @@ module.exports = function(referee) {
         assertMessage: "${customMessage}Expected ${actual} to be a Symbol",
         refuteMessage: "${customMessage}Expected ${actual} not to be a Symbol",
         expectation: "toBeSymbol",
-        values: actualMessageValues
+        values: function(actual, message) {
+            return {
+                actual: actual,
+                expected: "symbol",
+                customMessage: message
+            };
+        }
     });
 };

--- a/lib/assertions/json.js
+++ b/lib/assertions/json.js
@@ -19,9 +19,16 @@ module.exports = function(referee) {
             "${customMessage}Expected ${actual} not to equal ${expected}",
         expectation: "toEqualJson",
         values: function(actual, expected, message) {
+            var parsed;
+            try {
+                parsed = JSON.parse(actual);
+            } catch (e) {
+                // Do nothing
+            }
             return {
-                actual: actual,
-                expected: JSON.stringify(expected),
+                actualRaw: actual,
+                actual: parsed || actual,
+                expected: expected,
                 customMessage: message
             };
         }

--- a/lib/assertions/keys.js
+++ b/lib/assertions/keys.js
@@ -24,14 +24,15 @@ module.exports = function(referee) {
             return exactKeys(actual, keys);
         },
         assertMessage:
-            "${customMessage}Expected ${actualObject} to have exact keys ${keys}",
+            "${customMessage}Expected ${actualObject} to have exact keys ${expected}",
         refuteMessage:
-            "${customMessage}Expected not to have exact keys ${keys}",
+            "${customMessage}Expected not to have exact keys ${expected}",
         expectation: "toHaveKeys",
         values: function(actual, keys, message) {
             return {
                 actualObject: actual,
-                keys: keys,
+                actual: Object.keys(actual),
+                expected: keys,
                 customMessage: message
             };
         }

--- a/lib/assertions/match-json.js
+++ b/lib/assertions/match-json.js
@@ -22,9 +22,16 @@ module.exports = function(referee) {
             "${customMessage}Expected ${actual} not to match ${expected}",
         expectation: "toMatchJson",
         values: function(actual, matcher, message) {
+            var parsed;
+            try {
+                parsed = JSON.parse(actual);
+            } catch (e) {
+                // Do nothing
+            }
             return {
-                actual: actual,
-                expected: JSON.stringify(matcher),
+                actualRaw: actual,
+                actual: parsed || actual,
+                expected: matcher,
                 customMessage: message
             };
         }

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -61,7 +61,20 @@ function createAssertion(type, name, func, minArgs, messageValues, pass, fail) {
                 message = interpolatePosArg(message, args);
                 message = interpolateProperties(referee, message, this);
                 message = interpolateProperties(referee, message, namedValues);
-                fail("[" + type + "." + name + "] " + message);
+                var operator = type + "." + name;
+                var errorProperties = {
+                    operator: operator
+                };
+                if (type === "assert") {
+                    if (
+                        namedValues.hasOwnProperty("actual") &&
+                        namedValues.hasOwnProperty("expected")
+                    ) {
+                        errorProperties.actual = namedValues.actual;
+                        errorProperties.expected = namedValues.expected;
+                    }
+                }
+                fail("[" + operator + "] " + message, errorProperties);
                 return false;
             }
         };
@@ -189,9 +202,15 @@ referee.pass = function(message) {
     referee.emit.apply(referee, message);
 };
 
-referee.fail = function(message) {
+referee.fail = function(message, errorProperties) {
     var exception = new Error(message);
     exception.name = "AssertionError";
+    exception.code = "ERR_ASSERTION";
+    if (errorProperties) {
+        Object.keys(errorProperties).forEach(function(key) {
+            exception[key] = errorProperties[key];
+        });
+    }
 
     try {
         throw exception;

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -4,7 +4,7 @@ var referee = require("../lib/referee");
 var testHelper = require("./test-helper");
 var sinon = require("sinon");
 
-testHelper.assertionTests("assert", "isTrue", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isTrue", function(pass, fail, msg, error) {
     pass("for true", true);
     fail("for false", false);
     msg(
@@ -26,9 +26,22 @@ testHelper.assertionTests("assert", "isTrue", function(pass, fail, msg) {
         "fail if not passed arguments",
         "[assert.isTrue] Expected to receive at least 1 argument"
     );
+    error(
+        "for false",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isTrue"
+        },
+        false
+    );
 });
 
-testHelper.assertionTests("assert", "isFalse", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isFalse", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for false", false);
     fail("for true", true);
     msg(
@@ -52,12 +65,20 @@ testHelper.assertionTests("assert", "isFalse", function(pass, fail, msg) {
     fail("for NaN", NaN);
     fail("for null", null);
     fail("for undefined", undefined);
+    error(
+        "for true",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isFalse"
+        },
+        true
+    );
 });
 
 var obj = { id: 42 };
 var obj2 = { id: 42 };
 
-testHelper.assertionTests("assert", "same", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "same", function(pass, fail, msg, error) {
     pass("when comparing object to itself", obj, obj);
     fail("when comparing different objects", obj, obj2);
     pass("when comparing strings", "Hey", "Hey");
@@ -83,9 +104,20 @@ testHelper.assertionTests("assert", "same", function(pass, fail, msg) {
     );
     pass("when comparing NaN to NaN", NaN, NaN);
     fail("when comparing -0 to +0", -0, +0);
+    error(
+        "when comparing strings",
+        {
+            code: "ERR_ASSERTION",
+            actual: "foo",
+            expected: "bar",
+            operator: "assert.same"
+        },
+        "foo",
+        "bar"
+    );
 });
 
-testHelper.assertionTests("refute", "same", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "same", function(pass, fail, msg, error) {
     fail("comparing object to itself", obj, obj);
     pass("when comparing different objects", obj, obj2);
     fail("when comparing strings", "Hey", "Hey");
@@ -109,9 +141,18 @@ testHelper.assertionTests("refute", "same", function(pass, fail, msg) {
     );
     fail("when comparing NaN to NaN", NaN, NaN);
     pass("when comparing -0 to +0", -0, +0);
+    error(
+        "when comparing strings",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.same"
+        },
+        "foo",
+        "foo"
+    );
 });
 
-testHelper.assertionTests("assert", "equals", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
     var func = function() {};
     var arr = [];
     var date = new Date();
@@ -286,9 +327,31 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg) {
         "Yo",
         "Hey"
     );
+    error(
+        "when comparing strings",
+        {
+            code: "ERR_ASSERTION",
+            actual: "foo",
+            expected: "bar",
+            operator: "assert.equals"
+        },
+        "foo",
+        "bar"
+    );
+    error(
+        "when comparing different objects",
+        {
+            code: "ERR_ASSERTION",
+            actual: { id: 42 },
+            expected: {},
+            operator: "assert.equals"
+        },
+        { id: 42 },
+        {}
+    );
 });
 
-testHelper.assertionTests("refute", "equals", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
     fail("when comparing object to itself", obj, obj);
     fail("when comparing strings", "Hey", "Hey");
     fail("when comparing numbers", 32, 32);
@@ -424,9 +487,41 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg) {
         {},
         "Eh?"
     );
+    error(
+        "when comparing strings",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.equals"
+        },
+        "foo",
+        "foo"
+    );
+    error(
+        "when comparing multi-line strings",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.equals"
+        },
+        "foo\nbar",
+        "foo\nbar"
+    );
+    error(
+        "when comparing different objects",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.equals"
+        },
+        { id: 42 },
+        { id: 42 }
+    );
 });
 
-testHelper.assertionTests("assert", "greater", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "greater", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("when greater than", 2, 1);
     fail("when equal", 1, 1);
     fail("when less than", 0, 1);
@@ -436,9 +531,25 @@ testHelper.assertionTests("assert", "greater", function(pass, fail, msg) {
         1,
         2
     );
+    error(
+        "when less than",
+        {
+            code: "ERR_ASSERTION",
+            actual: 0,
+            expected: 1,
+            operator: "assert.greater"
+        },
+        0,
+        1
+    );
 });
 
-testHelper.assertionTests("refute", "greater", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "greater", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("when greater than", 2, 1);
     pass("when equal", 1, 1);
     pass("when less than", 0, 1);
@@ -448,9 +559,18 @@ testHelper.assertionTests("refute", "greater", function(pass, fail, msg) {
         2,
         1
     );
+    error(
+        "when greater than",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.greater"
+        },
+        2,
+        1
+    );
 });
 
-testHelper.assertionTests("assert", "less", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "less", function(pass, fail, msg, error) {
     fail("when greater than", 2, 1);
     fail("when equal", 1, 1);
     pass("when less than", 0, 1);
@@ -460,9 +580,20 @@ testHelper.assertionTests("assert", "less", function(pass, fail, msg) {
         2,
         1
     );
+    error(
+        "when greater than",
+        {
+            code: "ERR_ASSERTION",
+            actual: 2,
+            expected: 1,
+            operator: "assert.less"
+        },
+        2,
+        1
+    );
 });
 
-testHelper.assertionTests("refute", "less", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "less", function(pass, fail, msg, error) {
     pass("when greater than", 2, 1);
     pass("when equal", 1, 1);
     fail("when less than", 0, 1);
@@ -472,9 +603,23 @@ testHelper.assertionTests("refute", "less", function(pass, fail, msg) {
         1,
         2
     );
+    error(
+        "when less than",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.less"
+        },
+        0,
+        1
+    );
 });
 
-testHelper.assertionTests("assert", "isString", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isString", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for string", "Hey");
     fail("for object", {});
     msg(
@@ -488,9 +633,24 @@ testHelper.assertionTests("assert", "isString", function(pass, fail, msg) {
         {},
         "Snap"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            actual: "object",
+            expected: "string",
+            operator: "assert.isString"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("refute", "isString", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isString", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for string", "Hey");
     pass("for object", {});
     msg(
@@ -504,9 +664,22 @@ testHelper.assertionTests("refute", "isString", function(pass, fail, msg) {
         "Yo",
         "Here goes"
     );
+    error(
+        "for string",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isString"
+        },
+        "Hey"
+    );
 });
 
-testHelper.assertionTests("assert", "isObject", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isObject", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for object", {});
     fail("for function", function() {});
     fail("for null", null);
@@ -521,9 +694,24 @@ testHelper.assertionTests("assert", "isObject", function(pass, fail, msg) {
         "Hey",
         "OH!"
     );
+    error(
+        "for function",
+        {
+            code: "ERR_ASSERTION",
+            actual: "function",
+            expected: "object",
+            operator: "assert.isObject"
+        },
+        function() {}
+    );
 });
 
-testHelper.assertionTests("refute", "isObject", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isObject", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for object", {});
     pass("for function", function() {});
     pass("for null", null);
@@ -538,9 +726,22 @@ testHelper.assertionTests("refute", "isObject", function(pass, fail, msg) {
         {},
         "Oh no!"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isObject"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isFunction", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isFunction", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for function", function() {});
     fail("for object", {});
     msg(
@@ -554,9 +755,24 @@ testHelper.assertionTests("assert", "isFunction", function(pass, fail, msg) {
         "Hey",
         "Oh no"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            actual: "object",
+            expected: "function",
+            operator: "assert.isFunction"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("refute", "isFunction", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isFunction", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for function", function() {});
     pass("for object", {});
     msg(
@@ -570,9 +786,22 @@ testHelper.assertionTests("refute", "isFunction", function(pass, fail, msg) {
         function() {},
         "Hmm"
     );
+    error(
+        "for function",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isFunction"
+        },
+        function() {}
+    );
 });
 
-testHelper.assertionTests("assert", "isBoolean", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isBoolean", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for boolean", true);
     fail("for function", function() {});
     fail("for null", null);
@@ -587,9 +816,24 @@ testHelper.assertionTests("assert", "isBoolean", function(pass, fail, msg) {
         "Hey",
         "Boolean, plz"
     );
+    error(
+        "for string",
+        {
+            code: "ERR_ASSERTION",
+            actual: "string",
+            expected: "boolean",
+            operator: "assert.isBoolean"
+        },
+        "Hey"
+    );
 });
 
-testHelper.assertionTests("refute", "isBoolean", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isBoolean", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for boolean", true);
     pass("for function", function() {});
     pass("for null", null);
@@ -604,9 +848,22 @@ testHelper.assertionTests("refute", "isBoolean", function(pass, fail, msg) {
         true,
         "Here"
     );
+    error(
+        "for boolean",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isBoolean"
+        },
+        false
+    );
 });
 
-testHelper.assertionTests("assert", "isNumber", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isNumber", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for number", 32);
     fail("for NaN (sic)", NaN);
     fail("for function", function() {});
@@ -622,9 +879,24 @@ testHelper.assertionTests("assert", "isNumber", function(pass, fail, msg) {
         "Hey",
         "Check it"
     );
+    error(
+        "for string",
+        {
+            code: "ERR_ASSERTION",
+            actual: "string",
+            expected: "number",
+            operator: "assert.isNumber"
+        },
+        "Hey"
+    );
 });
 
-testHelper.assertionTests("refute", "isNumber", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isNumber", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for number", 32);
     pass("for NaN (sic)", NaN);
     pass("for function", function() {});
@@ -635,9 +907,17 @@ testHelper.assertionTests("refute", "isNumber", function(pass, fail, msg) {
         42,
         "Ho ho!"
     );
+    error(
+        "for number",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isNumber"
+        },
+        42
+    );
 });
 
-testHelper.assertionTests("assert", "isNaN", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isNaN", function(pass, fail, msg, error) {
     pass("for NaN", NaN);
     fail("for number", 32);
     fail("for function", function() {});
@@ -654,9 +934,19 @@ testHelper.assertionTests("assert", "isNaN", function(pass, fail, msg) {
         32,
         "No!"
     );
+    error(
+        "for number",
+        {
+            code: "ERR_ASSERTION",
+            actual: 42,
+            expected: "NaN",
+            operator: "assert.isNaN"
+        },
+        42
+    );
 });
 
-testHelper.assertionTests("refute", "isNaN", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isNaN", function(pass, fail, msg, error) {
     fail("for NaN", NaN);
     pass("for number", 32);
     pass("for function", function() {});
@@ -673,9 +963,22 @@ testHelper.assertionTests("refute", "isNaN", function(pass, fail, msg) {
         NaN,
         "Hey"
     );
+    error(
+        "for NaN",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isNaN"
+        },
+        NaN
+    );
 });
 
-testHelper.assertionTests("assert", "isArray", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isArray", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -704,9 +1007,22 @@ testHelper.assertionTests("assert", "isArray", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isArray"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isArrayBuffer", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isArrayBuffer", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -726,9 +1042,22 @@ testHelper.assertionTests("assert", "isArrayBuffer", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isArrayBuffer"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isDataView", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isDataView", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -752,9 +1081,17 @@ testHelper.assertionTests("assert", "isDataView", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isDataView"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isDate", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isDate", function(pass, fail, msg, error) {
     function captureArgs() {
         return arguments;
     }
@@ -776,9 +1113,22 @@ testHelper.assertionTests("assert", "isDate", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isDate"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -805,9 +1155,22 @@ testHelper.assertionTests("assert", "isError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isError"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isEvalError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isEvalError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -834,12 +1197,21 @@ testHelper.assertionTests("assert", "isEvalError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isEvalError"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isFloat32Array", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -861,12 +1233,21 @@ testHelper.assertionTests("assert", "isFloat32Array", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isFloat32Array"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isFloat64Array", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -888,9 +1269,22 @@ testHelper.assertionTests("assert", "isFloat64Array", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isFloat64Array"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isInfinity", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isInfinity", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -911,9 +1305,24 @@ testHelper.assertionTests("assert", "isInfinity", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for number",
+        {
+            code: "ERR_ASSERTION",
+            actual: 42,
+            expected: Infinity,
+            operator: "assert.isInfinity"
+        },
+        42
+    );
 });
 
-testHelper.assertionTests("assert", "isInt8Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isInt8Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -935,9 +1344,22 @@ testHelper.assertionTests("assert", "isInt8Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isInt8Array"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isInt16Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isInt16Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -959,9 +1381,22 @@ testHelper.assertionTests("assert", "isInt16Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isInt16Array"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isInt32Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isInt32Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -983,12 +1418,21 @@ testHelper.assertionTests("assert", "isInt32Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isInt32Array"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isIntlCollator", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -1010,12 +1454,21 @@ testHelper.assertionTests("assert", "isIntlCollator", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isIntlCollator"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -1037,12 +1490,21 @@ testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isIntlDateTimeFormat"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isIntlNumberFormat", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -1064,9 +1526,17 @@ testHelper.assertionTests("assert", "isIntlNumberFormat", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isIntlNumberFormat"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isMap", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isMap", function(pass, fail, msg, error) {
     function captureArgs() {
         return arguments;
     }
@@ -1087,9 +1557,22 @@ testHelper.assertionTests("assert", "isMap", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isMap"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isPromise", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isPromise", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1110,9 +1593,22 @@ testHelper.assertionTests("assert", "isPromise", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isPromise"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isRangeError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isRangeError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1134,12 +1630,21 @@ testHelper.assertionTests("assert", "isRangeError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isRangeError"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isReferenceError", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -1162,9 +1667,22 @@ testHelper.assertionTests("assert", "isReferenceError", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isReferenceError"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isRegExp", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isRegExp", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1186,9 +1704,17 @@ testHelper.assertionTests("assert", "isRegExp", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isRegExp"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isSet", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isSet", function(pass, fail, msg, error) {
     function captureArgs() {
         return arguments;
     }
@@ -1209,9 +1735,22 @@ testHelper.assertionTests("assert", "isSet", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isSet"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isSymbol", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isSymbol", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1232,9 +1771,24 @@ testHelper.assertionTests("assert", "isSymbol", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for string",
+        {
+            code: "ERR_ASSERTION",
+            actual: "apple pie",
+            expected: "symbol",
+            operator: "assert.isSymbol"
+        },
+        "apple pie"
+    );
 });
 
-testHelper.assertionTests("assert", "isSyntaxError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isSyntaxError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1256,9 +1810,22 @@ testHelper.assertionTests("assert", "isSyntaxError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isSyntaxError"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isTypeError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isTypeError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1280,9 +1847,22 @@ testHelper.assertionTests("assert", "isTypeError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isTypeError"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isURIError", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isURIError", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1304,9 +1884,22 @@ testHelper.assertionTests("assert", "isURIError", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isURIError"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isUint16Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isUint16Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1328,9 +1921,22 @@ testHelper.assertionTests("assert", "isUint16Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isUint16Array"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isUint32Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isUint32Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1352,9 +1958,22 @@ testHelper.assertionTests("assert", "isUint32Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isUint32Array"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isUint8Array", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isUint8Array", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1376,12 +1995,21 @@ testHelper.assertionTests("assert", "isUint8Array", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isUint8Array"
+        },
+        {}
+    );
 });
 
 testHelper.assertionTests("assert", "isUint8ClampedArray", function(
     pass,
     fail,
-    msg
+    msg,
+    error
 ) {
     function captureArgs() {
         return arguments;
@@ -1403,9 +2031,22 @@ testHelper.assertionTests("assert", "isUint8ClampedArray", function(
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isUint8ClampedArray"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isWeakMap", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isWeakMap", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1427,9 +2068,22 @@ testHelper.assertionTests("assert", "isWeakMap", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isWeakMap"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("assert", "isWeakSet", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isWeakSet", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1451,9 +2105,22 @@ testHelper.assertionTests("assert", "isWeakSet", function(pass, fail, msg) {
         {},
         "Nope"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isWeakSet"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("refute", "isArray", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isArray", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1482,9 +2149,22 @@ testHelper.assertionTests("refute", "isArray", function(pass, fail, msg) {
         [1, 2],
         "Hmm"
     );
+    error(
+        "for array",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isArray"
+        },
+        []
+    );
 });
 
-testHelper.assertionTests("assert", "isArrayLike", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isArrayLike", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1513,9 +2193,22 @@ testHelper.assertionTests("assert", "isArrayLike", function(pass, fail, msg) {
         {},
         "Here!"
     );
+    error(
+        "for object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isArrayLike"
+        },
+        {}
+    );
 });
 
-testHelper.assertionTests("refute", "isArrayLike", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isArrayLike", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     function captureArgs() {
         return arguments;
     }
@@ -1544,9 +2237,22 @@ testHelper.assertionTests("refute", "isArrayLike", function(pass, fail, msg) {
         [1, 2],
         "Hey"
     );
+    error(
+        "for array like",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isArrayLike"
+        },
+        arrayLike
+    );
 });
 
-testHelper.assertionTests("assert", "defined", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "defined", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for undefined", undefined);
     pass("for function", function() {});
     pass("for null", null);
@@ -1561,9 +2267,22 @@ testHelper.assertionTests("assert", "defined", function(pass, fail, msg) {
         undefined,
         "Huh?"
     );
+    error(
+        "for undefined",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.defined"
+        },
+        undefined
+    );
 });
 
-testHelper.assertionTests("refute", "defined", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "defined", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for undefined", undefined);
     fail("for function", function() {});
     fail("for null", null);
@@ -1578,9 +2297,17 @@ testHelper.assertionTests("refute", "defined", function(pass, fail, msg) {
         "Hey",
         "Yawn..."
     );
+    error(
+        "for null",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.defined"
+        },
+        null
+    );
 });
 
-testHelper.assertionTests("assert", "isNull", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "isNull", function(pass, fail, msg, error) {
     pass("for null", null);
     fail("for function", function() {});
     fail("for undefined", undefined);
@@ -1595,9 +2322,19 @@ testHelper.assertionTests("assert", "isNull", function(pass, fail, msg) {
         "Hey",
         "Hmm"
     ).expectedFormats = 1;
+    error(
+        "for undefined",
+        {
+            code: "ERR_ASSERTION",
+            actual: undefined,
+            expected: null,
+            operator: "assert.isNull"
+        },
+        undefined
+    );
 });
 
-testHelper.assertionTests("refute", "isNull", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "isNull", function(pass, fail, msg, error) {
     fail("for null", null);
     pass("for function", function() {});
     pass("for undefined", undefined);
@@ -1612,9 +2349,17 @@ testHelper.assertionTests("refute", "isNull", function(pass, fail, msg) {
         null,
         "Here"
     ).expectedFormats = 0;
+    error(
+        "for null",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.isNull"
+        },
+        null
+    );
 });
 
-testHelper.assertionTests("assert", "match", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "match", function(pass, fail, msg, error) {
     pass("matching regexp", "Assertions", /[a-z]/);
     pass("for generic object with test method returning true", "Assertions", {
         test: function() {
@@ -1774,9 +2519,21 @@ testHelper.assertionTests("assert", "match", function(pass, fail, msg) {
     pass("for matching array subset", [1, 2, 3, { id: 42 }], [{ id: 42 }]);
     fail("for mis-matching array 'subset'", [1, 2, 3], [2, 3, 4]);
     fail("for mis-ordered array 'subset'", [1, 2, 3], [1, 3]);
+
+    error(
+        "if match string is not substring of matchee",
+        {
+            code: "ERR_ASSERTION",
+            actual: "Vim",
+            expected: "Emacs",
+            operator: "assert.match"
+        },
+        "Vim",
+        "Emacs"
+    );
 });
 
-testHelper.assertionTests("refute", "match", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "match", function(pass, fail, msg, error) {
     fail("matching regexp", "Assertions", /[a-z]/);
     fail("generic object with test method returning true", "Assertions", {
         test: function() {
@@ -1934,9 +2691,19 @@ testHelper.assertionTests("refute", "match", function(pass, fail, msg) {
     fail("for matching array subset", [1, 2, 3, { id: 42 }], [{ id: 42 }]);
     pass("for mis-matching array 'subset'", [1, 2, 3], [2, 3, 4]);
     pass("for mis-ordered array 'subset'", [1, 2, 3], [1, 3]);
+
+    error(
+        "if match string is substring of matchee",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.match"
+        },
+        "Emacs",
+        "mac"
+    );
 });
 
-testHelper.assertionTests("assert", "keys", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "keys", function(pass, fail, msg, error) {
     function Class(o) {
         for (var key in o) {
             if (o.hasOwnProperty(key)) {
@@ -1982,9 +2749,21 @@ testHelper.assertionTests("assert", "keys", function(pass, fail, msg) {
         ["a", "b"],
         "Too bad"
     );
+
+    error(
+        "when keys are missing",
+        {
+            code: "ERR_ASSERTION",
+            actual: ["a", "b", "c"],
+            expected: ["a", "b"],
+            operator: "assert.keys"
+        },
+        { a: 1, b: 2, c: 3 },
+        ["a", "b"]
+    );
 });
 
-testHelper.assertionTests("refute", "keys", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "keys", function(pass, fail, msg, error) {
     function Class(o) {
         for (var key in o) {
             if (o.hasOwnProperty(key)) {
@@ -2029,6 +2808,15 @@ testHelper.assertionTests("refute", "keys", function(pass, fail, msg) {
         { a: 1, b: 2, c: 3 },
         ["a", "b", "c"],
         "Too bad"
+    );
+    error(
+        "when keys are exact",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.keys"
+        },
+        { a: 1, b: 2, c: 3 },
+        ["a", "b", "c"]
     );
 });
 
@@ -2182,7 +2970,12 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
     );
 });
 
-testHelper.assertionTests("assert", "tagName", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "tagName", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("for matching tag names", { tagName: "li" }, "li");
     pass("for case-insensitive matching tag names", { tagName: "LI" }, "li");
     pass("for case-insensitive matching tag names #2", { tagName: "li" }, "LI");
@@ -2234,9 +3027,26 @@ testHelper.assertionTests("assert", "tagName", function(pass, fail, msg) {
     if (typeof document !== "undefined") {
         pass("for DOM elements", document.createElement("li"), "li");
     }
+
+    error(
+        "for non-matching tag names",
+        {
+            code: "ERR_ASSERTION",
+            actual: "li",
+            expected: "p",
+            operator: "assert.tagName"
+        },
+        { tagName: "li" },
+        "p"
+    );
 });
 
-testHelper.assertionTests("refute", "tagName", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "tagName", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("for matching tag names", { tagName: "li" }, "li");
     fail("for case-insensitive matching tag names", { tagName: "LI" }, "li");
     fail("for case-insensitive matching tag names #2", { tagName: "LI" }, "li");
@@ -2294,9 +3104,24 @@ testHelper.assertionTests("refute", "tagName", function(pass, fail, msg) {
     if (typeof document !== "undefined") {
         pass("for DOM elements", document.createElement("li"), "p");
     }
+
+    error(
+        "for matching tag names",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.tagName"
+        },
+        { tagName: "li" },
+        "li"
+    );
 });
 
-testHelper.assertionTests("assert", "className", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "className", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     msg(
         "fail without arguments",
         "[assert.className] Expected to receive at least 2 arguments"
@@ -2374,9 +3199,26 @@ testHelper.assertionTests("assert", "className", function(pass, fail, msg) {
 
         pass("for DOM elements", li, "thing some");
     }
+
+    error(
+        "when element does not include all class names",
+        {
+            code: "ERR_ASSERTION",
+            actual: "feed item",
+            expected: "item post",
+            operator: "assert.className"
+        },
+        { className: "feed item" },
+        "item post"
+    );
 });
 
-testHelper.assertionTests("refute", "className", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "className", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     msg(
         "fail without arguments",
         "[refute.className] Expected to receive at least 2 arguments"
@@ -2457,9 +3299,19 @@ testHelper.assertionTests("refute", "className", function(pass, fail, msg) {
 
         pass("for DOM elements", li, "something");
     }
+
+    error(
+        "when element includes all class names",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.className"
+        },
+        { className: "feed item post" },
+        "item post"
+    );
 });
 
-testHelper.assertionTests("assert", "near", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "near", function(pass, fail, msg, error) {
     pass("for equal numbers", 3, 3, 0);
     fail("for numbers out of delta range", 2, 3, 0.5);
     msg(
@@ -2482,9 +3334,21 @@ testHelper.assertionTests("assert", "near", function(pass, fail, msg) {
         "fail if not passed arguments",
         "[assert.near] Expected to receive at least 3 arguments"
     );
+    error(
+        "for numbers out of delta range",
+        {
+            code: "ERR_ASSERTION",
+            actual: 2,
+            expected: 3,
+            operator: "assert.near"
+        },
+        2,
+        3,
+        0.5
+    );
 });
 
-testHelper.assertionTests("refute", "near", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "near", function(pass, fail, msg, error) {
     fail("for equal numbers", 3, 3, 0);
     pass("for numbers out of delta range", 2, 3, 0.5);
     msg(
@@ -2507,6 +3371,16 @@ testHelper.assertionTests("refute", "near", function(pass, fail, msg) {
         "fail if not passed arguments",
         "[refute.near] Expected to receive at least 3 arguments"
     );
+    error(
+        "for equal numbers",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.near"
+        },
+        3,
+        3,
+        0
+    );
 });
 
 function MyThing() {}
@@ -2516,7 +3390,12 @@ function F() {}
 F.prototype = myThing;
 var specializedThing = new F();
 
-testHelper.assertionTests("assert", "hasPrototype", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "hasPrototype", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail(
         "when object does not inherit from prototype",
         otherThing,
@@ -2551,9 +3430,25 @@ testHelper.assertionTests("assert", "hasPrototype", function(pass, fail, msg) {
         "fail if not passed arguments",
         "[assert.hasPrototype] Expected to receive at least 2 arguments"
     );
+    error(
+        "when object does not inherit from prototype",
+        {
+            code: "ERR_ASSERTION",
+            actual: otherThing,
+            expected: MyThing.prototype,
+            operator: "assert.hasPrototype"
+        },
+        otherThing,
+        MyThing.prototype
+    );
 });
 
-testHelper.assertionTests("refute", "hasPrototype", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "hasPrototype", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("when object inherits from prototype", myThing, MyThing.prototype);
     fail(
         "when not inheriting 'indirectly'",
@@ -2584,9 +3479,23 @@ testHelper.assertionTests("refute", "hasPrototype", function(pass, fail, msg) {
         "fail if not passed arguments",
         "[refute.hasPrototype] Expected to receive at least 2 arguments"
     );
+    error(
+        "when object inherits from prototype",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.hasPrototype"
+        },
+        myThing,
+        MyThing.prototype
+    );
 });
 
-testHelper.assertionTests("assert", "contains", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "contains", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("when array contains value", [0, 1, 2], 1);
     fail("when array does not contain value", [0, 1, 2], 3);
     msg(
@@ -2603,9 +3512,25 @@ testHelper.assertionTests("assert", "contains", function(pass, fail, msg) {
         [thing],
         someOtherThing
     );
+    error(
+        "when array does not contain value",
+        {
+            code: "ERR_ASSERTION",
+            actual: [0, 1, 2],
+            expected: 3,
+            operator: "assert.contains"
+        },
+        [0, 1, 2],
+        3
+    );
 });
 
-testHelper.assertionTests("refute", "contains", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "contains", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("when array contains value", [0, 1, 2], 1);
     pass("when array does not contain value", [0, 1, 2], 3);
     msg(
@@ -2622,16 +3547,25 @@ testHelper.assertionTests("refute", "contains", function(pass, fail, msg) {
         [thing],
         someOtherThing
     );
+    error(
+        "when array contains value",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.contains"
+        },
+        [0, 1, 2],
+        1
+    );
 });
 
-testHelper.assertionTests("assert", "json", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "json", function(pass, fail, msg, error) {
     pass("when json string equals object", '{"key":"value"}', { key: "value" });
     fail("when json string does not equal object", '{"key":"value"}', {
         key: "different"
     });
     msg(
         "with descriptive message",
-        '[assert.json] Expected {"key":"value"} to equal {"key":"different"}',
+        '[assert.json] Expected { key: "value" } to equal { key: "different" }',
         '{"key":"value"}',
         { key: "different" }
     );
@@ -2642,16 +3576,27 @@ testHelper.assertionTests("assert", "json", function(pass, fail, msg) {
         "{something:not parsable}",
         {}
     );
+    error(
+        "when json string does not equal object",
+        {
+            code: "ERR_ASSERTION",
+            actual: { key: "value" },
+            expected: { key: "different" },
+            operator: "assert.json"
+        },
+        '{"key":"value"}',
+        { key: "different" }
+    );
 });
 
-testHelper.assertionTests("refute", "json", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "json", function(pass, fail, msg, error) {
     fail("when json string equals object", '{"key":"value"}', { key: "value" });
     pass("when json string does not equal object", '{"key":"value"}', {
         key: "different"
     });
     msg(
         "with descriptive message",
-        '[refute.json] Expected {"key":"value"} not to equal {"key":"value"}',
+        '[refute.json] Expected { key: "value" } not to equal { key: "value" }',
         '{"key":"value"}',
         { key: "value" }
     );
@@ -2662,9 +3607,23 @@ testHelper.assertionTests("refute", "json", function(pass, fail, msg) {
         "{something:not parsable}",
         {}
     );
+    error(
+        "when json string equals object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.json"
+        },
+        '{"key":"value"}',
+        { key: "value" }
+    );
 });
 
-testHelper.assertionTests("assert", "matchJson", function(pass, fail, msg) {
+testHelper.assertionTests("assert", "matchJson", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     pass("when json string matches object", '{"key":"value","and":42}', {
         key: "value"
     });
@@ -2673,7 +3632,7 @@ testHelper.assertionTests("assert", "matchJson", function(pass, fail, msg) {
     });
     msg(
         "with descriptive message",
-        '[assert.matchJson] Expected {"key":"value","and":42} to match {"key":"different"}',
+        '[assert.matchJson] Expected { and: 42, key: "value" } to match { key: "different" }',
         '{"key":"value","and":42}',
         { key: "different" }
     );
@@ -2684,9 +3643,25 @@ testHelper.assertionTests("assert", "matchJson", function(pass, fail, msg) {
         "{something:not parsable}",
         {}
     );
+    error(
+        "when json string does not equal object",
+        {
+            code: "ERR_ASSERTION",
+            actual: { key: "value", and: 42 },
+            expected: { key: "different" },
+            operator: "assert.matchJson"
+        },
+        '{"key":"value","and":42}',
+        { key: "different" }
+    );
 });
 
-testHelper.assertionTests("refute", "matchJson", function(pass, fail, msg) {
+testHelper.assertionTests("refute", "matchJson", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
     fail("when json string equals object", '{"key":"value","and":42}', {
         key: "value"
     });
@@ -2695,7 +3670,7 @@ testHelper.assertionTests("refute", "matchJson", function(pass, fail, msg) {
     });
     msg(
         "with descriptive message",
-        '[refute.matchJson] Expected {"key":"value","and":42} not to match {"key":"value"}',
+        '[refute.matchJson] Expected { and: 42, key: "value" } not to match { key: "value" }',
         '{"key":"value","and":42}',
         { key: "value" }
     );
@@ -2705,5 +3680,14 @@ testHelper.assertionTests("refute", "matchJson", function(pass, fail, msg) {
         "[refute.matchJson] Expected {something:not parsable} to be valid JSON",
         "{something:not parsable}",
         {}
+    );
+    error(
+        "when json string equals object",
+        {
+            code: "ERR_ASSERTION",
+            operator: "refute.matchJson"
+        },
+        '{"key":"value","and":42}',
+        { key: "value" }
     );
 });

--- a/lib/test-helper.js
+++ b/lib/test-helper.js
@@ -179,6 +179,41 @@ function assertionMessageTest(type, assertion, message, args) {
     return test;
 }
 
+function failingErrorPropertiesTest(type, assertion, properties, args) {
+    return function() {
+        try {
+            referee[type][assertion].apply(referee, args);
+            throw new Error(type + "." + assertion + " expected to fail");
+        } catch (e) {
+            assert.equal(e.name, "AssertionError", e.name + ": " + e.message);
+            Object.keys(properties).forEach(function(key) {
+                assert.deepEqual(
+                    e[key],
+                    properties[key],
+                    "AssertionError." +
+                        key +
+                        " " +
+                        e[key] +
+                        " == " +
+                        properties[key]
+                );
+            });
+            Object.keys(e).forEach(function(key) {
+                if (!properties.hasOwnProperty(key) && key !== "name") {
+                    throw new Error(
+                        type +
+                            "." +
+                            assertion +
+                            " defined unexpected property '" +
+                            key +
+                            "'' on error"
+                    );
+                }
+            });
+        }
+    };
+}
+
 function assertionTests(type, assertion, callback) {
     var tests = {
         setUp: testHelper.setUp,
@@ -210,11 +245,22 @@ function assertionTests(type, assertion, callback) {
         return test;
     }
 
+    function error(name, properties) {
+        var label = "should fail " + name + " with correct error properties";
+        var test = failingErrorPropertiesTest(
+            type,
+            assertion,
+            properties,
+            slice(arguments, 2)
+        );
+        it(label, test);
+    }
+
     describe(type + "." + assertion, function() {
         beforeEach(testHelper.setUp);
         afterEach(testHelper.tearDown);
 
-        return callback.call(tests, pass, fail, msg);
+        return callback.call(tests, pass, fail, msg, error);
     });
 
     return;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "precommit": "lint-staged",
     "prepublishOnly": "npm run build && mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "mocha 'lib/**/*.test.js'",
-    "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
+    "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test",
+    "demo": "mocha demo/*.test.js"
   },
   "lint-staged": {
     "*.js": "eslint"


### PR DESCRIPTION
~~Do not merge until 34 is merged and this branch has been rebased against master. This change currently also contains the commit from 34.~~

This applies parts of the Node AssertionError convention to the AssertionError thrown by Referee (see https://nodejs.org/api/assert.html#assert_new_assert_assertionerror_options). The exposed `actual` and `expected` properties allow test runners to renders diffs. The `code` property is always set to "ERR_ASSERTION" and `operator` is set to the type and name of the Referee assertion or refutation.

Refutation do not expose `actual` and `expected` values because the values are usually equal to each other.