### PR TITLE
Add refute tests for isArrayBuffer

### DIFF
--- a/lib/assertions/is-array-buffer.test.js
+++ b/lib/assertions/is-array-buffer.test.js
@@ -71,3 +71,42 @@ describe("assert.isArrayBuffer", function() {
         });
     });
 });
+
+describe("refute.isArrayBuffer", function() {
+    context("when called with an ArrayBuffer instance", function() {
+        it("should fail", function() {
+            var actual;
+            try {
+                referee.refute.isArrayBuffer(new global.ArrayBuffer(8));
+            } catch (error) {
+                actual = error;
+            }
+
+            assert.equal(actual.code, "ERR_ASSERTION");
+            assert.equal(
+                actual.message,
+                "[refute.isArrayBuffer] Expected [ArrayBuffer] {  } not to be an ArrayBuffer"
+            );
+            assert.equal(actual.name, "AssertionError");
+            assert.equal(actual.operator, "refute.isArrayBuffer");
+        });
+    });
+
+    context("when called with Array", function() {
+        it("should pass", function() {
+            referee.refute.isArrayBuffer([]);
+        });
+    });
+
+    context("when called with Object", function() {
+        it("should pass", function() {
+            referee.refute.isArrayBuffer({});
+        });
+    });
+
+    context("when called with arguments", function() {
+        it("should pass", function() {
+            referee.refute.isArrayBuffer(captureArgs());
+        });
+    });
+});


### PR DESCRIPTION
This PR improves test coverage by adding tests for `refute.isArrayBuffer`, which I could have added in #55, or when I originally added `isArrayBuffer`

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
