### PR TITLE
Rewrite even more tests

### DIFF
--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -1,36 +1,162 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isIntlCollator", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Intl.Collator", new Intl.Collator());
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isIntlCollator] Expected {  } to be an Intl.Collator",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isIntlCollator] Nope: Expected {  } to be an Intl.Collator",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isIntlCollator"
-        },
-        {}
-    );
+describe("assert.isIntlCollator", function() {
+    it("should pass for Intl.Collator", function() {
+        referee.assert.isIntlCollator(new Intl.Collator());
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlCollator("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlCollator] Expected apple pie to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlCollator");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlCollator([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlCollator] Expected [] to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlCollator");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlCollator({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlCollator");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlCollator(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlCollator");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "de8e08f7-f0da-44d9-912e-f7c704dcf929";
+
+        assert.throws(
+            function() {
+                referee.assert.isIntlCollator("apple pie", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlCollator] " +
+                        message +
+                        ": Expected apple pie to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlCollator");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isIntlCollator", function() {
+    it("should fail for Intl.Collator", function() {
+        assert.throws(
+            function() {
+                referee.refute.isIntlCollator(new Intl.Collator());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlCollator] Expected [Collator] {  } not to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlCollator");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isIntlCollator("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isIntlCollator([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isIntlCollator({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isIntlCollator(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "0d6ff45e-4794-41d2-90ce-41b554580bb6";
+        assert.throws(
+            function() {
+                referee.refute.isIntlCollator(new Intl.Collator(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlCollator] " +
+                        message +
+                        ": Expected [Collator] {  } not to be an Intl.Collator"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlCollator");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -1,36 +1,165 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isIntlDateTimeFormat", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Intl.DateTimeFormat", new Intl.DateTimeFormat());
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isIntlDateTimeFormat] Nope: Expected {  } to be an Intl.DateTimeFormat",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isIntlDateTimeFormat"
-        },
-        {}
-    );
+describe("assert.isIntlDateTimeFormat", function() {
+    it("should pass for Intl.DateTimeFormat", function() {
+        referee.assert.isIntlDateTimeFormat(new Intl.DateTimeFormat());
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlDateTimeFormat("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlDateTimeFormat] Expected apple pie to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlDateTimeFormat([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlDateTimeFormat] Expected [] to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlDateTimeFormat({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlDateTimeFormat(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "b43c086b-2553-4882-8abb-0ef92965b699";
+
+        assert.throws(
+            function() {
+                referee.assert.isIntlDateTimeFormat("apple pie", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlDateTimeFormat] " +
+                        message +
+                        ": Expected apple pie to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isIntlDateTimeFormat", function() {
+    it("should fail for Intl.DateTimeFormat", function() {
+        assert.throws(
+            function() {
+                referee.refute.isIntlDateTimeFormat(new Intl.DateTimeFormat());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlDateTimeFormat] Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isIntlDateTimeFormat("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isIntlDateTimeFormat([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isIntlDateTimeFormat({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isIntlDateTimeFormat(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "c485cacd-b75c-4c2c-8903-c2e7f9b16766";
+        assert.throws(
+            function() {
+                referee.refute.isIntlDateTimeFormat(
+                    new Intl.DateTimeFormat(),
+                    message
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlDateTimeFormat] " +
+                        message +
+                        ": Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlDateTimeFormat");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -1,36 +1,165 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isIntlNumberFormat", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Intl.NumberFormat", new Intl.NumberFormat());
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isIntlNumberFormat] Nope: Expected {  } to be an Intl.NumberFormat",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isIntlNumberFormat"
-        },
-        {}
-    );
+describe("assert.isIntlNumberFormat", function() {
+    it("should pass for Intl.NumberFormat", function() {
+        referee.assert.isIntlNumberFormat(new Intl.NumberFormat());
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlNumberFormat("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlNumberFormat] Expected apple pie to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlNumberFormat([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlNumberFormat] Expected [] to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlNumberFormat({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isIntlNumberFormat(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "4eb2174d-3faa-4095-92d1-cd8dfb7e2a58";
+
+        assert.throws(
+            function() {
+                referee.assert.isIntlNumberFormat("apple pie", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isIntlNumberFormat] " +
+                        message +
+                        ": Expected apple pie to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isIntlNumberFormat", function() {
+    it("should fail for Intl.NumberFormat", function() {
+        assert.throws(
+            function() {
+                referee.refute.isIntlNumberFormat(new Intl.NumberFormat());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlNumberFormat] Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isIntlNumberFormat("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isIntlNumberFormat([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isIntlNumberFormat({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isIntlNumberFormat(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "f84e51dd-d5af-4ef0-81ec-2d575eadd735";
+        assert.throws(
+            function() {
+                referee.refute.isIntlNumberFormat(
+                    new Intl.NumberFormat(),
+                    message
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isIntlNumberFormat] " +
+                        message +
+                        ": Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isIntlNumberFormat");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -1,31 +1,186 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isMap", function(pass, fail, msg, error) {
-    pass("for Map", new Map());
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isMap] Expected {  } to be a Map",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isMap] Nope: Expected {  } to be a Map",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isMap"
-        },
-        {}
-    );
+describe("assert.isMap", function() {
+    it("should pass for Map", function() {
+        referee.assert.isMap(new Map());
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isMap("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] Expected apple pie to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isMap([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] Expected [] to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for WeakMap", function() {
+        assert.throws(
+            function() {
+                // eslint-disable-next-line ie11/no-weak-collections
+                referee.assert.isMap(new WeakMap());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] Expected [WeakMap] {  } to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isMap({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] Expected {  } to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isMap(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] Expected {  } to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "4eb2174d-3faa-4095-92d1-cd8dfb7e2a58";
+
+        assert.throws(
+            function() {
+                referee.assert.isMap("apple pie", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isMap] " +
+                        message +
+                        ": Expected apple pie to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isMap");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isMap", function() {
+    it("should fail for Map", function() {
+        assert.throws(
+            function() {
+                referee.refute.isMap(new Map());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isMap] Expected [Map] {  } not to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isMap");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isMap("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isMap([]);
+    });
+
+    it("should pass for WeakMap", function() {
+        // eslint-disable-next-line ie11/no-weak-collections
+        referee.refute.isMap(new WeakMap());
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isMap({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isMap(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "f84e51dd-d5af-4ef0-81ec-2d575eadd735";
+        assert.throws(
+            function() {
+                referee.refute.isMap(new Map(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isMap] " +
+                        message +
+                        ": Expected [Map] {  } not to be a Map"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isMap");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-nan.test.js
+++ b/lib/assertions/is-nan.test.js
@@ -1,59 +1,315 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
+var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isNaN", function(pass, fail, msg, error) {
-    pass("for NaN", NaN);
-    fail("for number", 32);
-    fail("for function", function() {});
-    fail("for object", {});
-    fail("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[assert.isNaN] Expected 32 to be NaN",
-        32
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isNaN] No! Expected 32 to be NaN",
-        32,
-        "No!"
-    );
-    error(
-        "for number",
-        {
-            code: "ERR_ASSERTION",
-            actual: 42,
-            expected: "NaN",
-            operator: "assert.isNaN"
-        },
-        42
-    );
+function noop() {}
+
+describe("assert.isNaN", function() {
+    it("should pass for NaN", function() {
+        referee.assert.isNaN(NaN);
+    });
+
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected null to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for undefined", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(undefined);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected undefined to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Infinity", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected Infinity to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for -Infinity", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(-Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected -Infinity to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for zero", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(0);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected 0 to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Number", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(42);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected 42 to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected apple pie to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected function noop() {} to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected [] to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected {  } to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNaN(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] Expected {  } to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom error", function() {
+        var message = "eb919d57-c96b-4ed1-a253-369efaf87e48";
+
+        assert.throws(
+            function() {
+                referee.assert.isNaN(null, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNaN] " + message + ": Expected null to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNaN");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isNaN", function(pass, fail, msg, error) {
-    fail("for NaN", NaN);
-    pass("for number", 32);
-    pass("for function", function() {});
-    pass("for object", {});
-    pass("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[refute.isNaN] Expected not to be NaN",
-        NaN
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isNaN] Hey: Expected not to be NaN",
-        NaN,
-        "Hey"
-    );
-    error(
-        "for NaN",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isNaN"
-        },
-        NaN
-    );
+describe("refute.isNaN", function() {
+    it("should fail for NaN", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNaN(NaN);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNaN] Expected not to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNaN");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for null", function() {
+        referee.refute.isNaN(null);
+    });
+
+    it("should pass for undefined", function() {
+        referee.refute.isNaN(undefined);
+    });
+
+    it("should pass for Infinity", function() {
+        referee.refute.isNaN(Infinity);
+    });
+
+    it("should pass for -Infinity", function() {
+        referee.refute.isNaN(-Infinity);
+    });
+
+    it("should pass for zero", function() {
+        referee.refute.isNaN(0);
+    });
+
+    it("should pass for Number", function() {
+        referee.refute.isNaN(42);
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isNaN("apple pie");
+    });
+
+    it("should pass for Function", function() {
+        referee.refute.isNaN(noop);
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isNaN([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isNaN({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isNaN(captureArgs());
+    });
+
+    it("should fail with custom error", function() {
+        var message = "b5124f48-5270-41ba-8a58-8619563c0f84";
+
+        assert.throws(
+            function() {
+                referee.refute.isNaN(NaN, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNaN] " + message + ": Expected not to be NaN"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNaN");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-null.test.js
+++ b/lib/assertions/is-null.test.js
@@ -1,55 +1,251 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
+var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isNull", function(pass, fail, msg, error) {
-    pass("for null", null);
-    fail("for function", function() {});
-    fail("for undefined", undefined);
-    msg(
-        "fail with descriptive message",
-        "[assert.isNull] Expected Hey to be null",
-        "Hey"
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isNull] Hmm: Expected Hey to be null",
-        "Hey",
-        "Hmm"
-    );
-    error(
-        "for undefined",
-        {
-            code: "ERR_ASSERTION",
-            actual: undefined,
-            expected: null,
-            operator: "assert.isNull"
-        },
-        undefined
-    );
+function noop() {}
+
+describe("assert.isNull", function() {
+    it("should pass for null", function() {
+        referee.assert.isNull(null);
+    });
+
+    it("should fail for undefined", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull(undefined);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected undefined to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for zero", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull(0);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected 0 to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for false", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull(false);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected false to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for empty string", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull("");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected (empty string) to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected function noop() {} to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected [] to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected {  } to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNull(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] Expected {  } to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "f5119659-4749-4992-abe3-eaeaf3afd279";
+
+        assert.throws(
+            function() {
+                referee.assert.isNull(undefined, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNull] " +
+                        message +
+                        ": Expected undefined to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNull");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isNull", function(pass, fail, msg, error) {
-    fail("for null", null);
-    pass("for function", function() {});
-    pass("for undefined", undefined);
-    msg(
-        "fail with descriptive message",
-        "[refute.isNull] Expected not to be null",
-        null
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isNull] Here: Expected not to be null",
-        null,
-        "Here"
-    );
-    error(
-        "for null",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isNull"
-        },
-        null
-    );
+describe("refute.isNull", function() {
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNull(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNull] Expected not to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNull");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for undefined", function() {
+        referee.refute.isNull(undefined);
+    });
+
+    it("should pass for zero", function() {
+        referee.refute.isNull(0);
+    });
+
+    it("should pass for false", function() {
+        referee.refute.isNull(false);
+    });
+
+    it("should pass for empty string", function() {
+        referee.refute.isNull("");
+    });
+
+    it("should pass for Function", function() {
+        referee.refute.isNull(noop);
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isNull([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isNull({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isNull(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "75a44f2e-1387-436d-bc6c-89e0b95a85b2";
+
+        assert.throws(
+            function() {
+                referee.refute.isNull(null, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNull] " + message + ": Expected not to be null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNull");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
