### PR TITLE
Rewrite tests for isFalse

### DIFF
--- a/lib/assertions/is-false.test.js
+++ b/lib/assertions/is-false.test.js
@@ -1,42 +1,206 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isFalse", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for false", false);
-    fail("for true", true);
-    msg(
-        "fail with message",
-        "[assert.isFalse] Expected true to be false",
-        true
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isFalse] Nooo! Expected true to be false",
-        true,
-        "Nooo!"
-    );
-    msg(
-        "represent expected value in message",
-        "[assert.isFalse] Expected {  } to be false",
-        {}
-    );
-    fail("for empty string", "");
-    fail("for 0", 0);
-    fail("for NaN", NaN);
-    fail("for null", null);
-    fail("for undefined", undefined);
-    error(
-        "for true",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isFalse"
-        },
-        true
-    );
+describe("assert.isFalse", function() {
+    it("should pass for false", function() {
+        referee.assert.isFalse(false);
+    });
+
+    it("should fail for true", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse(true);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected true to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for empty string", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse("");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected (empty string) to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for zero", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse(0);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected 0 to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for NaN", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse(NaN);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected NaN to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected null to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for undefined", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFalse(undefined);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] Expected undefined to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "f9cc72c8-d4d0-40a0-9fdf-2ec3f345788e";
+
+        assert.throws(
+            function() {
+                referee.assert.isFalse(true, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFalse] " +
+                        message +
+                        ": Expected true to be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFalse");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isFalse", function() {
+    it("should fail for false", function() {
+        assert.throws(
+            function() {
+                referee.refute.isFalse(false);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFalse] Expected false to not be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFalse");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for true", function() {
+        referee.refute.isFalse(true);
+    });
+
+    it("should pass for empty string", function() {
+        referee.refute.isFalse("");
+    });
+
+    it("should pass for zero", function() {
+        referee.refute.isFalse(0);
+    });
+
+    it("should pass for NaN", function() {
+        referee.refute.isFalse(NaN);
+    });
+
+    it("should pass for null", function() {
+        referee.refute.isFalse(null);
+    });
+
+    it("should pass for undefined", function() {
+        referee.refute.isFalse(undefined);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "ae298a16-7ddd-499d-a34a-f92d0b5f9c5e";
+
+        assert.throws(
+            function() {
+                referee.refute.isFalse(false, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFalse] " +
+                        message +
+                        ": Expected false to not be false"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFalse");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
