### PR TITLE
Add .verify() and .resetCount()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,20 @@ cache:
   - node_modules
 
 before_install:
-  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm install coveralls; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x10" ]; then npm install coveralls; fi
 
 before_script:
   # Make npm run work for the script phase:
-  - if [ "x$TRAVIS_NODE_VERSION" != "x8" ]; then npm config set ignore-scripts false; fi
+  - if [ "x$TRAVIS_NODE_VERSION" != "x10" ]; then npm config set ignore-scripts false; fi
   # these build targets only need to run once per build, so let's conserve a few resources
   # ESLint only supports Node >=4
-  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run lint; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x10" ]; then npm run lint; fi
 
 script:
   - npm test
 
 after_success:
-  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm run test-coverage && cat ./coverage/lcov.info | coveralls lib; fi
+  - if [ "x$TRAVIS_NODE_VERSION" = "x10" ]; then npm run test-coverage && cat ./coverage/lcov.info | coveralls lib; fi
 
 git:
   depth: 10

--- a/docs/index.md
+++ b/docs/index.md
@@ -2010,13 +2010,50 @@ All arguments are available for interpolation into the resulting error message. 
     </dd>
 </dl>
 
+### `referee.resetCount()`
+
+Resets `referee.count` to 0.
+
+
+### `referee.verify([expected])`
+
+Verifies that assertions have been made by examining `referee.count`. When `expected` is passed, then this is compared with `referee.count`.
+
+`referee.verify()` always resets `referee.count` to zero, to reset the test environment between tests.
+
+```js
+it("should do something", function(){
+    var limit = 10;
+    for (var i = 0; i < 10; i++){
+        console.log(i);
+    }
+
+    // this test will fail as no assertions have been made
+    referee.verify();
+});
+
+
+it("should do something", function(){
+    var limit = 10;
+    for (var i = 0; i < 10; i++){
+        assert.isTrue(true);
+    }
+
+    // this will pass because exactly 10 (`limit`) assertions have been made
+    referee.verify(limit);
+
+    console.log(referee.count);
+    // 0
+});
+```
+
 ## Properties
 
 ### `referee.count`
 
 `Number` increasing from 0.
 
-`referee.count` is incremented anytime an assertion is called. The assertion counter can be reset to any number at your convenience.
+`referee.count` is incremented anytime an assertion is called. To reset the counter, use `referee.resetCount()`.
 
 ### `referee.throwOnFailure`
 

--- a/lib/assert.test.js
+++ b/lib/assert.test.js
@@ -15,7 +15,7 @@ describe("assert", function() {
     afterEach(function() {
         sinon.restore();
         delete referee.listeners;
-        referee.count = 0;
+        referee.resetCount();
         delete referee.throwOnFailure;
     });
 
@@ -102,7 +102,7 @@ describe("assert", function() {
     });
 
     it("updates assertion count", function() {
-        referee.count = 0;
+        referee.resetCount();
 
         try {
             referee.assert(true);

--- a/lib/count-assertion.js
+++ b/lib/count-assertion.js
@@ -1,5 +1,0 @@
-"use strict";
-
-module.exports = function countAssertion(referee) {
-    referee.count += 1;
-};

--- a/lib/create-add.js
+++ b/lib/create-add.js
@@ -51,7 +51,7 @@ function verifyArguments(name, options) {
     }
 }
 
-function createAdd(referee) {
+function createAdd(referee, countAssertion) {
     function add(name, options) {
         verifyArguments(name, options);
 
@@ -67,6 +67,7 @@ function createAdd(referee) {
 
         defineAssertion(
             referee,
+            countAssertion,
             "assert",
             name,
             options.assert,
@@ -75,6 +76,7 @@ function createAdd(referee) {
         );
         defineAssertion(
             referee,
+            countAssertion,
             "refute",
             name,
             options.refute,

--- a/lib/create-assert.js
+++ b/lib/create-assert.js
@@ -1,11 +1,10 @@
 "use strict";
 
 var assertArgNum = require("./assert-arg-num");
-var countAssertion = require("./count-assertion");
 
-function createAssert(referee) {
+function createAssert(referee, countAssertion) {
     function assert(actual, message) {
-        countAssertion(referee);
+        countAssertion();
         if (!assertArgNum(referee.fail, "assert", arguments, 1)) {
             return;
         }

--- a/lib/create-count-assertion.js
+++ b/lib/create-count-assertion.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function createCountAssertion(counts) {
+    function countAssertion() {
+        counts.asserts += 1;
+    }
+
+    return countAssertion;
+}
+
+module.exports = createCountAssertion;

--- a/lib/create-refute.js
+++ b/lib/create-refute.js
@@ -1,11 +1,10 @@
 "use strict";
 
 var assertArgNum = require("./assert-arg-num");
-var countAssertion = require("./count-assertion");
 
-function createRefute(referee) {
+function createRefute(referee, countAssertion) {
     function refute(actual, message) {
-        countAssertion(referee);
+        countAssertion();
         if (!assertArgNum(referee.fail, "refute", arguments, 1)) {
             return;
         }

--- a/lib/create-reset-count.js
+++ b/lib/create-reset-count.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function createResetCount(counts) {
+    function resetCount() {
+        counts.asserts = 0;
+    }
+
+    return resetCount;
+}
+
+module.exports = createResetCount;

--- a/lib/create-verify.js
+++ b/lib/create-verify.js
@@ -1,0 +1,35 @@
+"use strict";
+
+function createVerify(referee) {
+    function verify(expected) {
+        var count = referee.count;
+
+        referee.resetCount();
+
+        if (
+            typeof expected !== "undefined" &&
+            (typeof expected !== "number" || expected < 1)
+        ) {
+            throw new TypeError("expected argument must be a number >= 1");
+        }
+
+        if (expected && count !== expected) {
+            throw new Error(
+                "Expected assertion count to be " +
+                    expected +
+                    " but was " +
+                    count
+            );
+        }
+
+        if (count === 0) {
+            throw new Error(
+                "Expected assertion count to be at least 1, but was 0"
+            );
+        }
+    }
+
+    return verify;
+}
+
+module.exports = createVerify;

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -15,7 +15,7 @@ describe("custom assertions", function() {
     afterEach(function() {
         sinon.restore();
         delete referee.listeners;
-        referee.count = 0;
+        referee.resetCount();
         delete referee.throwOnFailure;
 
         delete referee.assert.custom;

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -3,7 +3,6 @@
 var slice = require("@sinonjs/commons").prototypes.array.slice;
 
 var assertArgNum = require("./assert-arg-num");
-var countAssertion = require("./count-assertion");
 var interpolatePosArg = require("./interpolate-pos-arg");
 var interpolateProperties = require("./interpolate-properties");
 
@@ -89,9 +88,17 @@ function createAssertion(
 // care of all the nitty-gritty of assertion functions: counting,
 // verifying parameter count, interpolating messages with actual
 // values and so on.
-function defineAssertion(referee, type, name, func, minArgs, messageValues) {
+function defineAssertion(
+    referee,
+    countAssertion,
+    type,
+    name,
+    func,
+    minArgs,
+    messageValues
+) {
     referee[type][name] = function() {
-        countAssertion(referee);
+        countAssertion();
         var assertion = createAssertion(
             referee,
             type,

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -16,7 +16,7 @@ describe("expect", function() {
     afterEach(function() {
         sinon.restore();
         delete referee.listeners;
-        referee.count = 0;
+        referee.resetCount();
         delete referee.throwOnFailure;
     });
 

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -1,16 +1,32 @@
 "use strict";
 
 var bane = require("bane");
+
 var referee = bane.createEventEmitter();
 
+var counts = {
+    asserts: 0
+};
+
+Object.defineProperty(referee, "count", {
+    get: function get() {
+        return counts.asserts;
+    },
+    enumerable: true
+});
+
+var countAssertion = require("./create-count-assertion")(counts);
+
 // construct the public API
-referee.count = 0;
-referee.add = require("./create-add")(referee);
-referee.assert = require("./create-assert")(referee);
-referee.refute = require("./create-refute")(referee);
+referee.add = require("./create-add")(referee, countAssertion);
+referee.assert = require("./create-assert")(referee, countAssertion);
+referee.refute = require("./create-refute")(referee, countAssertion);
 referee.expect = require("./create-expect")(referee);
 referee.fail = require("./create-fail")(referee);
 referee.pass = require("./create-pass")(referee);
+
+referee.resetCount = require("./create-reset-count")(counts);
+referee.verify = require("./create-verify")(referee);
 
 // add all all the built-in assertions to the API
 require("./assertions/defined")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -63,7 +63,9 @@ describe("API", function() {
             "once",
             "pass",
             "refute",
-            "supervisors"
+            "resetCount",
+            "supervisors",
+            "verify"
         ]);
         var actualProperties = JSON.stringify(Object.keys(referee).sort());
 

--- a/lib/reset-count.test.js
+++ b/lib/reset-count.test.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var assert = require("assert");
+var referee = require("./referee");
+
+describe("resetCount", function() {
+    it("should reset referee.count to zero", function() {
+        referee.assert(true);
+        assert.equal(referee.count, 1);
+
+        referee.resetCount();
+        assert.equal(referee.count, 0);
+    });
+});

--- a/lib/test-helper/index.js
+++ b/lib/test-helper/index.js
@@ -19,7 +19,7 @@ var testHelper = {
         delete testHelper.okListener;
         delete testHelper.failListener;
         delete referee.listeners;
-        referee.count = 0;
+        referee.resetCount();
         delete referee.throwOnFailure;
     },
 

--- a/lib/verify.test.js
+++ b/lib/verify.test.js
@@ -1,0 +1,118 @@
+"use strict";
+
+var assert = require("assert");
+var referee = require("./referee");
+
+describe("verify", function() {
+    beforeEach(function() {
+        referee.resetCount();
+    });
+
+    it("should set referee.count to zero", function() {
+        var numberOfAssertions = 100;
+
+        for (var i = 0; i < numberOfAssertions; i++) {
+            referee.assert(true);
+        }
+        assert.equal(referee.count, numberOfAssertions);
+
+        referee.verify(numberOfAssertions);
+
+        assert.equal(referee.count, 0);
+    });
+
+    context("when called with zero expected argument", function() {
+        it("should throw an error", function() {
+            var error;
+            try {
+                referee.verify(0);
+            } catch (err) {
+                error = err;
+            }
+
+            assert.equal(
+                error.message,
+                "expected argument must be a number >= 1"
+            );
+        });
+    });
+
+    context("when called with non-number expected argument", function() {
+        it("should throw an error", function() {
+            var error;
+            try {
+                referee.verify("12");
+            } catch (err) {
+                error = err;
+            }
+
+            assert.equal(
+                error.message,
+                "expected argument must be a number >= 1"
+            );
+        });
+    });
+
+    context("when no assertions have been made", function() {
+        it("should throw an Error", function() {
+            var error;
+            try {
+                referee.verify();
+            } catch (err) {
+                error = err;
+            }
+
+            assert.equal(
+                error.message,
+                "Expected assertion count to be at least 1, but was 0"
+            );
+        });
+    });
+
+    context("when called without an expected value", function() {
+        it("should not throw", function() {
+            for (var i = 0; i < 1000; i++) {
+                referee.assert(true);
+                referee.verify();
+            }
+        });
+    });
+
+    context("when called with an expected value", function() {
+        context("when expected === referee.count", function() {
+            it("should not throw", function() {
+                var limit = 1000;
+                for (var i = 0; i < limit; i++) {
+                    referee.assert(true);
+                }
+
+                referee.verify(limit);
+            });
+        });
+
+        context("when expected !== referee.count", function() {
+            it("should throw an error", function() {
+                var limit = 10;
+                var expectedCount = 2;
+                var expectedMessage =
+                    "Expected assertion count to be " +
+                    expectedCount +
+                    " but was " +
+                    limit;
+                var error;
+
+                for (var i = 0; i < limit; i++) {
+                    referee.assert(true);
+                }
+
+                try {
+                    referee.verify(expectedCount);
+                } catch (err) {
+                    error = err;
+                }
+
+                assert.equal(error.message, expectedMessage);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Ref discussion in #47

* Improve `referee.count` so that it can't be written to directly.
* Add `referee.verify()` which will verify that count is not zero, and optionally is expected value
* Add `referee.resetCount()`, which predictably resets the count to zero

#### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [ ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
- [ ] Write documentation
- [ ] Add tests
