### PR TITLE
Rewrite tests for isInt32Array

### DIFF
--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -1,37 +1,185 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isInt32Array", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Int8Array", new Int8Array(2));
-    fail("for Int16Array", new Int16Array(2));
-    pass("for Int32Array", new Int32Array(2));
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isInt32Array] Expected {  } to be an Int32Array",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isInt32Array] Nope: Expected {  } to be an Int32Array",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isInt32Array"
-        },
-        {}
-    );
+describe("assert.isInt32Array", function() {
+    it("should fail for Int8Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array(new Int8Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Int16Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array(new Int16Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Int32Array", function() {
+        referee.assert.isInt32Array(new Int32Array(2));
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] Expected [] to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "593c3d59-bc50-456c-b3d6-a0ea0da372a1";
+
+        assert.throws(
+            function() {
+                referee.assert.isInt32Array(captureArgs(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isInt32Array] " +
+                        message +
+                        ": Expected {  } to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isInt32Array");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isInt32Array", function() {
+    it("should pass for Int8Array", function() {
+        referee.refute.isInt32Array(new Int8Array(2));
+    });
+
+    it("should pass for Int16Array", function() {
+        referee.refute.isInt32Array(new Int16Array(2));
+    });
+
+    it("should fail for Int32Array", function() {
+        assert.throws(
+            function() {
+                referee.refute.isInt32Array(new Int32Array(2));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isInt32Array] Expected 0,0 not to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isInt32Array");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isInt32Array([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isInt32Array({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isInt32Array(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "82576420-8e5d-4618-b6eb-87bcf00b9170";
+
+        assert.throws(
+            function() {
+                referee.refute.isInt32Array(new Int32Array(2), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isInt32Array] " +
+                        message +
+                        ": Expected 0,0 not to be an Int32Array"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isInt32Array");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
