### PR TITLE
Rewrite isDataView test

### DIFF
--- a/lib/assertions/is-data-view.test.js
+++ b/lib/assertions/is-data-view.test.js
@@ -1,39 +1,167 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isDataView", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
+function getDataView() {
     var ab = new global.ArrayBuffer(8);
     var dv = new global.DataView(ab);
 
-    pass("for DataView", dv);
-    fail("for ArrayBuffer", ab);
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isDataView] Expected {  } to be a DataView",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isDataView] Nope: Expected {  } to be a DataView",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isDataView"
-        },
-        {}
-    );
+    return dv;
+}
+
+describe("assert.isDataView", function() {
+    it("should pass for DataView", function() {
+        referee.assert.isDataView(getDataView());
+    });
+
+    it("should fail for ArrayBuffer", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDataView(new global.ArrayBuffer(8));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDataView] Expected [ArrayBuffer] {  } to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDataView");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDataView([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDataView] Expected [] to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDataView");
+                return true;
+            }
+        );
+    });
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDataView({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDataView] Expected {  } to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDataView");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDataView(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDataView] Expected {  } to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDataView");
+                return true;
+            }
+        );
+    });
+    it("should fail with custom message", function() {
+        var message = "c7472468-b79e-4d4a-afc4-593aef562521";
+
+        assert.throws(
+            function() {
+                referee.assert.isDataView([], message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDataView] " +
+                        message +
+                        ": Expected [] to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDataView");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isDataView", function() {
+    it("should fail for DataView", function() {
+        assert.throws(
+            function() {
+                referee.refute.isDataView(getDataView());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isDataView] Expected [DataView] {  } not to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isDataView");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for ArrayBuffer", function() {
+        referee.refute.isDataView(new global.ArrayBuffer(8));
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isDataView([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isDataView({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isDataView(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "ce1d6d74-060d-4655-b008-00b6cdfe1298";
+        assert.throws(
+            function() {
+                referee.refute.isDataView(getDataView(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isDataView] " +
+                        message +
+                        ": Expected [DataView] {  } not to be a DataView"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isDataView");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
