### PR TITLE
Use dot reporter and fix misconfigured test

### DIFF
--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -53,9 +53,11 @@ describe("refute.resolves", function() {
     it("should return a promise", function() {
         var refutation = referee.refute.resolves(
             Promise.resolve("test"),
-            "test"
+            "test2"
         );
         referee.assert.isPromise(refutation);
+
+        return refutation;
     });
 
     context(

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "precommit": "lint-staged",
     "prepublishOnly": "npm run build && mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
-    "test": "mocha 'lib/**/*.test.js'",
+    "test": "mocha --reporter dot 'lib/**/*.test.js'",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test",
     "demo": "mocha demo/*.test.js"
   },


### PR DESCRIPTION
This PR changes the default reporter to be "dot", which makes it easier to spot when there is unexpected output, like misconfigured tests. Also, fix the misconfigured test.

#### How to observe problem

1. `git checkout 248110a4ec470f83859bd03c94b6f6c362e0ab59` (current `master`)
1. `npm ci`
1. `npm test | grep "UnhandledPromiseRejectionWarning"`
1. Observe that there's output like the example below

```text
(node:20945) UnhandledPromiseRejectionWarning: AssertionError: [refute.resolves] test is identical to test
    at Object.fail (/Users/morgan/code/sinonjs/referee/lib/create-fail.js:5:25)
    at Object.fail (/Users/morgan/code/sinonjs/referee/lib/define-assertion.js:58:25)
    at /Users/morgan/code/sinonjs/referee/lib/create-async-assertion.js:24:18
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:20945) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 11)
(node:20945) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`
1. Observe that there are only dots in the output, and no `UnhandledPromiseRejectionWarning`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).