### PR TITLE
refactor(docs): add install note

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,18 @@ A collection of assertions to be used with a unit testing framework. **referee**
 
 **referee** contains lots of assertions. We strongly believe that high-level assertions are essential in the interest of producing clear and intent-revealing tests, and they also give you to-the-point failure messages.
 
+## Install
+
+```shell
+npm install @sinonjs/referee --save-dev
+```
+
+### [Sinon.JS](https://sinonjs.org) integration
+
+You can extend `referee` with assertions that integrates with [Sinon.JS](https://sinonjs.org)
+
+See [referee-sinon](https://github.com/sinonjs/referee-sinon)
+
 
 ## Assertions and refutations
 
@@ -1547,13 +1559,6 @@ Signature:
 ```
 
 Assertion failed. The callback is invoked with an [`AssertionError`](#class-assertionerror) object.
-
-
-## [Sinon.JS](https://sinonjs.org) integration
-
-You can extend `referee` with assertions that integrates with [Sinon.JS](https://sinonjs.org)
-
-See [referee-sinon](https://github.com/sinonjs/referee-sinon)
 
 
 ## Expectations


### PR DESCRIPTION
#### Background

I really like the docs, they  are compact and have great examples! Still I miss a tiny but common bit:

* A small note on how to install `referee`.
* Furthermore I think the block about the _SinonJS integration_ seems a bit lost between _Events_ and _Expectation_ somehow.


#### Solution

Add a block on how to install `referee` via npm as a dev dependency on top of the docs.  Also move the note about the sinonjs integration below that blog as a third level block.

I don't know if this makes sense or if this was spared out on purpose. Any thoughts?

#### How to verify - mandatory

1. Check the [`referee` docs](https://sinonjs.github.io/referee/)
2. Compare:
![referee](https://user-images.githubusercontent.com/2325260/47046005-74d0b500-d194-11e8-8411-174671066a1a.png)


#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
