### PR TITLE
Expose formatter function through getFormatter

### DIFF
--- a/lib/get-formatter.test.js
+++ b/lib/get-formatter.test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var assert = require("assert");
+var format = require("./format");
+var referee = require("./referee");
+
+describe("getFormatter", function() {
+    it("should return the format function", function() {
+        assert.strictEqual(referee.getFormatter(), format);
+    });
+});

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -14,6 +14,11 @@ referee.pass = require("./create-pass")(referee);
 referee.verifier = require("./create-verifier")(referee);
 referee.match = require("@sinonjs/samsam").createMatcher;
 
+var format = require("./format");
+referee.getFormatter = function() {
+    return format;
+};
+
 // add all all the built-in assertions to the API
 require("./assertions/defined")(referee);
 require("./assertions/class-name")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -60,6 +60,13 @@ describe("API", function() {
         });
     });
 
+    describe(".getFormatter", function() {
+        it("should be a zero-arity Function named 'match'", function() {
+            assert.equal(typeof referee.getFormatter, "function");
+            assert.equal(referee.getFormatter.length, 0);
+        });
+    });
+
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
@@ -72,6 +79,7 @@ describe("API", function() {
             "errbacks",
             "expect",
             "fail",
+            "getFormatter",
             "listeners",
             "match",
             "off",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This allows to upgrade Sinon and Referee in the `referee-sinon` project.

#### Background (Problem in detail)  - optional

Upgrading without this change is not possible due to an incompatibility here:

https://github.com/sinonjs/referee-sinon/blob/ad26b2f7e9f119c4c7e8cf0d05f7a13a13323e19/lib/referee-sinon.js#L41-L43

Sinon has a `setFormatter` function since https://github.com/sinonjs/sinon/pull/1503. With a corresponding `getFormatter()` in `referee` we can "sync" the formatting between the two libraries again.

While looking into the formatters, I realized that the referee and sinon format implementations are the same. This means the integration isn't even necessary. We can discuss if we want to do it nevertheless or skip it. In either case, `referee-sinon` needs access to a formatter.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).