### PR TITLE
Rewrite tests for isArrayLike

### DIFF
--- a/lib/assertions/is-array-like.test.js
+++ b/lib/assertions/is-array-like.test.js
@@ -1,91 +1,126 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isArrayLike", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    function captureArgs() {
-        return arguments;
-    }
+function captureArgs() {
+    return arguments;
+}
 
-    var arrayLike = {
-        length: 4,
-        "0": "One",
-        "1": "Two",
-        "2": "Three",
-        "3": "Four",
-        splice: function() {}
-    };
+var arrayLike = {
+    length: 4,
+    "0": "One",
+    "1": "Two",
+    "2": "Three",
+    "3": "Four",
+    splice: function() {}
+};
 
-    pass("for array", []);
-    fail("for object", {});
-    pass("for arguments", captureArgs());
-    pass("for array like", arrayLike);
-    msg(
-        "fail with descriptive message",
-        "[assert.isArrayLike] Expected {  } to be array like",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isArrayLike] Here! Expected {  } to be array like",
-        {},
-        "Here!"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isArrayLike"
-        },
-        {}
-    );
+describe("assert.isArrayLike", function() {
+    it("should pass for array", function() {
+        referee.assert.isArrayLike([]);
+    });
+
+    it("should pass for arguments", function() {
+        referee.assert.isArrayLike(captureArgs());
+    });
+
+    it("should pass for array like", function() {
+        referee.assert.isArrayLike(arrayLike);
+    });
+
+    it("should fail for object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isArrayLike({});
+            },
+            {
+                code: "ERR_ASSERTION",
+                message: "[assert.isArrayLike] Expected {  } to be array like",
+                name: "AssertionError",
+                operator: "assert.isArrayLike"
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        assert.throws(
+            function() {
+                referee.assert.isArrayLike({}, "Here!");
+            },
+            {
+                code: "ERR_ASSERTION",
+                message:
+                    "[assert.isArrayLike] Here! Expected {  } to be array like",
+                name: "AssertionError",
+                operator: "assert.isArrayLike"
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isArrayLike", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    function captureArgs() {
-        return arguments;
-    }
+describe("refute.isArrayLike", function() {
+    it("should fail for array", function() {
+        assert.throws(
+            function() {
+                referee.refute.isArrayLike([]);
+            },
+            {
+                code: "ERR_ASSERTION",
+                message:
+                    "[refute.isArrayLike] Expected [] not to be array like",
+                name: "AssertionError",
+                operator: "refute.isArrayLike"
+            }
+        );
+    });
 
-    var arrayLike = {
-        length: 4,
-        "0": "One",
-        "1": "Two",
-        "2": "Three",
-        "3": "Four",
-        splice: function() {}
-    };
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.refute.isArrayLike(captureArgs());
+            },
+            {
+                code: "ERR_ASSERTION",
+                message:
+                    "[refute.isArrayLike] Expected {  } not to be array like",
+                name: "AssertionError",
+                operator: "refute.isArrayLike"
+            }
+        );
+    });
 
-    fail("for array", []);
-    pass("for object", {});
-    fail("for arguments", captureArgs());
-    fail("for array like", arrayLike);
-    msg(
-        "fail with descriptive message",
-        "[refute.isArrayLike] Expected [1, 2] not to be array like",
-        [1, 2]
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isArrayLike] Hey: Expected [1, 2] not to be array like",
-        [1, 2],
-        "Hey"
-    );
-    error(
-        "for array like",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isArrayLike"
-        },
-        arrayLike
-    );
+    it("should fail for array like", function() {
+        assert.throws(
+            function() {
+                referee.refute.isArrayLike(arrayLike);
+            },
+            {
+                code: "ERR_ASSERTION",
+                message:
+                    '[refute.isArrayLike] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like',
+                name: "AssertionError",
+                operator: "refute.isArrayLike"
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        assert.throws(
+            function() {
+                referee.refute.isArrayLike(arrayLike, "apple pie");
+            },
+            {
+                code: "ERR_ASSERTION",
+                message:
+                    '[refute.isArrayLike] apple pie: Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like',
+                name: "AssertionError",
+                operator: "refute.isArrayLike"
+            }
+        );
+    });
+
+    it("should pass for object", function() {
+        referee.refute.isArrayLike({});
+    });
 });


### PR DESCRIPTION
This is part of a larger effort of converting tests to be plain Mocha tests, which will make it easier for people to do casual contributions to this library.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
