### PR TITLE
Get rid of test helper from near.spec.js

### DIFF
--- a/lib/assertions/near.test.js
+++ b/lib/assertions/near.test.js
@@ -1,75 +1,63 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
-testHelper.assertionTests("assert", "near", function(pass, fail, msg, error) {
-    pass("for equal numbers", 3, 3, 0);
-    fail("for numbers out of delta range", 2, 3, 0.5);
-    msg(
-        "fail with descriptive message",
-        "[assert.near] Expected 3 to be equal to 2 +/- 0.6",
-        3,
-        2,
-        0.6
-    );
-    msg(
-        "fail with custom message",
-        "[assert.near] Ho! Expected 3 to be equal to 2 +/- 0.6",
-        3,
-        2,
-        0.6,
-        "Ho!"
-    );
-    pass("for numbers in delta range", 2, 3, 1);
-    msg(
-        "fail if not passed arguments",
-        "[assert.near] Expected to receive at least 3 arguments"
-    );
-    error(
-        "for numbers out of delta range",
-        {
-            code: "ERR_ASSERTION",
-            actual: 2,
-            expected: 3,
-            operator: "assert.near"
-        },
-        2,
-        3,
-        0.5
-    );
-});
-
-testHelper.assertionTests("refute", "near", function(pass, fail, msg, error) {
-    fail("for equal numbers", 3, 3, 0);
-    pass("for numbers out of delta range", 2, 3, 0.5);
-    msg(
-        "with descriptive message",
-        "[refute.near] Expected 3 not to be equal to 3 +/- 0",
-        3,
-        3,
-        0
-    );
-    msg(
-        "with custom message",
-        "[refute.near] Hey: Expected 3 not to be equal to 3 +/- 0",
-        3,
-        3,
-        0,
-        "Hey"
-    );
-    fail("for numbers in delta range", 2, 3, 1);
-    msg(
-        "fail if not passed arguments",
-        "[refute.near] Expected to receive at least 3 arguments"
-    );
-    error(
-        "for equal numbers",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.near"
-        },
-        3,
-        3,
-        0
-    );
+describe("assert.near", function() {
+    it("should pass for equal numbers", function() {
+        referee.assert.near(3, 3, 0);
+    });
+    it("should pass for numbers in delta range", function() {
+        referee.assert.near(2, 3, 1);
+    });
+    it("should fail for numbers out of delta range", function() {
+        assert.throws(
+            function() {
+                referee.assert.near(2, 3, 0.5);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.near] Expected 2 to be equal to 3 +/- 0.5"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.near");
+                return true;
+            }
+        );
+    });
+    it("should fail with custom range", function() {
+        assert.throws(
+            function() {
+                referee.assert.near(3, 2, 0.6, "Ho!");
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.near] Ho! Expected 3 to be equal to 2 +/- 0.6"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.near");
+                return true;
+            }
+        );
+    });
+    it("should fail if not passed any arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.near();
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.near] Expected to receive at least 3 arguments"
+                );
+                assert.equal(error.name, "AssertionError");
+                return true;
+            }
+        );
+    });
 });


### PR DESCRIPTION
Remove test helper from spec to lower barrier of entry to the codebase