### PR TITLE
Reduce actual for match and matchJson

### DIFF
--- a/demo/diff.test.js
+++ b/demo/diff.test.js
@@ -15,6 +15,9 @@ describe("diff", function() {
     });
 
     it("matchJson", function() {
-        assert.matchJson('{"foo":42,"bar":true}', { foo: 42, bar: false });
+        assert.matchJson('{"foo":42,"bar":true,"ignored":true}', {
+            foo: 42,
+            bar: false
+        });
     });
 });

--- a/lib/actual-for-match.js
+++ b/lib/actual-for-match.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var toString = Object.prototype.toString;
+
+function actualForMatch(actual, match) {
+    if (
+        toString.call(actual) === "[object Object]" &&
+        toString.call(match) === "[object Object]"
+    ) {
+        var copy = {};
+        Object.keys(match).forEach(function(key) {
+            copy[key] = actual[key];
+        });
+        return copy;
+    }
+    return actual;
+}
+
+module.exports = actualForMatch;

--- a/lib/assertions/match-json.js
+++ b/lib/assertions/match-json.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var actualForMatch = require("../actual-for-match");
+
 module.exports = function(referee) {
     referee.add("matchJson", {
         assert: function(actual, matcher) {
@@ -27,6 +29,9 @@ module.exports = function(referee) {
                 parsed = JSON.parse(actual);
             } catch (e) {
                 // Do nothing
+            }
+            if (parsed) {
+                parsed = actualForMatch(parsed, matcher);
             }
             return {
                 actualRaw: actual,

--- a/lib/assertions/match.js
+++ b/lib/assertions/match.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var samsam = require("samsam");
-var actualAndExpectedMessageValues = require("../actual-and-expected-message-values");
+var actualForMatch = require("../actual-for-match");
 
 module.exports = function(referee) {
     referee.match = function(actual, matcher) {
@@ -49,7 +49,13 @@ module.exports = function(referee) {
         refuteMessage:
             "${customMessage}${actual} expected not to match ${expected}",
         expectation: "toMatch",
-        values: actualAndExpectedMessageValues
+        values: function(actual, matcher, message) {
+            return {
+                actual: actualForMatch(actual, matcher),
+                expected: matcher,
+                customMessage: message
+            };
+        }
     });
 
     referee.assert.match.exceptionMessage = referee.refute.match.exceptionMessage =

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -2531,6 +2531,20 @@ testHelper.assertionTests("assert", "match", function(pass, fail, msg, error) {
         "Vim",
         "Emacs"
     );
+    error(
+        "if object does not contain all properties in matcher",
+        {
+            code: "ERR_ASSERTION",
+            actual: { id: 42, doIt: "yes" },
+            expected: { id: 42, doIt: "no" },
+            operator: "assert.match"
+        },
+        object,
+        {
+            id: 42,
+            doIt: "no"
+        }
+    );
 });
 
 testHelper.assertionTests("refute", "match", function(pass, fail, msg, error) {
@@ -3632,7 +3646,7 @@ testHelper.assertionTests("assert", "matchJson", function(
     });
     msg(
         "with descriptive message",
-        '[assert.matchJson] Expected { and: 42, key: "value" } to match { key: "different" }',
+        '[assert.matchJson] Expected { key: "value" } to match { key: "different" }',
         '{"key":"value","and":42}',
         { key: "different" }
     );
@@ -3648,11 +3662,11 @@ testHelper.assertionTests("assert", "matchJson", function(
         {
             code: "ERR_ASSERTION",
             actual: { key: "value", and: 42 },
-            expected: { key: "different" },
+            expected: { key: "different", and: 42 },
             operator: "assert.matchJson"
         },
-        '{"key":"value","and":42}',
-        { key: "different" }
+        '{"key":"value","and":42,"ignoring":true}',
+        { key: "different", and: 42 }
     );
 });
 
@@ -3670,7 +3684,7 @@ testHelper.assertionTests("refute", "matchJson", function(
     });
     msg(
         "with descriptive message",
-        '[refute.matchJson] Expected { and: 42, key: "value" } not to match { key: "value" }',
+        '[refute.matchJson] Expected { key: "value" } not to match { key: "value" }',
         '{"key":"value","and":42}',
         { key: "value" }
     );


### PR DESCRIPTION
When asserting plain objects using match or matchJson, set the "actual"
object to an excerpt only containing the properties specified by the
matcher. If the original "actual" object is used, the diff produced by
test runners shows all properties that are not defined in the matcher as
missing. With this change, only properties that are actually compared
are shown.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

Also the `matchJson` demo was enhanced. Run it with `npm run demo`.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
