### PR TITLE
feat(docs): Add example on loading custom assertions with mocha

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1552,8 +1552,66 @@ refute.json.jsonParseExceptionMessage = "Expected ${actual} to be valid JSON";
 
 ## Custom assertions
 
-Custom, domain-specific assertions helps improve clarity and reveal intent in tests. They also facilitate much better feedback when they fail. You can add custom assertions that behave exactly like the built-in ones (i.e. with counting, message formatting, expectations and
+Custom, domain-specific assertions help improve clarity and reveal intent in tests. They also facilitate much better feedback when they fail. You can add custom assertions that behave exactly like the built-in ones (i.e. with counting, message formatting, expectations and
 more) by using the [`referee.add`](#refereeadd) method.
+
+### Load custom assertions
+
+Custom assertions can be loaded as modules using e.g. [mocha](https://mochajs.org/) to be used in tests.
+
+**Custom assertion:**
+
+`./test/assertions/is-prime.js`
+```js
+const referee = require("referee");
+
+// adapted from https://stackoverflow.com/a/40200710
+function isPrime(number){
+    for (var i = 2; i < number; i++){
+        if (number % i === 0){
+            return false;
+        }
+    }
+    return number !== 1 && number !== 0;
+}
+
+referee.add("isPrime", {
+    assert: function assert(actual) {
+        if (typeof actual !== "number" || actual < 0) {
+            throw new TypeError("'actual' argument should be a non-negative Number");
+        }
+
+        this.actual = actual;
+
+        return isPrime(actual);
+    },
+    assertMessage: "Expected ${actual} to be a prime number",
+    refuteMessage: "Expected ${actual} to not be a prime number",
+    expectation: "toHaveArity"
+
+});
+```
+
+**Test:**
+
+`./test/some.test.js`
+```js
+const { assert, refute  } = require("referee");
+
+describe("some", function() {
+    it("should have isPrime installed", function() {
+        assert.isPrime(5);
+        refute.isPrime(6);
+    });
+});
+```
+
+**Exectute:**
+```sh
+mocha -r ./test/assetions/*
+```
+
+[This repository](https://github.com/sinonjs/referee-custom-assert-with-mocha) hosts the full runnable example from above.
 
 ## Overriding assertion messages
 


### PR DESCRIPTION
#### Purpose

This adds an example on how to load custom assertions as modules as described in https://github.com/sinonjs/referee-custom-assert-with-mocha to docs. See: #19

A typo was fixed as well: helps -> help

#### How to verify - mandatory
1. Check out this branch
2. `mkdocs serve -f mkdocs.yml`
3. go to localhost:8000

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
