### PR TITLE
Rewrite tests for isDate

### DIFF
--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -1,32 +1,188 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isDate", function(pass, fail, msg, error) {
-    pass("for Date", new Date());
-    fail("for RegExp", new RegExp("[a-z]"));
-    fail("for string", "123");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isDate] Expected {  } to be a Date",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isDate] Nope: Expected {  } to be a Date",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isDate"
-        },
-        {}
-    );
+describe("assert.isDate", function() {
+    it("should pass for Date", function() {
+        referee.assert.isDate(new Date("[a-z]"));
+    });
+
+    it("should fail for RegExp", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDate(new RegExp("[a-z]"));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] Expected /[a-z]/ to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDate("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] Expected apple pie to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDate([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] Expected [] to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDate({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] Expected {  } to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isDate(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] Expected {  } to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "9d0346ee-490c-4bad-ad69-b925d75f5860";
+
+        assert.throws(
+            function() {
+                referee.assert.isDate({}, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isDate] " +
+                        message +
+                        ": Expected {  } to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isDate");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isDate", function() {
+    it("should fail for Date", function() {
+        assert.throws(
+            function() {
+                referee.refute.isDate(new Date(Date.UTC(0, 0, 0, 0, 0, 0)));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isDate] Expected Sun Dec 31 1899 00:00:00 GMT+0000 (Coordinated Universal Time) not to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isDate");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for RegExp", function() {
+        referee.refute.isDate(new RegExp());
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isDate("123");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isDate([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isDate({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isDate(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "5e790207-e300-4ecc-ac94-055e85639d95";
+
+        assert.throws(
+            function() {
+                referee.refute.isDate(
+                    new Date(Date.UTC(0, 0, 0, 0, 0, 0)),
+                    message
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isDate] " +
+                        message +
+                        ": Expected Sun Dec 31 1899 00:00:00 GMT+0000 (Coordinated Universal Time) not to be a Date"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isDate");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -124,16 +124,22 @@ describe("assert.isDate", function() {
 
 describe("refute.isDate", function() {
     it("should fail for Date", function() {
+        var date = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
+        // In node 6+8 date.toString() uses "(UTC)" as suffix in UTC timezone
+        // In node 10 date.toString() uses "(Coordinated Universal Time)"
+        var suffix = date.toString().match(/\(.*\)$/)[0];
+        var expectedMessage = "[refute.isDate] Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
+            "{suffix}",
+            suffix
+        );
+
         assert.throws(
             function() {
-                referee.refute.isDate(new Date(Date.UTC(0, 0, 0, 0, 0, 0)));
+                referee.refute.isDate(date);
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isDate] Expected Sun Dec 31 1899 00:00:00 GMT+0000 (Coordinated Universal Time) not to be a Date"
-                );
+                assert.equal(error.message, expectedMessage);
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDate");
                 return true;
@@ -163,22 +169,25 @@ describe("refute.isDate", function() {
 
     it("should fail with custom message", function() {
         var message = "5e790207-e300-4ecc-ac94-055e85639d95";
+        var date = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
+        // In node 6+8 date.toString() uses "(UTC)" as suffix in UTC timezone
+        // In node 10 date.toString() uses "(Coordinated Universal Time)"
+        var suffix = date.toString().match(/\(.*\)$/)[0];
+        var expectedMessage =
+            "[refute.isDate] " +
+            message +
+            ": Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
+                "{suffix}",
+                suffix
+            );
 
         assert.throws(
             function() {
-                referee.refute.isDate(
-                    new Date(Date.UTC(0, 0, 0, 0, 0, 0)),
-                    message
-                );
+                referee.refute.isDate(date, message);
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isDate] " +
-                        message +
-                        ": Expected Sun Dec 31 1899 00:00:00 GMT+0000 (Coordinated Universal Time) not to be a Date"
-                );
+                assert.equal(error.message, expectedMessage);
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDate");
                 return true;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "precommit": "lint-staged",
     "prepublishOnly": "npm run build && mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
-    "test": "mocha --reporter dot 'lib/**/*.test.js'",
+    "test": "TZ=UTC mocha --reporter dot 'lib/**/*.test.js'",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test",
     "demo": "mocha demo/*.test.js"
   },


### PR DESCRIPTION
Update `npm test` to run tests in UTC timezone, so that date based tests
are reproducible, no matter where in the world the test are run.

This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
