### PR TITLE
Rewrite tests for isFloat32Array and isFloat64Array

### DIFF
--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -1,36 +1,163 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isFloat32Array", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Float32Array", new Float32Array(2));
-    fail("for Float64Array", new Float64Array(2));
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isFloat32Array] Expected {  } to be a Float32Array",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isFloat32Array] Nope: Expected {  } to be a Float32Array",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isFloat32Array"
-        },
-        {}
-    );
+describe("assert.isFloat32Array", function() {
+    it("should pass for Float32Array", function() {
+        referee.assert.isFloat32Array(new Float32Array(2));
+    });
+
+    it("should fail for Float64Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat32Array(new Float64Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat32Array] Expected 0,0 to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat32Array([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat32Array] Expected [] to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat32Array({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat32Array(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "b547be3f-9453-4034-a3ee-e6dfe0f26fa1";
+
+        assert.throws(
+            function() {
+                referee.assert.isFloat32Array(new Float64Array(2), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat32Array] " +
+                        message +
+                        ": Expected 0,0 to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat32Array");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isFloat32Array", function() {
+    it("should fail for Float32Array", function() {
+        assert.throws(
+            function() {
+                referee.refute.isFloat32Array(new Float32Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFloat32Array] Expected 0,0 not to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFloat32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Float64Array", function() {
+        referee.refute.isFloat32Array(new Float64Array(2));
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isFloat32Array([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isFloat32Array({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isFloat32Array(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "2cc86fd1-dd39-44ed-a7c6-e5b83a16e27e";
+
+        assert.throws(
+            function() {
+                referee.refute.isFloat32Array(new Float32Array(2), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFloat32Array] " +
+                        message +
+                        ": Expected 0,0 not to be a Float32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFloat32Array");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -1,36 +1,163 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isFloat64Array", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Float32Array", new Float32Array(2));
-    pass("for Float64Array", new Float64Array(2));
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isFloat64Array] Expected {  } to be a Float64Array",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isFloat64Array] Nope: Expected {  } to be a Float64Array",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isFloat64Array"
-        },
-        {}
-    );
+describe("assert.isFloat64Array", function() {
+    it("should fail for Float32Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat64Array(new Float32Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat64Array] Expected 0,0 to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat64Array");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for isFloat64Array", function() {
+        referee.assert.isFloat64Array(new Float64Array(2));
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat64Array([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat64Array] Expected [] to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat64Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat64Array({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat64Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFloat64Array(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat64Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "b547be3f-9453-4034-a3ee-e6dfe0f26fa1";
+
+        assert.throws(
+            function() {
+                referee.assert.isFloat64Array(new Float32Array(2), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFloat64Array] " +
+                        message +
+                        ": Expected 0,0 to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFloat64Array");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isFloat64Array", function() {
+    it("should pass for Float32Array", function() {
+        referee.refute.isFloat64Array(new Float32Array(2));
+    });
+
+    it("should fail for Float64Array", function() {
+        assert.throws(
+            function() {
+                referee.refute.isFloat64Array(new Float64Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFloat64Array] Expected 0,0 not to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFloat64Array");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isFloat64Array([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isFloat64Array({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isFloat64Array(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "2cc86fd1-dd39-44ed-a7c6-e5b83a16e27e";
+
+        assert.throws(
+            function() {
+                referee.refute.isFloat64Array(new Float64Array(2), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFloat64Array] " +
+                        message +
+                        ": Expected 0,0 not to be a Float64Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFloat64Array");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
