### PR TITLE
Rewrite tests for isFunction

### DIFF
--- a/lib/assertions/is-function.test.js
+++ b/lib/assertions/is-function.test.js
@@ -1,63 +1,96 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isFunction", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for function", function() {});
-    fail("for object", {});
-    msg(
-        "fail with descriptive message",
-        "[assert.isFunction] Hey (string) expected to be function",
-        "Hey"
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isFunction] Oh no: Hey (string) expected to be function",
-        "Hey",
-        "Oh no"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            actual: "object",
-            expected: "function",
-            operator: "assert.isFunction"
-        },
-        {}
-    );
+function noop() {}
+
+describe("assert.isFunction", function() {
+    it("should pass for Function", function() {
+        referee.assert.isFunction(noop);
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isFunction({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFunction] [object Object] (object) expected to be function"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFunction");
+                return true;
+            }
+        );
+    });
+    it("should fail with custom message", function() {
+        var message = "e263d0d2-4155-4208-8600-06567b1a4feb";
+
+        assert.throws(
+            function() {
+                referee.assert.isFunction({}, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isFunction] " +
+                        message +
+                        ": [object Object] (object) expected to be function"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isFunction");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isFunction", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for function", function() {});
-    pass("for object", {});
-    msg(
-        "fail with descriptive message",
-        "[refute.isFunction] function () {} expected not to be function",
-        function() {}
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isFunction] Hmm: function () {} expected not to be function",
-        function() {},
-        "Hmm"
-    );
-    error(
-        "for function",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isFunction"
-        },
-        function() {}
-    );
+describe("refute.isFunction", function() {
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.refute.isFunction(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFunction] function noop() {} expected not to be function"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFunction");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isFunction({});
+    });
+
+    it("should fail with custom message", function() {
+        var message = "4d65bf17-9c90-4127-b29f-99da618e7022";
+        assert.throws(
+            function() {
+                referee.refute.isFunction(noop, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isFunction] " +
+                        message +
+                        ": function noop() {} expected not to be function"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isFunction");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
