### PR TITLE
Fail when passing undefined as the expectation for equals

### DIFF
--- a/lib/assertions/equals.js
+++ b/lib/assertions/equals.js
@@ -14,6 +14,11 @@ module.exports = function(referee) {
         // Uses arguments[2] because the function's .length is used to determine
         // the minimum required number of arguments.
         assert: function(actual, expected) {
+            if (typeof expected === "undefined") {
+                return this.fail(
+                    "Expectation for equals should not be undefined. Use assert.defined or refute.defined instead."
+                );
+            }
             return samsam.deepEqual(actual, expected);
         },
         assertMessage:

--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -17,7 +17,7 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
     pass("when comparing numbers", 32, 32);
     pass("when comparing booleans", false, false);
     pass("when comparing null", null, null);
-    pass("when comparing undefined", undefined, undefined);
+    fail("when comparing undefined", undefined, undefined);
     pass("when comparing function to itself", func, func);
     fail("when comparing functions", function() {}, function() {});
     pass("when comparing array to itself", arr, arr);
@@ -292,7 +292,7 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
     pass("when comparing different objects", obj, {});
     pass("when comparing object to null", {}, null);
     pass("when comparing null to object", {}, null);
-    pass("when comparing object to undefined", {}, undefined);
+    fail("when comparing object to undefined", {}, undefined);
     pass("when comparing undefined to object", undefined, {});
     pass("when comparing object to false", {}, false);
     pass("when comparing false to object", false, {});


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This is up for discussion. It's a breaking change and I'm not 100% sure about it.

I noticed that `assert.equals(foo.property, bar.property)` would pass if both properties are not defined, although it's unlikely that this meets my expectation.

This change throws if the expectation is `undefined` with a message recommending the use of `assert.defined` or `refute.defined` instead.

What are your thoughts on this? If we want to try to protect against cases like these, are there other assertions that should be changed as well?

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
