### PR TITLE
Expose match

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -195,10 +195,13 @@ Compares `actual` to `expected` property by property. If the property count does
 If `actual` is `null` or `undefined`, an exact match is required. Date objects are compared by their `getTime` method. Regular expressions are compared by their string representations. Primitives are compared using `==`, i.e., with coercion.
 
 `equals` passes when comparing an arguments object to an array if the both contain the same elements.
+Objects or arrays may contain the result of calling `match` to compare a property using a built-in or custom matcher.
 
 ```js
 assert.equals({ name: "Professor Chaos" }, { name: "Professor Chaos" }); // Passes
+assert.equals({ name: "Professor Chaos" }, { name: match.string }); // Passes
 assert.equals({ name: "Professor Chaos" }, { name: "Dr Evil" }); // Fails
+assert.equals({ name: "Professor Chaos" }, { name: match.number }); // Fails
 ```
 
 #### Messages

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+var assert = require("assert");
+var samsam = require("@sinonjs/samsam");
+var referee = require("./referee");
+
+describe("match", function() {
+    it("should be createMatcher from @sinonjs/samsam", function() {
+        assert.strictEqual(referee.match, samsam.createMatcher);
+    });
+
+    context("with assert.equals", function() {
+        it("should pass match.string in object", function() {
+            var object = { foo: 1, bar: "test" };
+
+            referee.assert.equals(object, {
+                foo: 1,
+                bar: referee.match.string
+            });
+        });
+
+        it("should fail match.string in object", function() {
+            var object = { foo: 1, bar: true };
+
+            assert.throws(
+                function() {
+                    referee.assert.equals(object, {
+                        foo: 1,
+                        bar: referee.match.string
+                    });
+                },
+                function(error) {
+                    assert.equal(error.code, "ERR_ASSERTION");
+                    assert.equal(
+                        error.message,
+                        '[assert.equals] { bar: true, foo: 1 } expected to be equal to { bar: typeOf("string"), foo: 1 }'
+                    );
+                    assert.equal(error.name, "AssertionError");
+                    assert.equal(error.operator, "assert.equals");
+                    return true;
+                }
+            );
+        });
+    });
+
+    context("with refute.equals", function() {
+        it("should pass match.string in object", function() {
+            var object = { foo: 1, bar: true };
+
+            referee.refute.equals(object, {
+                foo: 1,
+                bar: referee.match.string
+            });
+        });
+
+        it("should fail match.string in object", function() {
+            var object = { foo: 1, bar: "test" };
+
+            assert.throws(
+                function() {
+                    referee.refute.equals(object, {
+                        foo: 1,
+                        bar: referee.match.string
+                    });
+                },
+                function(error) {
+                    assert.equal(error.code, "ERR_ASSERTION");
+                    assert.equal(
+                        error.message,
+                        '[refute.equals] { bar: "test", foo: 1 } expected not to be equal to { bar: typeOf("string"), foo: 1 }'
+                    );
+                    assert.equal(error.name, "AssertionError");
+                    assert.equal(error.operator, "refute.equals");
+                    return true;
+                }
+            );
+        });
+    });
+});

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -11,8 +11,8 @@ referee.refute = require("./create-refute")(referee);
 referee.expect = require("./create-expect")(referee);
 referee.fail = require("./create-fail")(referee);
 referee.pass = require("./create-pass")(referee);
-
 referee.verifier = require("./create-verifier")(referee);
+referee.match = require("@sinonjs/samsam").createMatcher;
 
 // add all all the built-in assertions to the API
 require("./assertions/defined")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -46,6 +46,13 @@ describe("API", function() {
         });
     });
 
+    describe(".verifier", function() {
+        it("should be a zero-arity Function named 'verifier'", function() {
+            assert.equal(typeof referee.verifier, "function");
+            assert.equal(referee.verifier.length, 0);
+        });
+    });
+
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -53,6 +53,13 @@ describe("API", function() {
         });
     });
 
+    describe(".match", function() {
+        it("should be a binary Function named 'match'", function() {
+            assert.equal(typeof referee.match, "function");
+            assert.equal(referee.match.length, 2);
+        });
+    });
+
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
@@ -66,6 +73,7 @@ describe("API", function() {
             "expect",
             "fail",
             "listeners",
+            "match",
             "off",
             "on",
             "once",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "exclude": [
       "rollup.config.js",
       "coverage/**",
+      "site/**",
+      "dist/**",
       "**/*.test.js",
       "lib/test-helper/**"
     ]


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Since we now integrated with samsam 3, I'd like to expose a `match` function that can be used with `assert.equals` and `refute.equals`.

This change adds API tests, an integration test, and a small note in the documentation.

Obviously, this should be documented a lot better. I'm wondering if we should put the docs in samsam and refer to them here, or whether it should be documented in referee 🤔 

I also had to add two more excludes to the nyc config, or I wouldn't be able to commit anything 😆 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
