### PR TITLE
Rewrite more tests

### DIFF
--- a/lib/assertions/is-number.test.js
+++ b/lib/assertions/is-number.test.js
@@ -1,62 +1,275 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
+var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isNumber", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for number", 32);
-    fail("for NaN (sic)", NaN);
-    fail("for function", function() {});
-    fail("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[assert.isNumber] Expected Hey (string) to be a non-NaN number",
-        "Hey"
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isNumber] Check it: Expected Hey (string) to be a non-NaN number",
-        "Hey",
-        "Check it"
-    );
-    error(
-        "for string",
-        {
-            code: "ERR_ASSERTION",
-            actual: "string",
-            expected: "number",
-            operator: "assert.isNumber"
-        },
-        "Hey"
-    );
+function noop() {}
+
+describe("assert.isNumber", function() {
+    it("should pass for Number", function() {
+        referee.assert.isNumber(42);
+    });
+
+    it("should pass for Infinity", function() {
+        referee.assert.isNumber(Infinity);
+    });
+
+    it("should pass for -Infinity", function() {
+        referee.assert.isNumber(-Infinity);
+    });
+
+    it("should pass for Number.MAX_VALUE", function() {
+        referee.assert.isNumber(Number.MAX_VALUE);
+    });
+
+    it("should pass for Number.MIN_VALUE", function() {
+        referee.assert.isNumber(Number.MIN_VALUE);
+    });
+
+    it("should fail for NaN", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNumber(NaN);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] Expected NaN (number) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNumber("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] Expected apple pie (string) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNumber(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] Expected function noop() {} (function) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNumber(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] Expected {  } (object) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.assert.isNumber(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] Expected null (object) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "7e622cb3-2a4a-4808-ae9b-bc2b53482cf1";
+
+        assert.throws(
+            function() {
+                referee.assert.isNumber(NaN, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isNumber] " +
+                        message +
+                        ": Expected NaN (number) to be a non-NaN number"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isNumber");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isNumber", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for number", 32);
-    pass("for NaN (sic)", NaN);
-    pass("for function", function() {});
-    pass("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[refute.isNumber] Ho ho! Expected 42 to be NaN or a non-number value",
-        42,
-        "Ho ho!"
-    );
-    error(
-        "for number",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isNumber"
-        },
-        42
-    );
+describe("refute.isNumber", function() {
+    it("should fail for Number", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNumber(42);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] Expected 42 to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Infinity", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNumber(Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] Expected Infinity to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for -Infinity", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNumber(-Infinity);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] Expected -Infinity to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Number.MAX_VALUE", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNumber(Number.MAX_VALUE);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] Expected 1.7976931348623157e+308 to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Number.MIN_VALUE", function() {
+        assert.throws(
+            function() {
+                referee.refute.isNumber(Number.MIN_VALUE);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] Expected 5e-324 to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for NaN", function() {
+        referee.refute.isNumber(NaN);
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isNumber("apple pie");
+    });
+
+    it("should pass for Function", function() {
+        referee.refute.isNumber(noop);
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isNumber(arguments);
+    });
+
+    it("should pass for null", function() {
+        referee.refute.isNumber(null);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "9402608a-e6b3-4250-98eb-739a0232f0df";
+
+        assert.throws(
+            function() {
+                referee.refute.isNumber(42, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isNumber] " +
+                        message +
+                        ": Expected 42 to be NaN or a non-number value"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isNumber");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-object.test.js
+++ b/lib/assertions/is-object.test.js
@@ -1,65 +1,118 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "isObject", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for object", {});
-    fail("for function", function() {});
-    fail("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[assert.isObject] Hey (string) expected to be object and not null",
-        "Hey"
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isObject] OH! Hey (string) expected to be object and not null",
-        "Hey",
-        "OH!"
-    );
-    error(
-        "for function",
-        {
-            code: "ERR_ASSERTION",
-            actual: "function",
-            expected: "object",
-            operator: "assert.isObject"
-        },
-        function() {}
-    );
+function noop() {}
+
+describe("assert.isObject", function() {
+    it("should pass for Object", function() {
+        referee.assert.isObject({});
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isObject(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isObject] function noop() {} (function) expected to be object and not null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isObject");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for null", function() {
+        assert.throws(
+            function() {
+                referee.assert.isObject(null);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isObject] null (object) expected to be object and not null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isObject");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "5d9980ce-8577-4894-91af-4055eeaae215";
+
+        assert.throws(
+            function() {
+                referee.assert.isObject(noop, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isObject] " +
+                        message +
+                        ": function noop() {} (function) expected to be object and not null"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isObject");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "isObject", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for object", {});
-    pass("for function", function() {});
-    pass("for null", null);
-    msg(
-        "fail with descriptive message",
-        "[refute.isObject] {  } expected to be null or not an object",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[refute.isObject] Oh no! {  } expected to be null or not an object",
-        {},
-        "Oh no!"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.isObject"
-        },
-        {}
-    );
+describe("refute.isObject", function() {
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.refute.isObject({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isObject] {  } expected to be null or not an object"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isObject");
+                return true;
+            }
+        );
+    });
+    it("should pass for Function", function() {
+        referee.refute.isObject(noop);
+    });
+
+    it("should pass for null", function() {
+        referee.refute.isObject(null);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "49ee3516-6b75-4e89-86d9-0c72bca14a59";
+        assert.throws(
+            function() {
+                referee.refute.isObject({}, message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isObject] " +
+                        message +
+                        ": {  } expected to be null or not an object"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isObject");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -1,36 +1,186 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isPromise", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    pass("for Promise", Promise.resolve("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isPromise] Expected {  } to be a Promise",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isPromise] Nope: Expected {  } to be a Promise",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isPromise"
-        },
-        {}
-    );
+function noop() {}
+
+describe("assert.isPromise", function() {
+    it("should pass for Promise", function() {
+        referee.assert.isPromise(Promise.resolve("apple pie"));
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isPromise("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] Expected apple pie to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isPromise([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] Expected [] to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Function", function() {
+        assert.throws(
+            function() {
+                referee.assert.isPromise(noop);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] Expected function noop() {} to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isPromise({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] Expected {  } to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isPromise(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] Expected {  } to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "083406d6-58f6-41ff-9e00-f53edf9fa4aa";
+        assert.throws(
+            function() {
+                referee.assert.isPromise("apple pie", message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isPromise] " +
+                        message +
+                        ": Expected apple pie to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isPromise");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isPromise", function() {
+    it("should fail for Promise", function() {
+        assert.throws(
+            function() {
+                referee.refute.isPromise(Promise.resolve("apple pie"));
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isPromise] Expected [Promise] {  } not to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isPromise");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isPromise("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isPromise([]);
+    });
+
+    it("should pass for Function", function() {
+        referee.refute.isPromise(noop);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isPromise({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isPromise(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "30712884-5ff3-43d6-9f30-5901e840c75f";
+
+        assert.throws(
+            function() {
+                referee.refute.isPromise(Promise.resolve("apple pie"), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isPromise] " +
+                        message +
+                        ": Expected [Promise] {  } not to be a Promise"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isPromise");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
