### PR TITLE
Update @sinonjs/samsam to v3.3.0 for symbol property support

### DIFF
--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -129,17 +129,20 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
 
+    pass("when comparing empty arguments to empty array", captureArgs(), []);
+
+    fail("when comparing empty array to empty arguments", [], captureArgs());
+
     pass(
-        "when comparing arguments to array",
-        [1, 2, {}, []],
-        captureArgs(1, 2, {}, [])
+        "when comparing arguments with elements to array with equal elements",
+        captureArgs(1, 2, {}, []),
+        [1, 2, {}, []]
     );
-    pass("when comparing array to arguments", captureArgs(), []);
 
     pass(
         "when comparing arguments to array like object",
-        arrayLike,
-        captureArgs(1, 2, {}, [])
+        captureArgs(1, 2, {}, []),
+        arrayLike
     );
 
     msg(
@@ -309,15 +312,19 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
     var arrayLike = { length: 4, "0": 1, "1": 2, "2": {}, "3": [] };
 
     fail(
-        "when comparing arguments to array",
-        [1, 2, {}, []],
-        captureArgs(1, 2, {}, [])
+        "when comparing arguments with elements to array with equal elements",
+        captureArgs(1, 2, {}, []),
+        [1, 2, {}, []]
     );
-    fail("when comparing array to arguments", captureArgs(), []);
+
+    fail("when comparing empty arguments to empty array", captureArgs(), []);
+
+    pass("when comparing empty array to empty arguments", [], captureArgs());
+
     fail(
         "when comparing arguments to array like object",
-        arrayLike,
-        captureArgs(1, 2, {}, [])
+        captureArgs(1, 2, {}, []),
+        arrayLike
     );
 
     msg(

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,23 +154,13 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.0.tgz",
-      "integrity": "sha512-HYQiZXtwBEtjLPPZ3/X/wiKFNY9fMrJEjdSvYfeUEgTmppNVuDVQKIYGNTdM08sHkfes17KaE0RLOwHSbA0/ww==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.0.tgz",
+      "integrity": "sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==",
       "requires": {
-        "@sinonjs/commons": "1.0.2",
+        "@sinonjs/commons": "^1.0.2",
         "array-from": "^2.1.1",
-        "lodash.get": "4.4.2"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-          "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "lodash": "^4.17.11"
       }
     },
     "acorn": {
@@ -2212,13 +2202,13 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",
     "@sinonjs/formatio": "^3.1.0",
-    "@sinonjs/samsam": "^3.0.0",
+    "@sinonjs/samsam": "^3.3.0",
     "array-from": "2.1.1",
     "bane": "^1.x",
     "lodash.includes": "^4.3.0",


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This updates samsam to `v3.3.0` to [add symbol property support](https://github.com/sinonjs/samsam/pull/64) and fixes the related test cases.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).