### PR TITLE
Rewrite tests for isArrayBuffer

### DIFF
--- a/lib/assertions/is-array-buffer.test.js
+++ b/lib/assertions/is-array-buffer.test.js
@@ -1,38 +1,73 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isArrayBuffer", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    function captureArgs() {
-        return arguments;
-    }
+function captureArgs() {
+    return arguments;
+}
 
-    pass("for ArrayBuffer", new global.ArrayBuffer(8));
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isArrayBuffer] Nope: Expected {  } to be an ArrayBuffer",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isArrayBuffer"
-        },
-        {}
-    );
+describe("assert.isArrayBuffer", function() {
+    context("when called with an ArrayBuffer instance", function() {
+        it("should pass", function() {
+            referee.assert.isArrayBuffer(new global.ArrayBuffer(8));
+        });
+    });
+
+    context("when called with Array", function() {
+        it("should fail", function() {
+            var actual;
+            try {
+                referee.assert.isArrayBuffer([]);
+            } catch (error) {
+                actual = error;
+            }
+
+            assert.equal(actual.code, "ERR_ASSERTION");
+            assert.equal(
+                actual.message,
+                "[assert.isArrayBuffer] Expected [] to be an ArrayBuffer"
+            );
+            assert.equal(actual.name, "AssertionError");
+            assert.equal(actual.operator, "assert.isArrayBuffer");
+        });
+    });
+
+    context("when called with Object", function() {
+        it("should fail", function() {
+            var actual;
+            try {
+                referee.assert.isArrayBuffer({});
+            } catch (error) {
+                actual = error;
+            }
+
+            assert.equal(actual.code, "ERR_ASSERTION");
+            assert.equal(
+                actual.message,
+                "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+            );
+            assert.equal(actual.name, "AssertionError");
+            assert.equal(actual.operator, "assert.isArrayBuffer");
+        });
+    });
+
+    context("when called with arguments", function() {
+        it("should fail", function() {
+            var actual;
+            try {
+                referee.assert.isArrayBuffer(captureArgs());
+            } catch (error) {
+                actual = error;
+            }
+
+            assert.equal(actual.code, "ERR_ASSERTION");
+            assert.equal(
+                actual.message,
+                "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+            );
+            assert.equal(actual.name, "AssertionError");
+            assert.equal(actual.operator, "assert.isArrayBuffer");
+        });
+    });
 });


### PR DESCRIPTION
Use node's assert and plain Mocha

This is part of a bigger effort to remove `test-helper.js` and just have plain tests using Mocha, which will make `referee` a lot easier to contribute to.


#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
