### PR TITLE
Configure nyc to include all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build && mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "TZ=UTC mocha --reporter dot 'lib/**/*.test.js'",
     "test-check-coverage": "npm run test-coverage && nyc check-coverage --branches 100 --functions 100 --lines 100",
-    "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test",
+    "test-coverage": "nyc --all --reporter text --reporter html --reporter lcovonly npm run test",
     "demo": "mocha demo/*.test.js"
   },
   "lint-staged": {
@@ -36,6 +36,7 @@
   },
   "nyc": {
     "exclude": [
+      "rollup.config.js",
       "coverage/**",
       "**/*.test.js",
       "lib/test-helper/**"


### PR DESCRIPTION
This ensures that all source files are considered when measuring
coverage, even those without any test coverage.

Excludes `rollup.config.js`

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Try adding a file that ins't covered by tests
1. `npm run test-check-coverage`
1. Observe that the command fails

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
