### PR TITLE
Upgrade samsam to v3

### DIFF
--- a/lib/assertions/exception.js
+++ b/lib/assertions/exception.js
@@ -43,7 +43,13 @@ module.exports = function(referee) {
             }
 
             if (typeof matcher === "object" && !samsam.match(err, matcher)) {
-                return this.fail(typeFailMessage);
+                var prop;
+                for (prop in matcher) {
+                    if (!samsam.match(err[prop], matcher[prop])) {
+                        return this.fail(typeFailMessage);
+                    }
+                }
+                return true;
             }
 
             if (typeof matcher === "function" && matcher(err) !== true) {

--- a/lib/assertions/exception.js
+++ b/lib/assertions/exception.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var samsam = require("@sinonjs/samsam");
+var hasOwnProperty = require("@sinonjs/commons").prototypes.object
+    .hasOwnProperty;
 
 var captureException = require("../capture-exception");
 
@@ -45,7 +47,10 @@ module.exports = function(referee) {
             if (typeof matcher === "object" && !samsam.match(err, matcher)) {
                 var prop;
                 for (prop in matcher) {
-                    if (!samsam.match(err[prop], matcher[prop])) {
+                    if (
+                        hasOwnProperty(matcher, prop) &&
+                        !samsam.match(err[prop], matcher[prop])
+                    ) {
                         return this.fail(typeFailMessage);
                     }
                 }

--- a/lib/assertions/match.test.js
+++ b/lib/assertions/match.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var samsam = require("@sinonjs/samsam");
 var sinon = require("sinon");
 
 var referee = require("../referee");
@@ -151,9 +152,9 @@ testHelper.assertionTests("assert", "match", function(pass, fail, msg, error) {
     pass("for nested matcher", object2, {
         owner: {
             someDude: "Yes",
-            hello: function(value) {
+            hello: samsam.createMatcher(function(value) {
                 return value === "ok";
-            }
+            })
         }
     });
 
@@ -316,9 +317,9 @@ testHelper.assertionTests("refute", "match", function(pass, fail, msg, error) {
     fail("for nested matcher", object2, {
         owner: {
             someDude: "Yes",
-            hello: function(value) {
+            hello: samsam.createMatcher(function(value) {
                 return value === "ok";
-            }
+            })
         }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,19 +42,31 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
       "requires": {
-        "@sinonjs/samsam": "2.1.0"
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-      "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.0.tgz",
+      "integrity": "sha512-HYQiZXtwBEtjLPPZ3/X/wiKFNY9fMrJEjdSvYfeUEgTmppNVuDVQKIYGNTdM08sHkfes17KaE0RLOwHSbA0/ww==",
       "requires": {
-        "array-from": "^2.1.1"
+        "@sinonjs/commons": "1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "4.4.2"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+          "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
       }
     },
     "acorn": {
@@ -2243,8 +2255,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -2530,6 +2541,24 @@
         "text-encoding": "^0.6.4"
       },
       "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+          "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/samsam": "2.1.0"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        },
         "lolex": {
           "version": "2.7.5",
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.3.0",
-    "@sinonjs/formatio": "^3.0.0",
-    "@sinonjs/samsam": "^2.1.0",
+    "@sinonjs/formatio": "^3.1.0",
+    "@sinonjs/samsam": "^3.0.0",
     "array-from": "2.1.1",
     "bane": "^1.x",
     "lodash.includes": "^4.3.0",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

__BREAKING:__ Upgrade samsam to v3 with slightly changed `deepEqual` and `match` semantics.

A small change in the verification logic for exceptions was required to reduce the "breakingness" of this upgrade.

#### Motivation:

What we will gain from samsam 3 is a unified approach to using custom and built in matches. With this change, the Sinon matchers have moved to samsam and can be used in referee within `assert.equals`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
