### PR TITLE
Refactor define assertion

### DIFF
--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -16,8 +16,7 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
                 referee.fail,
                 fullName,
                 arguments,
-                minArgs || func.length,
-                referee.fail
+                minArgs || func.length
             )
         ) {
             return;

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -6,16 +6,7 @@ var assertArgNum = require("./assert-arg-num");
 var interpolatePosArg = require("./interpolate-pos-arg");
 var interpolateProperties = require("./interpolate-properties");
 
-function createAssertion(
-    referee,
-    type,
-    name,
-    func,
-    minArgs,
-    messageValues,
-    pass,
-    fail
-) {
+function createAssertion(referee, type, name, func, minArgs, messageValues) {
     var assertion = function() {
         var fullName = type + "." + name;
         var failed = false;
@@ -26,7 +17,7 @@ function createAssertion(
                 fullName,
                 arguments,
                 minArgs || func.length,
-                fail
+                referee.fail
             )
         ) {
             return;
@@ -65,7 +56,7 @@ function createAssertion(
                         errorProperties.expected = namedValues.expected;
                     }
                 }
-                fail("[" + operator + "] " + message, errorProperties);
+                referee.fail("[" + operator + "] " + message, errorProperties);
                 return false;
             }
         };
@@ -77,7 +68,7 @@ function createAssertion(
         }
 
         if (!failed) {
-            pass(["pass", fullName].concat(args));
+            referee.pass(["pass", fullName].concat(args));
         }
     };
 
@@ -105,9 +96,7 @@ function defineAssertion(
             name,
             func,
             minArgs,
-            messageValues,
-            referee.pass,
-            referee.fail
+            messageValues
         );
         assertion.apply(null, arguments);
     };


### PR DESCRIPTION
This PR tidies up `define-assertion.js` slightly by removing extraneous internal arguments and not passing `referee.fail` twice to `assertArgNum` (which would just use the equivalent of `var fail = referee.fail || referee.fail`).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).