### PR TITLE
Add some more structure to documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,24 +73,47 @@ opposed.
 All assertions support an optional `message` argument, which is
 prepended to the failure message.
 
-*Overview:*
+### Overview
 
-* [`same()`](#same)
-* [`equals()`](#equals)
-* [`greater()`](#greater)
-* [`less()`](#less)
+#### Any
+
 * [`defined()`](#defined)
-* [`isNull()`](#isnull)
+* [`equals()`](#equals)
 * [`match()`](#match)
-* [`exception()`](#exception)
-* [`near()`](#near)
-* [`hasPrototype()`](#hasprototype)
-* [`contains()`](#contains)
-* [`tagName()`](#tagname)
-* [`className()`](#classname)
+* [`same()`](#same)
+
+#### String
+
 * [`json()`](#json)
 * [`matchJson()`](#matchjson)
 
+#### Number
+
+* [`greater()`](#greater)
+* [`less()`](#less)
+* [`near()`](#near)
+
+#### Function
+
+* [`exception()`](#exception)
+
+#### Object
+* [`hasPrototype()`](#hasprototype)
+
+#### Array and array like
+
+* [`contains()`](#contains)
+
+#### DOM element
+
+* [`tagName()`](#tagname)
+* [`className()`](#classname)
+
+#### Types and values
+
+These assertions are for checking for built-in types and values.
+
+* [`isNull()`](#isnull)
 * [`isArray()`](#isarray)
 * [`isArrayBuffer()`](#isarraybuffer)
 * [`isArrayLike()`](#isarraylike)


### PR DESCRIPTION
This PR improves the documentation by adding a few headers and re-organising the links in the overview, hopefully making it easier for readers to determine if there is a built-in assertion for what they want to do.