### PR TITLE
Add tests for internal helper assertArgNum

### DIFF
--- a/lib/assert-arg-num.test.js
+++ b/lib/assert-arg-num.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+var assert = require("assert");
+var sinon = require("sinon");
+var assertArgNum = require("./assert-arg-num");
+
+describe("assertArgNum", function() {
+    describe("when number of arguments is equal to expected", function() {
+        it("should return true", function() {
+            var defaultFail = sinon.fake();
+            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+            var expected = 2;
+            var args = new Array(expected);
+            var actual = assertArgNum(defaultFail, name, args, expected);
+
+            assert.equal(actual, true);
+        });
+
+        it("should not call `defaultFail` argument", function() {
+            var defaultFail = sinon.fake();
+            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+            var expected = 2;
+            var args = new Array(expected);
+
+            assertArgNum(defaultFail, name, args, expected);
+
+            assert.equal(defaultFail.called, false);
+        });
+
+        it("should not call `customFail` argument", function() {
+            var defaultFail = sinon.fake();
+            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+            var expected = 2;
+            var args = new Array(expected);
+            var customFail = sinon.fake();
+
+            assertArgNum(defaultFail, name, args, expected, customFail);
+
+            assert.equal(customFail.called, false);
+        });
+    });
+
+    describe("when number of arguments is greater than expected", function() {
+        it("should return true", function() {
+            var fail = sinon.fake();
+            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+            var expected = 3;
+            var greaterThanExpected = expected + 1;
+            var args = new Array(greaterThanExpected);
+            var actual = assertArgNum(fail, name, args, expected);
+
+            assert.equal(actual, true);
+        });
+    });
+
+    describe("when number of arguments is smaller than expected", function() {
+        it("should call defaultFail with message", function() {
+            var fail = sinon.fake();
+            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+            var expected = 1;
+            var smallerThanExpected = expected - 1;
+            var args = new Array(smallerThanExpected);
+
+            assertArgNum(fail, name, args, expected);
+
+            var expectedMessage =
+                "[" +
+                name +
+                "] Expected to receive at least " +
+                expected +
+                " argument";
+
+            assert.equal(fail.calledOnce, true);
+            assert.equal(fail.getCall(0).args[0], expectedMessage);
+        });
+
+        context("when passed customFail argument", function() {
+            it("should call customFail with message", function() {
+                var fail = sinon.fake();
+                var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
+                var expected = 3;
+                var smallerThanExpected = expected - 1;
+                var args = new Array(smallerThanExpected);
+                var customFail = sinon.fake();
+
+                assertArgNum(fail, name, args, expected, customFail);
+
+                var expectedMessage =
+                    "[" +
+                    name +
+                    "] Expected to receive at least " +
+                    expected +
+                    " arguments";
+
+                assert.equal(fail.calledOnce, false);
+                assert.equal(customFail.calledOnce, true);
+                assert.equal(customFail.getCall(0).args[0], expectedMessage);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This was only implicitly covered by other tests. As they change when we
rewrite those to not use `testHelper` but plain Mocha + node assert,
then coverage for this helper drops below the threshold.

Ultimately, I'd like to rewrite this, so that it doesn't have two arguments for failing, but that will touch a lot of files, so I'll do that in a later PR.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
