### PR TITLE
Remove test helper from tag name

### DIFF
--- a/lib/assertions/tag-name.test.js
+++ b/lib/assertions/tag-name.test.js
@@ -1,149 +1,82 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "tagName", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for matching tag names", { tagName: "li" }, "li");
-    pass("for case-insensitive matching tag names", { tagName: "LI" }, "li");
-    pass("for case-insensitive matching tag names #2", { tagName: "li" }, "LI");
-    pass("for uppercase matching tag names", { tagName: "LI" }, "LI");
-    fail("for non-matching tag names", { tagName: "li" }, "p");
-    fail("for substring matches in tag names", { tagName: "li" }, "i");
+describe("tagName", function() {
+    it("should pass for matching tag names", function() {
+        referee.assert.tagName({ tagName: "li" }, "li");
+    });
 
-    msg(
-        "fail with message",
-        "[assert.tagName] Expected tagName to be p but was li",
-        { tagName: "li" },
-        "p"
-    );
+    it("should pass for case-insensitive matching tag names", function() {
+        referee.assert.tagName({ tagName: "LI" }, "li");
+    });
 
-    msg(
-        "fail with custom message",
-        "[assert.tagName] Here: Expected tagName to be p but was li",
-        { tagName: "li" },
-        "p",
-        "Here"
-    );
-
-    msg(
-        "fail if not passed arguments",
-        "[assert.tagName] Expected to receive at least 2 arguments"
-    );
-
-    msg(
-        "fail if not passed tag name",
-        "[assert.tagName] Expected to receive at least 2 arguments",
-        { tagName: "" }
-    );
-
-    msg(
-        "fail if object does not have tagName property",
-        "[assert.tagName] Expected {  } to have tagName property",
-        {},
-        "li"
-    );
-
-    msg(
-        "fail with custom message if object does not have tagName property",
-        "[assert.tagName] Yikes! Expected {  } to have tagName property",
-        {},
-        "li",
-        "Yikes!"
-    );
+    it("should pass for case-insensitive matching tag names #2", function() {
+        referee.assert.tagName({ tagName: "li" }, "LI");
+    });
 
     if (typeof document !== "undefined") {
-        pass("for DOM elements", document.createElement("li"), "li");
+        it("should pass for DOM elements", function() {
+            referee.assert.tagName(document.createElement("li"), "li");
+        });
     }
 
-    error(
-        "for non-matching tag names",
-        {
-            code: "ERR_ASSERTION",
-            actual: "li",
-            expected: "p",
-            operator: "assert.tagName"
-        },
-        { tagName: "li" },
-        "p"
-    );
-});
+    it("should pass for uppercase matching tag names", function() {
+        referee.assert.tagName({ tagName: "LI" }, "LI");
+    });
 
-testHelper.assertionTests("refute", "tagName", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for matching tag names", { tagName: "li" }, "li");
-    fail("for case-insensitive matching tag names", { tagName: "LI" }, "li");
-    fail("for case-insensitive matching tag names #2", { tagName: "LI" }, "li");
-    fail("for same casing matching tag names", { tagName: "li" }, "li");
-    pass("for non-matching tag names", { tagName: "li" }, "p");
-    pass("for substring matching tag names", { tagName: "li" }, "i");
-    pass("for case-insensitive non-matching tag names", { tagName: "li" }, "P");
-    pass(
-        "for case-insensitive substring mathcing tag names",
-        { tagName: "li" },
-        "i"
-    );
+    it("should fail if no tag name is passed", function() {
+        assert.throws(
+            function() {
+                referee.assert.tagName({}, "LI");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.tagName] Expected {  } to have tagName property"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.tagName");
+                return true;
+            }
+        );
+    });
 
-    msg(
-        "fail with message",
-        "[refute.tagName] Expected tagName not to be li",
-        { tagName: "li" },
-        "li"
-    );
+    it("should fail for non-matching tag names", function() {
+        assert.throws(
+            function() {
+                referee.assert.tagName({ tagName: "li" }, "p");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.tagName] Expected tagName to be p but was li"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.tagName");
+                return true;
+            }
+        );
+    });
 
-    msg(
-        "fail with custom message",
-        "[refute.tagName] Oh well: Expected tagName not to be li",
-        { tagName: "li" },
-        "li",
-        "Oh well"
-    );
-
-    msg(
-        "fail if not passed arguments",
-        "[refute.tagName] Expected to receive at least 2 arguments"
-    );
-
-    msg(
-        "fail if not passed tag name",
-        "[refute.tagName] Expected to receive at least 2 arguments",
-        { tagName: "p" }
-    );
-
-    msg(
-        "fail if object does not have tagName property",
-        "[refute.tagName] Expected {  } to have tagName property",
-        {},
-        "li"
-    );
-
-    msg(
-        "fail with custom message if object does not have tagName property",
-        "[refute.tagName] Yes: Expected {  } to have tagName property",
-        {},
-        "li",
-        "Yes"
-    );
-
-    if (typeof document !== "undefined") {
-        pass("for DOM elements", document.createElement("li"), "p");
-    }
-
-    error(
-        "for matching tag names",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.tagName"
-        },
-        { tagName: "li" },
-        "li"
-    );
+    it("should fail for substring matches in tag names", function() {
+        assert.throws(
+            function() {
+                referee.assert.tagName({ tagName: "li" }, "i");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.tagName] Expected tagName to be i but was li"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.tagName");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
Remove test helper from tag name file

Also I have removed the refute tests, as doing the test then the same with a refute feels a bit pointless, I don't feel it would improve coverage but I am open to be told otherwise, I did some searching on the web to see if there is a reason to follow such a pattern. 
