### PR TITLE
Rewrite tests for isBoolean

### DIFF
--- a/lib/assertions/is-boolean.test.js
+++ b/lib/assertions/is-boolean.test.js
@@ -1,65 +1,122 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isBoolean", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for boolean", true);
-    fail("for function", function() {});
-    fail("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[assert.isBoolean] Expected Hey (string) to be boolean",
-        "Hey"
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isBoolean] Boolean, plz: Expected Hey (string) to be boolean",
-        "Hey",
-        "Boolean, plz"
-    );
-    error(
-        "for string",
-        {
-            code: "ERR_ASSERTION",
-            actual: "string",
-            expected: "boolean",
-            operator: "assert.isBoolean"
-        },
-        "Hey"
-    );
+function noop() {
+    return undefined;
+}
+
+describe("assert.isBoolean", function() {
+    it("should pass for Boolean", function() {
+        referee.assert.isBoolean(true);
+        referee.assert.isBoolean(false);
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isBoolean(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isBoolean] Expected function noop() {} (function) to be boolean"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isBoolean");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.assert.isBoolean(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isBoolean] Expected null (object) to be boolean"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isBoolean");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "48ddd3d5-e636-492e-9bed-26fe11ccc15f";
+
+        assert.throws(
+            function() {
+                referee.assert.isBoolean("hello", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isBoolean] " +
+                        message +
+                        ": Expected hello (string) to be boolean"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isBoolean");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isBoolean", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for boolean", true);
-    pass("for function", function() {});
-    pass("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[refute.isBoolean] Expected true not to be boolean",
-        true
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isBoolean] Here: Expected true not to be boolean",
-        true,
-        "Here"
-    );
-    error(
-        "for boolean",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isBoolean"
-        },
-        false
-    );
+describe("refute.isBoolean", function() {
+    it("should fail for Boolean", function() {
+        assert.throws(
+            function() {
+                referee.refute.isBoolean(true);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isBoolean] Expected true not to be boolean"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isBoolean");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Function", function() {
+        referee.refute.isBoolean(noop);
+    });
+
+    it("should pass for null", function() {
+        referee.refute.isBoolean(null);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "1dfcdf31-53d8-4aa9-a889-d72fface2710";
+        assert.throws(
+            function() {
+                referee.refute.isBoolean(true, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isBoolean] " +
+                        message +
+                        ": Expected true not to be boolean"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isBoolean");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

This is branched from #62, which should be merged first

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
