### PR TITLE
Rewrite is-true tests to remove test-helper

### DIFF
--- a/lib/assertions/is-true.test.js
+++ b/lib/assertions/is-true.test.js
@@ -1,35 +1,79 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isTrue", function(pass, fail, msg, error) {
-    pass("for true", true);
-    fail("for false", false);
-    msg(
-        "represent expected value in message",
-        "[assert.isTrue] Expected {  } to be true",
-        {}
-    );
-    msg(
-        "include custom message",
-        "[assert.isTrue] Oh: Expected {  } to be true",
-        {},
-        "Oh"
-    );
-    fail("for object", {});
-    fail("for array", []);
-    fail("for string", "32");
-    fail("for number", 32);
-    msg(
-        "fail if not passed arguments",
-        "[assert.isTrue] Expected to receive at least 1 argument"
-    );
-    error(
-        "for false",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isTrue"
-        },
-        false
-    );
+describe("isTrue", function() {
+    it("should pass for true", function() {
+        referee.assert.isTrue(true);
+    });
+
+    it("should fail for false", function() {
+        var actual;
+        try {
+            referee.assert.isTrue(false);
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(actual.operator, "assert.isTrue");
+    });
+
+    it("should fail for object", function() {
+        var actual;
+        try {
+            referee.assert.isTrue({});
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(actual.operator, "assert.isTrue");
+    });
+
+    it("should fail for array", function() {
+        var actual;
+        try {
+            referee.assert.isTrue([]);
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(actual.operator, "assert.isTrue");
+    });
+
+    it("should fail for string", function() {
+        var actual;
+        try {
+            referee.assert.isTrue("32");
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(actual.operator, "assert.isTrue");
+    });
+
+    it("should fail for number", function() {
+        var actual;
+        try {
+            referee.assert.isTrue(32);
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(actual.operator, "assert.isTrue");
+    });
+
+    it("should fail if not passed arguments", function() {
+        var actual;
+        try {
+            referee.assert.isTrue();
+        } catch (err) {
+            actual = err;
+        }
+        assert.equal(actual.code, "ERR_ASSERTION");
+        assert.equal(
+            actual.message,
+            "[assert.isTrue] Expected to receive at least 1 argument"
+        );
+    });
 });


### PR DESCRIPTION
To lower the bar of entry and make the repo more accessible, I have removed test-helper from `is-true.js`