### PR TITLE
Rewrite tests for isArray

### DIFF
--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 var obj = { id: 42 };
 
@@ -126,22 +127,19 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
     fail("when comparing 'empty' object to number object", {}, new Number());
     fail("when comparing 'empty' object to empty array", {}, []);
 
-    function gather() {
-        return arguments;
-    }
     var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
 
     pass(
         "when comparing arguments to array",
         [1, 2, {}, []],
-        gather(1, 2, {}, [])
+        captureArgs(1, 2, {}, [])
     );
-    pass("when comparing array to arguments", gather(), []);
+    pass("when comparing array to arguments", captureArgs(), []);
 
     pass(
         "when comparing arguments to array like object",
         arrayLike,
-        gather(1, 2, {}, [])
+        captureArgs(1, 2, {}, [])
     );
 
     msg(
@@ -308,21 +306,18 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
     pass("when comparing 'empty' object to empty array", {}, []);
     pass("when comparing multi-line strings", "Hey\nHo", "Yo\nNo");
 
-    function gather() {
-        return arguments;
-    }
     var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
 
     fail(
         "when comparing arguments to array",
         [1, 2, {}, []],
-        gather(1, 2, {}, [])
+        captureArgs(1, 2, {}, [])
     );
-    fail("when comparing array to arguments", gather(), []);
+    fail("when comparing array to arguments", captureArgs(), []);
     fail(
         "when comparing arguments to array like object",
         arrayLike,
-        gather(1, 2, {}, [])
+        captureArgs(1, 2, {}, [])
     );
 
     msg(

--- a/lib/assertions/is-array-buffer.test.js
+++ b/lib/assertions/is-array-buffer.test.js
@@ -2,10 +2,7 @@
 
 var assert = require("assert");
 var referee = require("../referee");
-
-function captureArgs() {
-    return arguments;
-}
+var captureArgs = require("../test-helper/capture-args");
 
 describe("assert.isArrayBuffer", function() {
     context("when called with an ArrayBuffer instance", function() {

--- a/lib/assertions/is-array-like.test.js
+++ b/lib/assertions/is-array-like.test.js
@@ -3,15 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
-
-var arrayLike = {
-    length: 4,
-    "0": "One",
-    "1": "Two",
-    "2": "Three",
-    "3": "Four",
-    splice: function() {}
-};
+var getArrayLike = require("../test-helper/get-array-like");
 
 describe("assert.isArrayLike", function() {
     it("should pass for array", function() {
@@ -23,7 +15,7 @@ describe("assert.isArrayLike", function() {
     });
 
     it("should pass for array like", function() {
-        referee.assert.isArrayLike(arrayLike);
+        referee.assert.isArrayLike(getArrayLike());
     });
 
     it("should fail for object", function() {
@@ -106,7 +98,7 @@ describe("refute.isArrayLike", function() {
     it("should fail for array like", function() {
         assert.throws(
             function() {
-                referee.refute.isArrayLike(arrayLike);
+                referee.refute.isArrayLike(getArrayLike());
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
@@ -125,7 +117,7 @@ describe("refute.isArrayLike", function() {
     it("should fail with custom message", function() {
         assert.throws(
             function() {
-                referee.refute.isArrayLike(arrayLike, "apple pie");
+                referee.refute.isArrayLike(getArrayLike(), "apple pie");
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");

--- a/lib/assertions/is-array-like.test.js
+++ b/lib/assertions/is-array-like.test.js
@@ -2,10 +2,7 @@
 
 var assert = require("assert");
 var referee = require("../referee");
-
-function captureArgs() {
-    return arguments;
-}
+var captureArgs = require("../test-helper/capture-args");
 
 var arrayLike = {
     length: 4,

--- a/lib/assertions/is-array.test.js
+++ b/lib/assertions/is-array.test.js
@@ -1,91 +1,141 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
+var captureArgs = require("../test-helper/capture-args");
+var getArrayLike = require("../test-helper/get-array-like");
 
-testHelper.assertionTests("assert", "isArray", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    function captureArgs() {
-        return arguments;
-    }
+describe("assert.isArray", function() {
+    it("should pass for Array", function() {
+        referee.assert.isArray([]);
+    });
 
-    var arrayLike = {
-        length: 4,
-        "0": "One",
-        "1": "Two",
-        "2": "Three",
-        "3": "Four",
-        splice: function() {}
-    };
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isArray({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isArray] Expected {  } to be array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isArray");
+                return true;
+            }
+        );
+    });
 
-    pass("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    fail("for array like", arrayLike);
-    msg(
-        "fail with descriptive message",
-        "[assert.isArray] Expected {  } to be array",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isArray] Nope: Expected {  } to be array",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isArray"
-        },
-        {}
-    );
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isArray(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isArray] Expected {  } to be array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isArray");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for array like", function() {
+        assert.throws(
+            function() {
+                referee.assert.isArray(getArrayLike());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    '[assert.isArray] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } to be array'
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isArray");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "c7d5eb79-f8a4-4980-893a-50549bb6ee5e";
+
+        assert.throws(
+            function() {
+                referee.assert.isArray({}, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isArray] " +
+                        message +
+                        ": Expected {  } to be array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isArray");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isArray", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    function captureArgs() {
-        return arguments;
-    }
+describe("refute.isArray", function() {
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.refute.isArray([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isArray] Expected [] not to be array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isArray");
+                return true;
+            }
+        );
+    });
 
-    var arrayLike = {
-        length: 4,
-        "0": "One",
-        "1": "Two",
-        "2": "Three",
-        "3": "Four",
-        splice: function() {}
-    };
+    it("should pass for Object", function() {
+        referee.refute.isArray({});
+    });
 
-    fail("for array", []);
-    pass("for object", {});
-    pass("for arguments", captureArgs());
-    pass("for array like", arrayLike);
-    msg(
-        "fail with descriptive message",
-        "[refute.isArray] Expected [1, 2] not to be array",
-        [1, 2]
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isArray] Hmm: Expected [1, 2] not to be array",
-        [1, 2],
-        "Hmm"
-    );
-    error(
-        "for array",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isArray"
-        },
-        []
-    );
+    it("should pass for arguments", function() {
+        referee.refute.isArray(captureArgs());
+    });
+
+    it("should pass for array like", function() {
+        referee.refute.isArray(getArrayLike());
+    });
+
+    it("should fail with custome message", function() {
+        var message = "12c6cbf6-0ff7-4afe-815b-a40380635a89";
+        assert.throws(
+            function() {
+                referee.refute.isArray([], message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isArray] " +
+                        message +
+                        ": Expected [] not to be array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isArray");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-data-view.test.js
+++ b/lib/assertions/is-data-view.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isDataView", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isDataView", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     var ab = new global.ArrayBuffer(8);
     var dv = new global.DataView(ab);
 

--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -1,12 +1,9 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isDate", function(pass, fail, msg, error) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Date", new Date());
     fail("for RegExp", new RegExp("[a-z]"));
     fail("for string", "123");

--- a/lib/assertions/is-error.test.js
+++ b/lib/assertions/is-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Error", new Error("error"));
     pass("for EvalError", new EvalError("eval error"));
     pass("for RangeError", new RangeError("range error"));

--- a/lib/assertions/is-eval-error.test.js
+++ b/lib/assertions/is-eval-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isEvalError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isEvalError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("error"));
     pass("for EvalError", new EvalError("eval error"));
     fail("for RangeError", new RangeError("range error"));

--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isFloat32Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isFloat32Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Float32Array", new Float32Array(2));
     fail("for Float64Array", new Float64Array(2));
     fail("for array", []);

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isFloat64Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isFloat64Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Float32Array", new Float32Array(2));
     pass("for Float64Array", new Float64Array(2));
     fail("for array", []);

--- a/lib/assertions/is-infinity.test.js
+++ b/lib/assertions/is-infinity.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isInfinity", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isInfinity", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Infinity", Infinity);
     fail("for NaN", NaN);
     fail("for array", []);

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isInt16Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isInt16Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Int8Array", new Int8Array(2));
     pass("for Int16Array", new Int16Array(2));
     fail("for Int32Array", new Int32Array(2));

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isInt32Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isInt32Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Int8Array", new Int8Array(2));
     fail("for Int16Array", new Int16Array(2));
     pass("for Int32Array", new Int32Array(2));

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isInt8Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isInt8Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Int8Array", new Int8Array(2));
     fail("for Int16Array", new Int16Array(2));
     fail("for Int32Array", new Int32Array(2));

--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isIntlCollator", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isIntlCollator", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Intl.Collator", new Intl.Collator());
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Intl.DateTimeFormat", new Intl.DateTimeFormat());
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isIntlNumberFormat", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isIntlNumberFormat", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Intl.NumberFormat", new Intl.NumberFormat());
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -1,12 +1,9 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isMap", function(pass, fail, msg, error) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Map", new Map());
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isPromise", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isPromise", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Promise", Promise.resolve("apple pie"));
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-range-error.test.js
+++ b/lib/assertions/is-range-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isRangeError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isRangeError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("not pie"));
     pass("for RangeError", new RangeError("apple pie"));
     fail("for string", "apple pie");

--- a/lib/assertions/is-reference-error.test.js
+++ b/lib/assertions/is-reference-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isReferenceError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isReferenceError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("not pie"));
     pass("for ReferenceError", new ReferenceError("apple pie"));
     fail("for string", "apple pie");

--- a/lib/assertions/is-reg-exp.test.js
+++ b/lib/assertions/is-reg-exp.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isRegExp", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isRegExp", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for RegExp", new RegExp("apple pie"));
     pass("for RegExp literal", /apple pie/);
     fail("for string", "apple pie");

--- a/lib/assertions/is-set.test.js
+++ b/lib/assertions/is-set.test.js
@@ -1,12 +1,9 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isSet", function(pass, fail, msg, error) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Set", new Set());
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-symbol.test.js
+++ b/lib/assertions/is-symbol.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isSymbol", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isSymbol", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Symbol", Symbol("apple pie"));
     fail("for string", "apple pie");
     fail("for array", []);

--- a/lib/assertions/is-syntax-error.test.js
+++ b/lib/assertions/is-syntax-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isSyntaxError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isSyntaxError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("not pie"));
     pass("for SyntaxError", new SyntaxError("apple pie"));
     fail("for string", "apple pie");

--- a/lib/assertions/is-type-error.test.js
+++ b/lib/assertions/is-type-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isTypeError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isTypeError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("not pie"));
     pass("for TypeError", new TypeError("apple pie"));
     fail("for string", "apple pie");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isUint16Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isUint16Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     pass("for Uint16Array", new Uint16Array());
     fail("for Uint32Array", new Uint32Array());
     fail("for Uint8Array", new Uint8Array());

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isUint32Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isUint32Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Uint16Array", new Uint16Array());
     pass("for Uint32Array", new Uint32Array());
     fail("for Uint8Array", new Uint8Array());

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isUint8Array", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isUint8Array", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Uint16Array", new Uint16Array());
     fail("for Uint32Array", new Uint32Array());
     pass("for Uint8Array", new Uint8Array());

--- a/lib/assertions/is-u-int-8-clamped-array.test.js
+++ b/lib/assertions/is-u-int-8-clamped-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isUint8ClampedArray", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isUint8ClampedArray", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Uint8Array", new Uint8Array());
     pass("for Uint8ClampedArray", new Uint8ClampedArray());
     fail("for array", []);

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isURIError", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isURIError", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     fail("for Error", new Error("not pie"));
     pass("for URIError", new URIError("apple pie"));
     fail("for string", "apple pie");

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isWeakMap", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isWeakMap", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     // eslint-disable-next-line ie11/no-weak-collections
     pass("for WeakMap", new WeakMap());
     fail("for Map", new Map());

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var testHelper = require("../test-helper");
+var captureArgs = require("../test-helper/capture-args");
 
 testHelper.assertionTests("assert", "isWeakSet", function(
     pass,
@@ -8,10 +9,6 @@ testHelper.assertionTests("assert", "isWeakSet", function(
     msg,
     error
 ) {
-    function captureArgs() {
-        return arguments;
-    }
-
     // eslint-disable-next-line ie11/no-weak-collections
     pass("for WeakSet", new WeakSet());
     fail("for Set", new Set());

--- a/lib/test-helper/capture-args.js
+++ b/lib/test-helper/capture-args.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function captureArgs() {
+    return arguments;
+};

--- a/lib/test-helper/get-array-like.js
+++ b/lib/test-helper/get-array-like.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function getArrayLike() {
+    return {
+        length: 4,
+        "0": "One",
+        "1": "Two",
+        "2": "Three",
+        "3": "Four",
+        splice: function() {}
+    };
+};


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
