### PR TITLE
Add setFormatter from Sinon

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -8,8 +8,26 @@ var formatter = formatio.configure({
     limitChildrenCount: 250
 });
 
-function format(object) {
-    return formatter.ascii(object);
+var customFormatter;
+
+function format() {
+    if (customFormatter) {
+        return customFormatter.apply(null, arguments);
+    }
+
+    return formatter.ascii.apply(formatter, arguments);
 }
+
+format.setFormatter = function(aCustomFormatter) {
+    if (typeof aCustomFormatter !== "function") {
+        throw new Error("format.setFormatter must be called with a function");
+    }
+
+    customFormatter = aCustomFormatter;
+};
+
+format.reset = function() {
+    customFormatter = null;
+};
 
 module.exports = format;

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var assert = require("assert");
+var format = require("./format");
+var referee = require("..");
+
+describe("format", function() {
+    afterEach(function() {
+        format.reset();
+    });
+
+    it("formats with formatio by default", function() {
+        assert.equal(format({ id: 42 }), "{ id: 42 }");
+    });
+
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip("should configure formatio to use maximum 250 entries", function() {
+        // not sure how we can verify this integration with the current setup
+        // where sinon.js calls formatio as part of its loading
+        // extracting sinon.format into a separate module would make this a lot
+        // easier
+    });
+
+    it("formats strings without quotes", function() {
+        assert.equal(format("Hey"), "Hey");
+    });
+
+    describe("format.setFormatter", function() {
+        it("sets custom formatter", function() {
+            format.setFormatter(function() {
+                return "formatted";
+            });
+            assert.equal(format("Hey"), "formatted");
+        });
+
+        it("throws if custom formatter is not a function", function() {
+            assert.throws(
+                function() {
+                    format.setFormatter("foo");
+                },
+                function(err) {
+                    assert.equal(
+                        err.message,
+                        "format.setFormatter must be called with a function"
+                    );
+                    return true;
+                }
+            );
+        });
+
+        it("exposes method on referee", function() {
+            assert.equal(referee.setFormatter, format.setFormatter);
+        });
+    });
+});

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -13,6 +13,7 @@ referee.fail = require("./create-fail")(referee);
 referee.pass = require("./create-pass")(referee);
 referee.verifier = require("./create-verifier")(referee);
 referee.match = require("@sinonjs/samsam").createMatcher;
+referee.setFormatter = require("./format").setFormatter;
 
 // add all all the built-in assertions to the API
 require("./assertions/defined")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -60,6 +60,13 @@ describe("API", function() {
         });
     });
 
+    describe(".setFormatter", function() {
+        it("should be a unary Function named 'setFormatter'", function() {
+            assert.equal(typeof referee.setFormatter, "function");
+            assert.equal(referee.setFormatter.length, 1);
+        });
+    });
+
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
@@ -79,6 +86,7 @@ describe("API", function() {
             "once",
             "pass",
             "refute",
+            "setFormatter",
             "supervisors",
             "verifier"
         ]);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This is an alternative to #82. Instead of exposing the formatter, this introduces `setFormatter` in exactly the same way as Sinon does. With this change, `referee-sinon` can create its own formatter and inject it into Sinon and Referee (inversion of control FTW).

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
