### PR TITLE
 feat(assertion) add resolves/rejects assertions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1463,22 +1463,23 @@ assert.className(el, ["item", "feed"]); // Passes
 ### `resolves()`
 
 ```js
-assert.resolves(Promise, value)
+assert.resolves(promise, value)
 ```
 
-**NOTE:** This assertion returns a `Promise`!
+**NOTE:** This assertion returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)!
 
-The assertion **resolves**, if the value resolved from `Promise` is
+The assertion **resolves**, if the value resolved from `promise` is
 [`identical`](http://sinonjs.github.io/samsam/#identicalx-y) to the given `value`.
 
 Furthermore, the assertion **rejects** if,
 
-* the resolved value from the input `Promise` is not `identical` to the given `value`
-* the given `Promise` rejects instead of resolving
-* the given input is not a `Promise`
+* the resolved value from the input `promise` is not `identical` to the given `value`
+* the given `promise` rejects instead of resolving
+* the given input is not a Promise
 
 **NOTE:** In order to tell the test runner to wait until the assertion has completed, you
-either need to return the `Promise` from the assertion:
+either need to return the Promise from the assertion:
 
 ```js
 test("some asynchronous code", function() {
@@ -1497,22 +1498,23 @@ test("some asynchronous code", async function() {
 ### `rejects()`
 
 ```js
-assert.rejects(Promise, value)
+assert.rejects(promise, value)
 ```
 
-**NOTE:** This assertion returns a `Promise`!
+**NOTE:** This assertion returns a
+[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)!
 
-The assertion **resolves**, if the value rejected from `Promise` is
+The assertion **resolves**, if the value rejected from `promise` is
 [`identical`](http://sinonjs.github.io/samsam/#identicalx-y) to the given `value`.
 
 Furthermore, the assertion **rejects** if,
 
-* the rejected value from the input `Promise` is not `identical` to the given `value`
-* the given `Promise` resolves instead of rejecting
-* the given input is not a `Promise`
+* the rejected value from the input `promise` is not `identical` to the given `value`
+* the given `promise` resolves instead of rejecting
+* the given input is not a Promise
 
 **NOTE:** In order to tell the test runner to wait until the assertion has completed, you
-either need to return the `Promise` from the assertion:
+either need to return the Promise from the assertion:
 
 ```js
 test("some asynchronous code", function() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,11 @@ prepended to the failure message.
 * [`tagName()`](#tagname)
 * [`className()`](#classname)
 
+#### Promise
+
+* [`resolves`](#resolves)
+* [`rejects`](#rejects)
+
 #### Types and values
 
 These assertions are for checking for built-in types and values.
@@ -1455,6 +1460,73 @@ assert.className(el, "feed items");     // Fails, "items" is not a match
 assert.className(el, ["item", "feed"]); // Passes
 ```
 
+### `resolves()`
+
+```js
+assert.resolves(Promise, value)
+```
+
+**NOTE:** This assertion returns a `Promise`!
+
+The assertion **resolves**, if the value resolved from `Promise` is
+[`identical`](http://sinonjs.github.io/samsam/#identicalx-y) to the given `value`.
+
+Furthermore, the assertion **rejects** if,
+
+* the resolved value from the input `Promise` is not `identical` to the given `value`
+* the given `Promise` rejects instead of resolving
+* the given input is not a `Promise`
+
+**NOTE:** In order to tell the test runner to wait until the assertion has completed, you
+either need to return the `Promise` from the assertion:
+
+```js
+test("some asynchronous code", function() {
+    return assert.resolves(myAsyncFunc(), {...});
+});
+```
+
+or use `async`/`await`:
+
+```js
+test("some asynchronous code", async function() {
+    await assert.resolves(myAsyncFunc(), {...});
+});
+```
+
+### `rejects()`
+
+```js
+assert.rejects(Promise, value)
+```
+
+**NOTE:** This assertion returns a `Promise`!
+
+The assertion **resolves**, if the value rejected from `Promise` is
+[`identical`](http://sinonjs.github.io/samsam/#identicalx-y) to the given `value`.
+
+Furthermore, the assertion **rejects** if,
+
+* the rejected value from the input `Promise` is not `identical` to the given `value`
+* the given `Promise` resolves instead of rejecting
+* the given input is not a `Promise`
+
+**NOTE:** In order to tell the test runner to wait until the assertion has completed, you
+either need to return the `Promise` from the assertion:
+
+```js
+test("some asynchronous code", function() {
+    return assert.rejects(myAsyncFunc(), {...});
+});
+```
+
+or use `async`/`await`:
+
+```js
+test("some asynchronous code", async function() {
+    await assert.rejects(myAsyncFunc(), {...});
+});
+```
 
 ### `json()`
 

--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -3,78 +3,29 @@
 var samsam = require("@sinonjs/samsam");
 var createAsyncAssertion = require("../create-async-assertion");
 
+var assertMessage = "${actual} is not identical to ${expected}";
+var refuteMessage = "${actual} is identical to ${expected}";
+
 module.exports = function(referee) {
     function thenCallback() {
-        this.reject("${0} does not reject, it resolves instead");
+        this.reject("${0} did not reject, it resolved instead");
     }
     referee.add("rejects", {
         assert: createAsyncAssertion(thenCallback, function(actual, expected) {
             if (!samsam.identical(actual, expected)) {
-                this.reject(referee.assert.rejects.message);
+                this.reject(assertMessage);
+                return;
             }
             this.resolve();
         }),
         refute: createAsyncAssertion(thenCallback, function(actual, expected) {
             if (samsam.identical(actual, expected)) {
-                this.reject(referee.refute.rejects.message);
+                this.reject(refuteMessage);
+                return;
             }
             this.resolve();
         }),
-        /*
-        assert: function(promise, expected) {
-            this.expected = expected;
-            var self = this;
-            return new Promise(function(resolve, reject) {
-                try {
-                    promise
-                        .catch(function(actual) {
-                            self.actual = actual;
-                            if (!samsam.identical(actual, expected)) {
-                                reject(
-                                    "${actual} is not identical to ${expected}"
-                                );
-                            }
-                            resolve();
-                        })
-                        .then(function() {
-                            reject(
-                                "Promise does not reject it resolves instead"
-                            );
-                        });
-                } catch (e) {
-                    reject(e);
-                }
-            }).catch(function(e) {
-                self.fail(e);
-            });
-        },
-        refute: function(promise, expected) {
-            this.expected = expected;
-            var self = this;
-            return new Promise(function(resolve, reject) {
-                try {
-                    promise
-                        .catch(function(actual) {
-                            self.actual = actual;
-                            if (samsam.identical(actual, expected)) {
-                                reject("${actual} is identical to ${expected}");
-                            }
-                            resolve();
-                        })
-                        .then(function() {
-                            reject(
-                                "Promise does not reject it resolves instead"
-                            );
-                        });
-                } catch (e) {
-                    reject(e);
-                }
-            }).catch(function(e) {
-                self.fail(e);
-            });
-        },
-        */
-        assertMessage: "${actual} is not identical to ${expected}",
-        refuteMessage: "${actual} is identical to ${expected}"
+        assertMessage: assertMessage,
+        refuteMessage: refuteMessage
     });
 };

--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -1,0 +1,62 @@
+"use strict";
+
+var samsam = require("@sinonjs/samsam");
+
+module.exports = function(referee) {
+    referee.add("rejects", {
+        assert: function(promise, expected) {
+            this.expected = expected;
+            var self = this;
+            return new Promise(function(resolve, reject) {
+                try {
+                    promise
+                        .catch(function(actual) {
+                            self.actual = actual;
+                            if (!samsam.identical(actual, expected)) {
+                                reject(
+                                    "${actual} is not identical to ${expected}"
+                                );
+                            }
+                            resolve();
+                        })
+                        .then(function() {
+                            reject(
+                                "Promise does not reject it resolves instead"
+                            );
+                        });
+                } catch (e) {
+                    reject(e);
+                }
+            }).catch(function(e) {
+                self.fail(e);
+            });
+        },
+        refute: function(promise, expected) {
+            this.expected = expected;
+            var self = this;
+            return new Promise(function(resolve, reject) {
+                try {
+                    promise
+                        .catch(function(actual) {
+                            self.actual = actual;
+                            if (samsam.identical(actual, expected)) {
+                                reject("${actual} is identical to ${expected}");
+                            }
+                            resolve();
+                        })
+                        .then(function() {
+                            reject(
+                                "Promise does not reject it resolves instead"
+                            );
+                        });
+                } catch (e) {
+                    reject(e);
+                }
+            }).catch(function(e) {
+                self.fail(e);
+            });
+        },
+        assertMessage: "${actual} is not identical to ${expected}",
+        refuteMessage: "${actual} is identical to ${expected}"
+    });
+};

--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -1,9 +1,26 @@
 "use strict";
 
 var samsam = require("@sinonjs/samsam");
+var createAsyncAssertion = require("../create-async-assertion");
 
 module.exports = function(referee) {
+    function thenCallback() {
+        this.reject("${0} does not reject, it resolves instead");
+    }
     referee.add("rejects", {
+        assert: createAsyncAssertion(thenCallback, function(actual, expected) {
+            if (!samsam.identical(actual, expected)) {
+                this.reject(referee.assert.rejects.message);
+            }
+            this.resolve();
+        }),
+        refute: createAsyncAssertion(thenCallback, function(actual, expected) {
+            if (samsam.identical(actual, expected)) {
+                this.reject(referee.refute.rejects.message);
+            }
+            this.resolve();
+        }),
+        /*
         assert: function(promise, expected) {
             this.expected = expected;
             var self = this;
@@ -56,6 +73,7 @@ module.exports = function(referee) {
                 self.fail(e);
             });
         },
+        */
         assertMessage: "${actual} is not identical to ${expected}",
         refuteMessage: "${actual} is identical to ${expected}"
     });

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var referee = require("../referee");
+
+describe("assert.rejects", function() {
+    it("should resolve and pass when identical", function() {
+        return referee.assert.rejects(Promise.reject("test"), "test");
+    });
+
+    it("should reject and fail when not identical", function() {
+        return referee.assert
+            .rejects(Promise.reject("test"), "test2")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+
+    it("should reject and fail when input is not a promise", function() {
+        return referee.assert.rejects({}, "test").catch(function(e) {
+            referee.assert.isError(e);
+        });
+    });
+
+    it("should reject and fail if the input promise resolves", function() {
+        return referee.assert
+            .rejects(Promise.resolve(), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+});
+
+describe("refute.rejects", function() {
+    it("should resolve and pass when not identical", function() {
+        return referee.refute.rejects(Promise.reject("test"), "test2");
+    });
+
+    it("should reject and fail when identical", function() {
+        return referee.refute
+            .rejects(Promise.reject("test"), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+
+    it("should reject and fail when input is not a promise", function() {
+        return referee.refute.rejects({}, "test").catch(function(e) {
+            referee.assert.isError(e);
+        });
+    });
+
+    it("should reject and fail if the input promise resolves", function() {
+        return referee.assert
+            .rejects(Promise.resolve(), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+});

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -3,57 +3,92 @@
 var referee = require("../referee");
 
 describe("assert.rejects", function() {
-    it("should resolve and pass when identical", function() {
-        return referee.assert.rejects(Promise.reject("test"), "test");
+    it("should return a promise", function() {
+        var assertion = referee.assert.rejects(Promise.reject("test"), "test");
+        referee.assert.isPromise(assertion);
     });
 
-    it("should reject and fail when not identical", function() {
-        return referee.assert
-            .rejects(Promise.reject("test"), "test2")
-            .catch(function(e) {
-                referee.assert.isError(e);
-            });
-    });
-
-    it("should reject and fail when input is not a promise", function() {
-        return referee.assert.rejects({}, "test").catch(function(e) {
-            referee.assert.isError(e);
+    context("when promise argument rejects to value argument", function() {
+        it("should resolve the returned promise", function() {
+            return referee.assert.rejects(Promise.reject("test"), "test");
         });
     });
 
-    it("should reject and fail if the input promise resolves", function() {
-        return referee.assert
-            .rejects(Promise.resolve(), "test")
-            .catch(function(e) {
+    context(
+        "when promise argument does not reject to value argument",
+        function() {
+            it("should reject the returned promise", function() {
+                return referee.assert
+                    .rejects(Promise.reject("test"), "test2")
+                    .catch(function(e) {
+                        referee.assert.isError(e);
+                    });
+            });
+        }
+    );
+
+    context("when promise argument is not a promise", function() {
+        it("should reject the returned promise", function() {
+            return referee.assert.rejects({}, "test").catch(function(e) {
                 referee.assert.isError(e);
             });
+        });
+    });
+
+    context("when promise argument does not reject", function() {
+        it("should reject the returned promise", function() {
+            return referee.assert
+                .rejects(Promise.resolve(), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
+        });
     });
 });
 
 describe("refute.rejects", function() {
-    it("should resolve and pass when not identical", function() {
-        return referee.refute.rejects(Promise.reject("test"), "test2");
+    it("should return a promise", function() {
+        var refutation = referee.refute.rejects(
+            Promise.reject("test"),
+            "test2"
+        );
+        referee.assert.isPromise(refutation);
     });
 
-    it("should reject and fail when identical", function() {
-        return referee.refute
-            .rejects(Promise.reject("test"), "test")
-            .catch(function(e) {
-                referee.assert.isError(e);
+    context(
+        "when promise argument does not rejects to value argument",
+        function() {
+            it("should resolve the returned promise", function() {
+                return referee.refute.rejects(Promise.reject("test"), "test2");
             });
-    });
+        }
+    );
 
-    it("should reject and fail when input is not a promise", function() {
-        return referee.refute.rejects({}, "test").catch(function(e) {
-            referee.assert.isError(e);
+    context("when promise argument rejects to value argument", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute
+                .rejects(Promise.reject("test"), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
         });
     });
 
-    it("should reject and fail if the input promise resolves", function() {
-        return referee.assert
-            .rejects(Promise.resolve(), "test")
-            .catch(function(e) {
+    context("when promise argument is not a promise", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute.rejects({}, "test").catch(function(e) {
                 referee.assert.isError(e);
             });
+        });
+    });
+
+    context("when promise argument does not reject", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute
+                .rejects(Promise.resolve(), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
+        });
     });
 });

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -1,9 +1,26 @@
 "use strict";
 
 var samsam = require("@sinonjs/samsam");
+var createAsyncAssertion = require("../create-async-assertion");
 
 module.exports = function(referee) {
+    function catchCallback() {
+        this.reject("${0} does not resolve, it rejects instead");
+    }
     referee.add("resolves", {
+        assert: createAsyncAssertion(function(actual, expected) {
+            if (!samsam.identical(actual, expected)) {
+                this.reject(referee.assert.resolves.message);
+            }
+            this.resolve();
+        }, catchCallback),
+        refute: createAsyncAssertion(function(actual, expected) {
+            if (samsam.identical(actual, expected)) {
+                this.reject(referee.refute.resolves.message);
+            }
+            this.resolve();
+        }, catchCallback),
+        /*
         assert: function(promise, expected) {
             this.expected = expected;
             var self = this;
@@ -56,6 +73,7 @@ module.exports = function(referee) {
                 self.fail(e);
             });
         },
+        */
         assertMessage: "${actual} is not identical to ${expected}",
         refuteMessage: "${actual} is identical to ${expected}"
     });

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -1,0 +1,62 @@
+"use strict";
+
+var samsam = require("@sinonjs/samsam");
+
+module.exports = function(referee) {
+    referee.add("resolves", {
+        assert: function(promise, expected) {
+            this.expected = expected;
+            var self = this;
+            return new Promise(function(resolve, reject) {
+                try {
+                    promise
+                        .then(function(actual) {
+                            self.actual = actual;
+                            if (!samsam.identical(actual, expected)) {
+                                reject(
+                                    "${actual} is not identical to ${expected}"
+                                );
+                            }
+                            resolve();
+                        })
+                        .catch(function() {
+                            reject(
+                                "Promise does not resolve it rejects instead"
+                            );
+                        });
+                } catch (e) {
+                    reject(e);
+                }
+            }).catch(function(e) {
+                self.fail(e);
+            });
+        },
+        refute: function(promise, expected) {
+            this.expected = expected;
+            var self = this;
+            return new Promise(function(resolve, reject) {
+                try {
+                    promise
+                        .then(function(actual) {
+                            self.actual = actual;
+                            if (samsam.identical(actual, expected)) {
+                                reject("${actual} is identical to ${expected}");
+                            }
+                            resolve();
+                        })
+                        .catch(function() {
+                            reject(
+                                "Promise does not resolve it rejects instead"
+                            );
+                        });
+                } catch (e) {
+                    reject(e);
+                }
+            }).catch(function(e) {
+                self.fail(e);
+            });
+        },
+        assertMessage: "${actual} is not identical to ${expected}",
+        refuteMessage: "${actual} is identical to ${expected}"
+    });
+};

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -3,78 +3,29 @@
 var samsam = require("@sinonjs/samsam");
 var createAsyncAssertion = require("../create-async-assertion");
 
+var assertMessage = "${actual} is not identical to ${expected}";
+var refuteMessage = "${actual} is identical to ${expected}";
+
 module.exports = function(referee) {
     function catchCallback() {
-        this.reject("${0} does not resolve, it rejects instead");
+        this.reject("${0} did not resolve, it rejected instead");
     }
     referee.add("resolves", {
         assert: createAsyncAssertion(function(actual, expected) {
             if (!samsam.identical(actual, expected)) {
-                this.reject(referee.assert.resolves.message);
+                this.reject(assertMessage);
+                return;
             }
             this.resolve();
         }, catchCallback),
         refute: createAsyncAssertion(function(actual, expected) {
             if (samsam.identical(actual, expected)) {
-                this.reject(referee.refute.resolves.message);
+                this.reject(refuteMessage);
+                return;
             }
             this.resolve();
         }, catchCallback),
-        /*
-        assert: function(promise, expected) {
-            this.expected = expected;
-            var self = this;
-            return new Promise(function(resolve, reject) {
-                try {
-                    promise
-                        .then(function(actual) {
-                            self.actual = actual;
-                            if (!samsam.identical(actual, expected)) {
-                                reject(
-                                    "${actual} is not identical to ${expected}"
-                                );
-                            }
-                            resolve();
-                        })
-                        .catch(function() {
-                            reject(
-                                "Promise does not resolve it rejects instead"
-                            );
-                        });
-                } catch (e) {
-                    reject(e);
-                }
-            }).catch(function(e) {
-                self.fail(e);
-            });
-        },
-        refute: function(promise, expected) {
-            this.expected = expected;
-            var self = this;
-            return new Promise(function(resolve, reject) {
-                try {
-                    promise
-                        .then(function(actual) {
-                            self.actual = actual;
-                            if (samsam.identical(actual, expected)) {
-                                reject("${actual} is identical to ${expected}");
-                            }
-                            resolve();
-                        })
-                        .catch(function() {
-                            reject(
-                                "Promise does not resolve it rejects instead"
-                            );
-                        });
-                } catch (e) {
-                    reject(e);
-                }
-            }).catch(function(e) {
-                self.fail(e);
-            });
-        },
-        */
-        assertMessage: "${actual} is not identical to ${expected}",
-        refuteMessage: "${actual} is identical to ${expected}"
+        assertMessage: assertMessage,
+        refuteMessage: refuteMessage
     });
 };

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -1,0 +1,59 @@
+"use strict";
+
+var referee = require("../referee");
+
+describe("assert.resolves", function() {
+    it("should resolve and pass when identical", function() {
+        return referee.assert.resolves(Promise.resolve("test"), "test");
+    });
+
+    it("should reject and fail when not identical", function() {
+        return referee.assert
+            .resolves(Promise.resolve("test"), "test2")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+
+    it("should reject and fail when input is not a promise", function() {
+        return referee.assert.resolves({}, "test").catch(function(e) {
+            referee.assert.isError(e);
+        });
+    });
+
+    it("should reject and fail if the input promise rejects", function() {
+        return referee.assert
+            .resolves(Promise.reject(), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+});
+
+describe("refute.resolves", function() {
+    it("should resolve and pass when not identical", function() {
+        return referee.refute.resolves(Promise.resolve("test"), "test2");
+    });
+
+    it("should reject and fail when identical", function() {
+        return referee.refute
+            .resolves(Promise.resolve("test"), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+
+    it("should reject and fail when input is not a promise", function() {
+        return referee.refute.resolves({}, "test").catch(function(e) {
+            referee.assert.isError(e);
+        });
+    });
+
+    it("should reject and fail if the input promise rejects", function() {
+        return referee.refute
+            .resolves(Promise.reject(), "test")
+            .catch(function(e) {
+                referee.assert.isError(e);
+            });
+    });
+});

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -3,57 +3,98 @@
 var referee = require("../referee");
 
 describe("assert.resolves", function() {
-    it("should resolve and pass when identical", function() {
-        return referee.assert.resolves(Promise.resolve("test"), "test");
+    it("should return a promise", function() {
+        var assertion = referee.assert.resolves(
+            Promise.resolve("test"),
+            "test"
+        );
+        referee.assert.isPromise(assertion);
     });
 
-    it("should reject and fail when not identical", function() {
-        return referee.assert
-            .resolves(Promise.resolve("test"), "test2")
-            .catch(function(e) {
-                referee.assert.isError(e);
-            });
-    });
-
-    it("should reject and fail when input is not a promise", function() {
-        return referee.assert.resolves({}, "test").catch(function(e) {
-            referee.assert.isError(e);
+    context("when promise argument resolves to value argument", function() {
+        it("should resolve the returned promise", function() {
+            return referee.assert.resolves(Promise.resolve("test"), "test");
         });
     });
 
-    it("should reject and fail if the input promise rejects", function() {
-        return referee.assert
-            .resolves(Promise.reject(), "test")
-            .catch(function(e) {
+    context(
+        "when promise argument does not resolves to value argument",
+        function() {
+            it("should reject the returned promise", function() {
+                return referee.assert
+                    .resolves(Promise.resolve("test"), "test2")
+                    .catch(function(e) {
+                        referee.assert.isError(e);
+                    });
+            });
+        }
+    );
+
+    context("when promise argument is not a promise", function() {
+        it("should reject the returned promise", function() {
+            return referee.assert.resolves({}, "test").catch(function(e) {
                 referee.assert.isError(e);
             });
+        });
+    });
+
+    context("when promise argument does not resolve", function() {
+        it("should reject the returned promise", function() {
+            return referee.assert
+                .resolves(Promise.reject(), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
+        });
     });
 });
 
 describe("refute.resolves", function() {
-    it("should resolve and pass when not identical", function() {
-        return referee.refute.resolves(Promise.resolve("test"), "test2");
+    it("should return a promise", function() {
+        var refutation = referee.refute.resolves(
+            Promise.resolve("test"),
+            "test"
+        );
+        referee.assert.isPromise(refutation);
     });
 
-    it("should reject and fail when identical", function() {
-        return referee.refute
-            .resolves(Promise.resolve("test"), "test")
-            .catch(function(e) {
-                referee.assert.isError(e);
+    context(
+        "when promise argument does not resolve to value argument",
+        function() {
+            it("should resolve the returned promise", function() {
+                return referee.refute.resolves(
+                    Promise.resolve("test"),
+                    "test2"
+                );
             });
-    });
+        }
+    );
 
-    it("should reject and fail when input is not a promise", function() {
-        return referee.refute.resolves({}, "test").catch(function(e) {
-            referee.assert.isError(e);
+    context("when promise argument resolves to value argument", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute
+                .resolves(Promise.resolve("test"), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
         });
     });
 
-    it("should reject and fail if the input promise rejects", function() {
-        return referee.refute
-            .resolves(Promise.reject(), "test")
-            .catch(function(e) {
+    context("when promise argument is not a promise", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute.resolves({}, "test").catch(function(e) {
                 referee.assert.isError(e);
             });
+        });
+    });
+
+    context("when promise argument does not resolve", function() {
+        it("should reject the returned promise", function() {
+            return referee.refute
+                .resolves(Promise.reject(), "test")
+                .catch(function(e) {
+                    referee.assert.isError(e);
+                });
+        });
     });
 });

--- a/lib/create-async-assertion.js
+++ b/lib/create-async-assertion.js
@@ -1,0 +1,33 @@
+"use strict";
+
+function createAsyncAssertion(thenFunc, catchFunc) {
+    function asyncAssertion(promise, expected) {
+        var self = this;
+        this.expected = expected;
+        function applyCallback(callback, context) {
+            return function(actual) {
+                self.actual = actual;
+                callback.apply(context, [actual, expected]);
+            };
+        }
+        var assertionPromise = new Promise(function(resolve, reject) {
+            try {
+                var context = { resolve: resolve, reject: reject };
+                promise.then(
+                    applyCallback(thenFunc, context),
+                    applyCallback(catchFunc, context)
+                );
+            } catch (error) {
+                reject(error.message);
+            }
+        }).catch(function(message) {
+            self.fail(message);
+        });
+
+        return assertionPromise;
+    }
+
+    return asyncAssertion;
+}
+
+module.exports = createAsyncAssertion;

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+var referee = require("./referee");
+var sinon = require("sinon");
+var createAsyncAssertion = require("./create-async-assertion");
+var noop = function() {};
+
+describe("createAsyncAssertion", function() {
+    it("should return a Function", function() {
+        var func = createAsyncAssertion(noop, noop);
+        referee.assert.isFunction(func);
+    });
+
+    it("should result in a promise", function() {
+        var func = createAsyncAssertion(noop, noop);
+        var promise = func.call({}, Promise.resolve(), "test");
+        referee.assert.isPromise(promise);
+    });
+
+    it("should fail when input is not a promise", function() {
+        var fail = sinon.spy();
+        var func = createAsyncAssertion(noop, noop);
+        var context = {
+            fail: fail
+        };
+        var promise = func.call(context, {}, "test");
+        return promise.then(function() {
+            referee.assert.isTrue(
+                fail.calledOnceWith("promise.then is not a function")
+            );
+        });
+    });
+
+    describe("applyCallback", function() {
+        var resolve = function() {
+            this.resolve();
+        };
+        var thenCallback = sinon.spy(resolve);
+        var catchCallback = sinon.spy(resolve);
+        var func = createAsyncAssertion(thenCallback, catchCallback);
+
+        beforeEach(function() {
+            thenCallback.resetHistory();
+            catchCallback.resetHistory();
+        });
+
+        it("should apply and call the given `thenCallback`", function() {
+            var promise = func.call({}, Promise.resolve("test"), "test");
+            return promise.then(function() {
+                referee.assert.isTrue(
+                    thenCallback.calledOnceWith("test", "test")
+                );
+                referee.refute.isTrue(catchCallback.called);
+            });
+        });
+
+        it("should apply and call the given `catchCallback`", function() {
+            var promise = func.call({}, Promise.reject("test"), "test");
+            return promise.then(function() {
+                referee.assert.isTrue(
+                    catchCallback.calledOnceWith("test", "test")
+                );
+                referee.refute.isTrue(thenCallback.called);
+            });
+        });
+    });
+});

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -60,7 +60,21 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
             }
         };
 
-        if (!func.apply(ctx, arguments) && !failed) {
+        var result = func.apply(ctx, arguments);
+
+        if (result instanceof Promise) {
+            // Here we need to return the promise in order to tell test
+            // runners that this is an asychronous assertion.
+            // eslint complains about the return statement, because it is
+            // not expected here, so let's ignore.
+            // https://eslint.org/docs/rules/consistent-return
+            /* eslint-disable-next-line consistent-return */
+            return result.then(function() {
+                referee.pass(["pass", fullName].concat(args));
+            });
+        }
+
+        if (!result && !failed) {
             // when a function returns false and hasn't already failed with a custom message,
             // fail with default message
             ctx.fail("message");
@@ -97,7 +111,7 @@ function defineAssertion(
             minArgs,
             messageValues
         );
-        assertion.apply(null, arguments);
+        return assertion.apply(null, arguments);
     };
 }
 

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -86,5 +86,7 @@ require("./assertions/same")(referee);
 require("./assertions/tag-name")(referee);
 require("./assertions/json")(referee);
 require("./assertions/match-json")(referee);
+require("./assertions/resolves")(referee);
+require("./assertions/rejects")(referee);
 
 module.exports = referee;


### PR DESCRIPTION
Copy of #44 because I accidentally closed with `git push --force` :man_facepalming:  

#### Purpose

This is a first attempt for #27 


#### Solution

Adds a `resolves` assertion to **referee**, that uses `samsam`'s `identical` method to check if a promise resolves to an expected value. The assertion returns a Promise which can be passed to the test runner to know that this is an async method.

* If both values are identical the returned Promise resolves.
* If both values are different the returned Promise rejects and fails.
* If the given Promise/async method does not resolve, the returned Promise will reject.
* If the given input is not a Promise/async method the, the returned Promise will reject

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
- [ ] Write sufficient tests
- [x] Add documentation