### PR TITLE
Introduce isUndefined, deprecate defined

### DIFF
--- a/lib/assertions/defined.js
+++ b/lib/assertions/defined.js
@@ -1,11 +1,18 @@
 "use strict";
 
 var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+var deprecated = require("@sinonjs/commons").deprecated;
 
 module.exports = function(referee) {
+    function definedAssert(actual) {
+        return typeof actual !== "undefined";
+    }
     referee.add("defined", {
         assert: function(actual) {
-            return typeof actual !== "undefined";
+            return deprecated.wrap(
+                definedAssert,
+                "defined is deprecated and will be removed in the future. Please use isUndefined instead."
+            )(actual);
         },
         assertMessage: "${customMessage}Expected to be defined",
         refuteMessage:

--- a/lib/assertions/is-undefined.js
+++ b/lib/assertions/is-undefined.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var actualAndTypeOfMessageValues = require("../actual-and-type-of-message-values");
+
+module.exports = function(referee) {
+    referee.add("isUndefined", {
+        assert: function(actual) {
+            return typeof actual === "undefined";
+        },
+        assertMessage:
+            "${customMessage}Expected ${actual} (${actualType}) to be undefined",
+        refuteMessage:
+            "${customMessage}Expected ${actual} (${actualType}) not to be undefined",
+        expectation: "toBeUndefined",
+        values: actualAndTypeOfMessageValues
+    });
+};

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var testHelper = require("../test-helper");
+
+testHelper.assertionTests("assert", "isUndefined", function(
+    pass,
+    fail,
+    msg,
+    error
+) {
+    fail("for array", {});
+    fail("for boolean", true);
+    fail("for function", function() {});
+    fail("for null", null);
+    fail("for number", 42);
+    fail("for object", {});
+    fail("for string", "Test");
+    pass("for undefined", undefined);
+    msg(
+        "fail with descriptive message",
+        "[assert.isUndefined] Expected null (object) to be undefined",
+        null
+    );
+    msg(
+        "fail with custom message",
+        "[assert.isUndefined] fails: Expected null (object) to be undefined",
+        null,
+        "fails"
+    );
+    error(
+        "for null",
+        {
+            code: "ERR_ASSERTION",
+            operator: "assert.isUndefined"
+        },
+        null
+    );
+});

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var commons = require("@sinonjs/commons");
 var sinon = require("sinon");
 var referee = require("./referee");
 var expect = referee.expect;
@@ -11,6 +12,9 @@ describe("expect", function() {
         referee.on("pass", this.okListener);
         this.failListener = sinon.spy();
         referee.on("failure", this.failListener);
+        sinon.replace(commons.deprecated, "wrap", function(f) {
+            return f;
+        });
     });
 
     afterEach(function() {

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -96,6 +96,8 @@ describe("expect", function() {
         expect({}).not.toBeDate();
         expect(null).toBeDefined();
         expect(undefined).not.toBeDefined();
+        expect(undefined).toBeUndefined();
+        expect(null).not.toBeUndefined();
         expect(null).toBeNull();
         expect(42).not.toBeNull();
         expect(obj).toMatch({ id: 42 });

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -59,6 +59,7 @@ require("./assertions/is-symbol")(referee);
 require("./assertions/is-syntax-error")(referee);
 require("./assertions/is-true")(referee);
 require("./assertions/is-type-error")(referee);
+require("./assertions/is-undefined")(referee);
 require("./assertions/is-uri-error")(referee);
 require("./assertions/is-u-int-16-array")(referee);
 require("./assertions/is-u-int-32-array")(referee);

--- a/lib/test-helper/index.js
+++ b/lib/test-helper/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var commons = require("@sinonjs/commons");
 var referee = require("../referee");
 var sinon = require("sinon");
 var slice = require("@sinonjs/commons").prototypes.array.slice;
@@ -12,6 +13,9 @@ var testHelper = {
         referee.on("pass", testHelper.okListener);
         testHelper.failListener = sinon.spy();
         referee.on("failure", testHelper.failListener);
+        sinon.replace(commons.deprecated, "wrap", function(f) {
+            return f;
+        });
     },
 
     tearDown: function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,9 +138,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
       "requires": {
         "type-detect": "4.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
-    "@sinonjs/commons": "^1.3.0",
+    "@sinonjs/commons": "^1.4.0",
     "@sinonjs/formatio": "^3.1.0",
     "@sinonjs/samsam": "^3.0.0",
     "array-from": "2.1.1",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
This PR introduces an assertion called `isUndefined` that passes when the given value is `undefined`. This also deprecates the `defined` assertion


#### Background (Problem in detail)  - optional

See #87 #89 

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm run test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
