### PR TITLE
Rewrite tests for isInfinity

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,7 @@ These assertions are for checking for built-in types and values.
 * [`isIntlNumberFormat()`](#isintlnumberformat)
 * [`isMap()`](#ismap)
 * [`isNaN()`](#isnan)
+* [`isNegativeInfinity()`](#isnegativeinfinity)
 * [`isNull()`](#isnull)
 * [`isNumber()`](#isnumber)
 * [`isObject()`](#isobject)
@@ -585,6 +586,20 @@ assert.isNaN({});            // Fails, would pass for standard javascript functi
 ```js
 assert.isNaN.message = "Expected ${actual} to be NaN";
 refute.isNaN.message = "Expected not to be NaN";
+```
+
+
+### `isNegativeInfinity()`
+
+```js
+assert.isNegativeInfinity(actual[, message])
+```
+
+Fails if `actual` is not `-Infinity`.
+
+```js
+assert.isNegativeInfinity(-Infinity); // Passes
+assert.isNegativeInfinity(42);       // Fails
 ```
 
 

--- a/lib/assertions/is-infinity.test.js
+++ b/lib/assertions/is-infinity.test.js
@@ -1,38 +1,185 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isInfinity", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Infinity", Infinity);
-    fail("for NaN", NaN);
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isInfinity] Expected {  } to be Infinity",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isInfinity] Nope: Expected {  } to be Infinity",
-        {},
-        "Nope"
-    );
-    error(
-        "for number",
-        {
-            code: "ERR_ASSERTION",
-            actual: 42,
-            expected: Infinity,
-            operator: "assert.isInfinity"
-        },
-        42
-    );
+describe("assert.isInfinity", function() {
+    it("should pass for Infinity", function() {
+        referee.assert.isInfinity(Infinity);
+    });
+
+    it("should fail for -Infinity", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInfinity(-Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] Expected -Infinity to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for NaN", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInfinity(NaN);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] Expected NaN to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInfinity([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] Expected [] to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInfinity({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] Expected {  } to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInfinity(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] Expected {  } to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "bd8f19ef-c847-456f-88d4-70dc540678bb";
+
+        assert.throws(
+            function() {
+                referee.assert.isInfinity(-Infinity, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInfinity] " +
+                        message +
+                        ": Expected -Infinity to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInfinity");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isInfinity", function() {
+    it("should fail for Infinity", function() {
+        assert.throws(
+            function() {
+                referee.refute.isInfinity(Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isInfinity] Expected Infinity not to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for -Infinity", function() {
+        referee.refute.isInfinity(-Infinity);
+    });
+
+    it("should pass for NaN", function() {
+        referee.refute.isInfinity(NaN);
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isInfinity([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isInfinity({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isInfinity(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "5fd5a4ca-34a8-42f3-98dd-ba4d39dc4944";
+
+        assert.throws(
+            function() {
+                referee.refute.isInfinity(Infinity, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isInfinity] " +
+                        message +
+                        ": Expected Infinity not to be Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isInfinity");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-negative-infinity.js
+++ b/lib/assertions/is-negative-infinity.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = function(referee) {
+    referee.add("isNegativeInfinity", {
+        assert: function(actual) {
+            return actual === -Infinity;
+        },
+        assertMessage: "${customMessage}Expected ${actual} to be -Infinity",
+        refuteMessage: "${customMessage}Expected ${actual} not to be -Infinity",
+        expectation: "toBeNegativeInfinity",
+        values: function(actual, message) {
+            return {
+                actual: actual,
+                expected: -Infinity,
+                customMessage: message
+            };
+        }
+    });
+};

--- a/lib/assertions/is-negative-infinity.test.js
+++ b/lib/assertions/is-negative-infinity.test.js
@@ -1,0 +1,185 @@
+"use strict";
+
+var assert = require("assert");
+var referee = require("../referee");
+var captureArgs = require("../test-helper/capture-args");
+
+describe("assert.isNegativeInfinity", function() {
+    it("should pass for -Infinity", function() {
+        referee.assert.isNegativeInfinity(-Infinity);
+    });
+
+    it("should fail for Infinity", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity(Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] Expected Infinity to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for NaN", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity(NaN);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] Expected NaN to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] Expected [] to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "bd8f19ef-c847-456f-88d4-70dc540678bb";
+
+        assert.throws(
+            function() {
+                referee.assert.isNegativeInfinity(Infinity, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNegativeInfinity] " +
+                        message +
+                        ": Expected Infinity to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isNegativeInfinity", function() {
+    it("should fail for Infinity", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNegativeInfinity(-Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNegativeInfinity] Expected -Infinity not to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Infinity", function() {
+        referee.refute.isNegativeInfinity(Infinity);
+    });
+
+    it("should pass for NaN", function() {
+        referee.refute.isNegativeInfinity(NaN);
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isNegativeInfinity([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isNegativeInfinity({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isNegativeInfinity(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "5fd5a4ca-34a8-42f3-98dd-ba4d39dc4944";
+
+        assert.throws(
+            function() {
+                referee.refute.isNegativeInfinity(-Infinity, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNegativeInfinity] " +
+                        message +
+                        ": Expected -Infinity not to be -Infinity"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNegativeInfinity");
+                return true;
+            }
+        );
+    });
+});

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -45,6 +45,7 @@ require("./assertions/is-intl-number-format")(referee);
 require("./assertions/is-map")(referee);
 require("./assertions/is-nan")(referee);
 require("./assertions/is-null")(referee);
+require("./assertions/is-negative-infinity")(referee);
 require("./assertions/is-number")(referee);
 require("./assertions/is-object")(referee);
 require("./assertions/is-promise")(referee);


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

**Bonus commit:** Add `isNegativeInfinity`

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
