### PR TITLE
Rewrite tests for hasPrototype

### DIFF
--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var testHelper = require("../test-helper");
+var assert = require("assert");
+var referee = require("../referee");
 
 function MyThing() {}
 var myThing = new MyThing();
@@ -9,102 +10,217 @@ function F() {}
 F.prototype = myThing;
 var specializedThing = new F();
 
-testHelper.assertionTests("assert", "hasPrototype", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail(
-        "when object does not inherit from prototype",
-        otherThing,
-        MyThing.prototype
-    );
-    fail(
-        "when primitive does not inherit from prototype",
-        3,
-        MyThing.prototype
-    );
-    fail("with only one object", {});
-    pass(
-        "when object has other object on prototype chain",
-        myThing,
-        MyThing.prototype
-    );
-    pass("when not directly inheriting", specializedThing, MyThing.prototype);
-    msg(
-        "with descriptive message",
-        "[assert.hasPrototype] Expected {  } to have [MyThing] {  } on its prototype chain",
-        otherThing,
-        MyThing.prototype
-    );
-    msg(
-        "with custom message",
-        "[assert.hasPrototype] Oh: Expected {  } to have [MyThing] {  } on its prototype chain",
-        otherThing,
-        MyThing.prototype,
-        "Oh"
-    );
-    msg(
-        "fail if not passed arguments",
-        "[assert.hasPrototype] Expected to receive at least 2 arguments"
-    );
-    error(
-        "when object does not inherit from prototype",
-        {
-            code: "ERR_ASSERTION",
-            actual: otherThing,
-            expected: MyThing.prototype,
-            operator: "assert.hasPrototype"
-        },
-        otherThing,
-        MyThing.prototype
-    );
+describe("assert.hasPrototype", function() {
+    it("should fail when object does not inherit from prototype", function() {
+        assert.throws(
+            function() {
+                referee.assert.hasPrototype(otherThing, MyThing.prototype);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.hasPrototype] Expected {  } to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.hasPrototype");
+                return true;
+            }
+        );
+    });
+
+    it("should fail when primitive does not inherit from prototype", function() {
+        assert.throws(
+            function() {
+                referee.assert.hasPrototype(3, MyThing.prototype);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.hasPrototype] Expected 3 to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.hasPrototype");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with no arguments", function() {
+        assert.throws(
+            function() {
+                referee.assert.hasPrototype();
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.hasPrototype] Expected to receive at least 2 arguments"
+                );
+                assert.equal(error.name, "AssertionError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with only one object", function() {
+        assert.throws(
+            function() {
+                referee.assert.hasPrototype({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.hasPrototype] Expected to receive at least 2 arguments"
+                );
+                assert.equal(error.name, "AssertionError");
+                return true;
+            }
+        );
+    });
+
+    it("should pass when object has other object on prototype chain", function() {
+        referee.assert.hasPrototype(myThing, MyThing.prototype);
+    });
+
+    it("should pass when object has other object as ancestor", function() {
+        referee.assert.hasPrototype(specializedThing, MyThing.prototype);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "272bbe5f-e863-490b-9ed0-6af2e95b4b0e";
+
+        assert.throws(
+            function() {
+                referee.assert.hasPrototype(
+                    otherThing,
+                    MyThing.prototype,
+                    message
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[assert.hasPrototype] " +
+                        message +
+                        ": Expected {  } to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "assert.hasPrototype");
+                return true;
+            }
+        );
+    });
 });
 
-testHelper.assertionTests("refute", "hasPrototype", function(
-    pass,
-    fail,
-    msg,
-    error
-) {
-    fail("when object inherits from prototype", myThing, MyThing.prototype);
-    fail(
-        "when not inheriting 'indirectly'",
-        specializedThing,
-        MyThing.prototype
-    );
-    fail("with only one object", {});
-    pass(
-        "when primitive does not inherit from prototype",
-        3,
-        MyThing.prototype
-    );
-    pass("when object does not inherit", otherThing, MyThing.prototype);
-    msg(
-        "with descriptive message",
-        "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain",
-        myThing,
-        MyThing.prototype
-    );
-    msg(
-        "with descriptive message",
-        "[refute.hasPrototype] Oh: Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain",
-        myThing,
-        MyThing.prototype,
-        "Oh"
-    );
-    msg(
-        "fail if not passed arguments",
-        "[refute.hasPrototype] Expected to receive at least 2 arguments"
-    );
-    error(
-        "when object inherits from prototype",
-        {
-            code: "ERR_ASSERTION",
-            operator: "refute.hasPrototype"
-        },
-        myThing,
-        MyThing.prototype
-    );
+describe("refute.hasPrototype", function() {
+    it("should fail with no arguments", function() {
+        assert.throws(
+            function() {
+                referee.refute.hasPrototype();
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.hasPrototype] Expected to receive at least 2 arguments"
+                );
+                assert.equal(error.name, "AssertionError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail with only one object", function() {
+        assert.throws(
+            function() {
+                referee.refute.hasPrototype({});
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.hasPrototype] Expected to receive at least 2 arguments"
+                );
+                assert.equal(error.name, "AssertionError");
+                return true;
+            }
+        );
+    });
+
+    it("should fail when object inherits from prototype", function() {
+        assert.throws(
+            function() {
+                referee.refute.hasPrototype(myThing, MyThing.prototype);
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.hasPrototype");
+                return true;
+            }
+        );
+    });
+
+    it("should fail when object has prototype as ancestor", function() {
+        assert.throws(
+            function() {
+                referee.refute.hasPrototype(
+                    specializedThing,
+                    MyThing.prototype
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.hasPrototype");
+                return true;
+            }
+        );
+    });
+
+    it("should pass when primitive does not inherit from prototype", function() {
+        referee.refute.hasPrototype(3, MyThing);
+    });
+
+    it("should pass when object does not inherit", function() {
+        referee.refute.hasPrototype(otherThing, MyThing);
+    });
+
+    it("should fail with custom message", function() {
+        var message = "d4aea902-44f2-4ba1-a33e-503132f82eca";
+
+        assert.throws(
+            function() {
+                referee.refute.hasPrototype(
+                    specializedThing,
+                    MyThing.prototype,
+                    message
+                );
+            },
+            function(error) {
+                assert.equal(error.code, "ERR_ASSERTION");
+                assert.equal(
+                    error.message,
+                    "[refute.hasPrototype] " +
+                        message +
+                        ": Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                );
+                assert.equal(error.name, "AssertionError");
+                assert.equal(error.operator, "refute.hasPrototype");
+                return true;
+            }
+        );
+    });
 });

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -11,9 +11,7 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
         var fullName = type + "." + name;
         var failed = false;
 
-        if (!assertArgNum(referee.fail, fullName, arguments, minArgs)) {
-            return;
-        }
+        assertArgNum(referee.fail, fullName, arguments, minArgs);
 
         var args = slice(arguments, 0);
         var namedValues = {};
@@ -53,10 +51,6 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
         if (typeof Promise === "function" && result instanceof Promise) {
             // Here we need to return the promise in order to tell test
             // runners that this is an asychronous assertion.
-            // eslint complains about the return statement, because it is
-            // not expected here, so let's ignore.
-            // https://eslint.org/docs/rules/consistent-return
-            /* eslint-disable-next-line consistent-return */
             return result.then(function() {
                 referee.pass(["pass", fullName].concat(args));
             });
@@ -71,6 +65,8 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
         if (!failed) {
             referee.pass(["pass", fullName].concat(args));
         }
+
+        return undefined;
     };
 
     return assertion;


### PR DESCRIPTION
This PR rewrites the tests for `hasPrototype`

While working on this, I discovered the unnecessary conditional in `defineAssertion`, so the first commit is for that.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
