### PR TITLE
Refactor is*Error tests

### DIFF
--- a/lib/assertions/is-range-error.test.js
+++ b/lib/assertions/is-range-error.test.js
@@ -1,37 +1,295 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isRangeError", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Error", new Error("not pie"));
-    pass("for RangeError", new RangeError("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isRangeError] Expected {  } to be a RangeError",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isRangeError] Nope: Expected {  } to be a RangeError",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isRangeError"
-        },
-        {}
-    );
+describe("assert.isRangeError", function() {
+    it("should fail for Error", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new Error());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected Error to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for EvalError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new EvalError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected EvalError to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for RangeError", function() {
+        referee.assert.isRangeError(new RangeError());
+    });
+
+    it("should fail for ReferenceError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new ReferenceError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected ReferenceError to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for SyntaxError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new SyntaxError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected SyntaxError to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for TypeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new TypeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected TypeError to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for URIError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new URIError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected URIError to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected apple pie to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected [] to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "5b298207-387b-4d2f-90c0-cb3514386c44";
+
+        assert.throws(
+            function() {
+                referee.assert.isRangeError(new Error(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isRangeError] " +
+                        message +
+                        ": Expected Error to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isRangeError");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isRangeError", function() {
+    it("should pass for Error", function() {
+        referee.refute.isRangeError(new Error());
+    });
+
+    it("should pass for EvalError", function() {
+        referee.refute.isRangeError(new EvalError());
+    });
+
+    it("should fail for RangeError", function() {
+        assert.throws(
+            function() {
+                referee.refute.isRangeError(new RangeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isRangeError] Expected RangeError not to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isRangeError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for ReferenceError", function() {
+        referee.refute.isRangeError(new ReferenceError());
+    });
+
+    it("should pass for SyntaxError", function() {
+        referee.refute.isRangeError(new SyntaxError());
+    });
+
+    it("should pass for TypeError", function() {
+        referee.refute.isRangeError(new TypeError());
+    });
+
+    it("should pass for URIError", function() {
+        referee.refute.isRangeError(new URIError());
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isRangeError("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isRangeError([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isRangeError({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isRangeError(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "9ac2e81f-e01a-401a-afe2-9b64fb5df461";
+
+        assert.throws(
+            function() {
+                referee.refute.isRangeError(new RangeError(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isRangeError] " +
+                        message +
+                        ": Expected RangeError not to be a RangeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isRangeError");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-reference-error.test.js
+++ b/lib/assertions/is-reference-error.test.js
@@ -1,37 +1,295 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isReferenceError", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Error", new Error("not pie"));
-    pass("for ReferenceError", new ReferenceError("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isReferenceError] Expected {  } to be a ReferenceError",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isReferenceError] Nope: Expected {  } to be a ReferenceError",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isReferenceError"
-        },
-        {}
-    );
+describe("assert.isReferenceError", function() {
+    it("should fail for Error", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new Error());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected Error to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for EvalError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new EvalError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected EvalError to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fal for RangeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new RangeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected RangeError to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for ReferenceError", function() {
+        referee.assert.isReferenceError(new ReferenceError());
+    });
+
+    it("should fail for SyntaxError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new SyntaxError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected SyntaxError to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for TypeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new TypeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected TypeError to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for URIError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new URIError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected URIError to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected apple pie to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected [] to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "d6ff6a83-f598-4592-b795-f39f6d4769d8";
+
+        assert.throws(
+            function() {
+                referee.assert.isReferenceError(new Error(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isReferenceError] " +
+                        message +
+                        ": Expected Error to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isReferenceError");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isReferenceError", function() {
+    it("should pass for Error", function() {
+        referee.refute.isReferenceError(new Error());
+    });
+
+    it("should pass for EvalError", function() {
+        referee.refute.isReferenceError(new EvalError());
+    });
+
+    it("should pass for RangeError", function() {
+        referee.refute.isReferenceError(new RangeError());
+    });
+
+    it("should fail for ReferenceError", function() {
+        assert.throws(
+            function() {
+                referee.refute.isReferenceError(new ReferenceError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isReferenceError] Expected ReferenceError not to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isReferenceError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for SyntaxError", function() {
+        referee.refute.isReferenceError(new SyntaxError());
+    });
+
+    it("should pass for TypeError", function() {
+        referee.refute.isReferenceError(new TypeError());
+    });
+
+    it("should pass for URIError", function() {
+        referee.refute.isReferenceError(new URIError());
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isReferenceError("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isReferenceError([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isReferenceError({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isReferenceError(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "aa4c2dc0-9b54-4ffb-9797-c3cc09449759";
+
+        assert.throws(
+            function() {
+                referee.refute.isReferenceError(new ReferenceError(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isReferenceError] " +
+                        message +
+                        ": Expected ReferenceError not to be a ReferenceError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isReferenceError");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-syntax-error.test.js
+++ b/lib/assertions/is-syntax-error.test.js
@@ -1,37 +1,295 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isSyntaxError", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Error", new Error("not pie"));
-    pass("for SyntaxError", new SyntaxError("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isSyntaxError] Expected {  } to be a SyntaxError",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isSyntaxError] Nope: Expected {  } to be a SyntaxError",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isSyntaxError"
-        },
-        {}
-    );
+describe("assert.isSyntaxError", function() {
+    it("should fail for Error", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new Error());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected Error to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for EvalError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new EvalError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected EvalError to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fal for RangeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new RangeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected RangeError to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for ReferenceError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new ReferenceError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected ReferenceError to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for SyntaxError", function() {
+        referee.assert.isSyntaxError(new SyntaxError());
+    });
+
+    it("should fail for TypeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new TypeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected TypeError to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for URIError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new URIError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected URIError to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected apple pie to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected [] to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "d5092be6-3193-408b-aa02-1cb5b58bf4bc";
+
+        assert.throws(
+            function() {
+                referee.assert.isSyntaxError(new Error(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isSyntaxError] " +
+                        message +
+                        ": Expected Error to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isSyntaxError");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isSyntaxError", function() {
+    it("should pass for Error", function() {
+        referee.refute.isSyntaxError(new Error());
+    });
+
+    it("should pass for EvalError", function() {
+        referee.refute.isSyntaxError(new EvalError());
+    });
+
+    it("should pass for RangeError", function() {
+        referee.refute.isSyntaxError(new RangeError());
+    });
+
+    it("should pass for ReferenceError", function() {
+        referee.refute.isSyntaxError(new ReferenceError());
+    });
+
+    it("should fail for SyntaxError", function() {
+        assert.throws(
+            function() {
+                referee.refute.isSyntaxError(new SyntaxError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isSyntaxError] Expected SyntaxError not to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isSyntaxError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for TypeError", function() {
+        referee.refute.isSyntaxError(new TypeError());
+    });
+
+    it("should pass for URIError", function() {
+        referee.refute.isSyntaxError(new URIError());
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isSyntaxError("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isSyntaxError([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isSyntaxError({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isSyntaxError(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "dfaac10d-6c38-4dc6-97c2-bb39a4c7f0d7";
+
+        assert.throws(
+            function() {
+                referee.refute.isSyntaxError(new SyntaxError(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isSyntaxError] " +
+                        message +
+                        ": Expected SyntaxError not to be a SyntaxError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isSyntaxError");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-type-error.test.js
+++ b/lib/assertions/is-type-error.test.js
@@ -1,37 +1,295 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isTypeError", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Error", new Error("not pie"));
-    pass("for TypeError", new TypeError("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isTypeError] Expected {  } to be a TypeError",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isTypeError] Nope: Expected {  } to be a TypeError",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isTypeError"
-        },
-        {}
-    );
+describe("assert.isTypeError", function() {
+    it("should fail for Error", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new Error());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected Error to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for EvalError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new EvalError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected EvalError to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fal for RangeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new RangeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected RangeError to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for ReferenceError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new ReferenceError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected ReferenceError to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for SyntaxError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new SyntaxError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected SyntaxError to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for TypeError", function() {
+        referee.assert.isTypeError(new TypeError());
+    });
+
+    it("should fail for URIError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new URIError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected URIError to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected apple pie to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected [] to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "2b16c1de-fa54-444a-855d-febcdf4b31b3";
+
+        assert.throws(
+            function() {
+                referee.assert.isTypeError(new Error(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isTypeError] " +
+                        message +
+                        ": Expected Error to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isTypeError");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isTypeError", function() {
+    it("should pass for Error", function() {
+        referee.refute.isTypeError(new Error());
+    });
+
+    it("should pass for EvalError", function() {
+        referee.refute.isTypeError(new EvalError());
+    });
+
+    it("should pass for RangeError", function() {
+        referee.refute.isTypeError(new RangeError());
+    });
+
+    it("should pass for ReferenceError", function() {
+        referee.refute.isTypeError(new ReferenceError());
+    });
+
+    it("should pass for SyntaxError", function() {
+        referee.refute.isTypeError(new SyntaxError());
+    });
+
+    it("should fail for TypeError", function() {
+        assert.throws(
+            function() {
+                referee.refute.isTypeError(new TypeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isTypeError] Expected TypeError not to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isTypeError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for URIError", function() {
+        referee.refute.isTypeError(new URIError());
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isTypeError("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isTypeError([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isTypeError({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isTypeError(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "d34333eb-f353-4589-8460-df8c9a8a273a";
+
+        assert.throws(
+            function() {
+                referee.refute.isTypeError(new TypeError(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isTypeError] " +
+                        message +
+                        ": Expected TypeError not to be a TypeError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isTypeError");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -1,37 +1,295 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
-testHelper.assertionTests("assert", "isURIError", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("for Error", new Error("not pie"));
-    pass("for URIError", new URIError("apple pie"));
-    fail("for string", "apple pie");
-    fail("for array", []);
-    fail("for object", {});
-    fail("for arguments", captureArgs());
-    msg(
-        "fail with descriptive message",
-        "[assert.isURIError] Expected {  } to be a URIError",
-        {}
-    );
-    msg(
-        "fail with custom message",
-        "[assert.isURIError] Nope: Expected {  } to be a URIError",
-        {},
-        "Nope"
-    );
-    error(
-        "for object",
-        {
-            code: "ERR_ASSERTION",
-            operator: "assert.isURIError"
-        },
-        {}
-    );
+describe("assert.isURIError", function() {
+    it("should fail for Error", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new Error());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected Error to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for EvalError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new EvalError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected EvalError to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fal for RangeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new RangeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected RangeError to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for ReferenceError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new ReferenceError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected ReferenceError to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for SyntaxError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new SyntaxError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected SyntaxError to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for TypeError", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new TypeError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected TypeError to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for URIError", function() {
+        referee.assert.isURIError(new URIError());
+    });
+
+    it("should fail for String", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError("apple pie");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected apple pie to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Array", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError([]);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected [] to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for Object", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected {  } to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail for arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.isURIError(captureArgs());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] Expected {  } to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with custom message", function() {
+        var message = "0bedeb92-f9c8-4440-95f7-e54ab7ecf728";
+
+        assert.throws(
+            function() {
+                referee.assert.isURIError(new Error(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.isURIError] " +
+                        message +
+                        ": Expected Error to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.isURIError");
+                return true;
+            }
+        );
+    });
+});
+
+describe("refute.isURIError", function() {
+    it("should pass for Error", function() {
+        referee.refute.isURIError(new Error());
+    });
+
+    it("should pass for EvalError", function() {
+        referee.refute.isURIError(new EvalError());
+    });
+
+    it("should pass for RangeError", function() {
+        referee.refute.isURIError(new RangeError());
+    });
+
+    it("should pass for ReferenceError", function() {
+        referee.refute.isURIError(new ReferenceError());
+    });
+
+    it("should fail for SyntaxError", function() {
+        referee.refute.isURIError(new SyntaxError());
+    });
+
+    it("should fail for TypeError", function() {
+        referee.refute.isURIError(new TypeError());
+    });
+
+    it("should pass for URIError", function() {
+        assert.throws(
+            function() {
+                referee.refute.isURIError(new URIError());
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isURIError] Expected URIError not to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isURIError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass for String", function() {
+        referee.refute.isURIError("apple pie");
+    });
+
+    it("should pass for Array", function() {
+        referee.refute.isURIError([]);
+    });
+
+    it("should pass for Object", function() {
+        referee.refute.isURIError({});
+    });
+
+    it("should pass for arguments", function() {
+        referee.refute.isURIError(captureArgs());
+    });
+
+    it("should fail with custom message", function() {
+        var message = "d0150e59-e58d-46c8-b932-e7d0280a0a79";
+
+        assert.throws(
+            function() {
+                referee.refute.isURIError(new URIError(), message);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.isURIError] " +
+                        message +
+                        ": Expected URIError not to be a URIError"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.isURIError");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
This PR is part of the ongoing effort to refactor the tests to use plain Mocha, and remove the difficult to understand test helper.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
