### PR TITLE
Feature detect Promise for old IE

### DIFF
--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var assert = require("assert");
 var sinon = require("sinon");
 var referee = require("./referee");
 
@@ -161,5 +162,23 @@ describe("custom assertions", function() {
         });
 
         referee.expect("foo").toBeFoo();
+    });
+
+    it("should not throw if Promise is not defined", function() {
+        // Let sinon restore global.Promise:
+        sinon.replace(global, "Promise", function() {});
+        delete global.Promise;
+
+        referee.add("custom", {
+            assert: function(actual) {
+                return Boolean(actual);
+            },
+            assertMessage: "${0} ${0}",
+            refuteMessage: "${0} ${0}"
+        });
+
+        assert.doesNotThrow(function() {
+            referee.assert.custom(1);
+        });
     });
 });

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -50,7 +50,7 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
 
         var result = func.apply(ctx, arguments);
 
-        if (result instanceof Promise) {
+        if (typeof Promise === "function" && result instanceof Promise) {
             // Here we need to return the promise in order to tell test
             // runners that this is an asychronous assertion.
             // eslint complains about the return statement, because it is


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This fixes an issue in IE 11 where `Promise` is not defined (see failing tests in https://github.com/sinonjs/samsam/pull/62).

#### Solution  - optional

Feature detect Promise support.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).