### PR TITLE
Refactor assertArgNum to remove customFail arg

### DIFF
--- a/lib/assert-arg-num.js
+++ b/lib/assert-arg-num.js
@@ -2,22 +2,14 @@
 
 // Internal helper. Used throughout to fail assertions if they receive
 // too few arguments. The name is provided for a helpful error message.
-function assertArgNum(defaultFail, name, args, num, customFail) {
-    var fail = customFail || defaultFail;
-
-    if (args.length < num) {
-        fail(
-            "[" +
-                name +
-                "] Expected to receive at least " +
-                num +
-                " argument" +
-                (num > 1 ? "s" : "")
-        );
-        return false;
+function assertArgNum(fail, name, args, num) {
+    if (args.length >= num) {
+        return true;
     }
 
-    return true;
+    fail("[" + name + "] Expected to receive at least " + num + " argument(s)");
+
+    return false;
 }
 
 module.exports = assertArgNum;

--- a/lib/assert-arg-num.test.js
+++ b/lib/assert-arg-num.test.js
@@ -26,18 +26,6 @@ describe("assertArgNum", function() {
 
             assert.equal(defaultFail.called, false);
         });
-
-        it("should not call `customFail` argument", function() {
-            var defaultFail = sinon.fake();
-            var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
-            var expected = 2;
-            var args = new Array(expected);
-            var customFail = sinon.fake();
-
-            assertArgNum(defaultFail, name, args, expected, customFail);
-
-            assert.equal(customFail.called, false);
-        });
     });
 
     describe("when number of arguments is greater than expected", function() {
@@ -68,34 +56,10 @@ describe("assertArgNum", function() {
                 name +
                 "] Expected to receive at least " +
                 expected +
-                " argument";
+                " argument(s)";
 
             assert.equal(fail.calledOnce, true);
             assert.equal(fail.getCall(0).args[0], expectedMessage);
-        });
-
-        context("when passed customFail argument", function() {
-            it("should call customFail with message", function() {
-                var fail = sinon.fake();
-                var name = "14ea32a5-8465-4396-8c14-5421da8c2b52";
-                var expected = 3;
-                var smallerThanExpected = expected - 1;
-                var args = new Array(smallerThanExpected);
-                var customFail = sinon.fake();
-
-                assertArgNum(fail, name, args, expected, customFail);
-
-                var expectedMessage =
-                    "[" +
-                    name +
-                    "] Expected to receive at least " +
-                    expected +
-                    " arguments";
-
-                assert.equal(fail.calledOnce, false);
-                assert.equal(customFail.calledOnce, true);
-                assert.equal(customFail.getCall(0).args[0], expectedMessage);
-            });
         });
     });
 });

--- a/lib/assert.test.js
+++ b/lib/assert.test.js
@@ -17,7 +17,7 @@ describe("assert", function() {
             } catch (error) {
                 referee.assert.equals(
                     error.message,
-                    "[assert] Expected to receive at least 1 argument"
+                    "[assert] Expected to receive at least 1 argument(s)"
                 );
             }
         });
@@ -112,7 +112,7 @@ describe("assert", function() {
         } catch (e) {
             referee.assert.equals(
                 e.message,
-                "[assert] Expected to receive at least 1 argument"
+                "[assert] Expected to receive at least 1 argument(s)"
             );
         }
     });

--- a/lib/assertions/class-name.test.js
+++ b/lib/assertions/class-name.test.js
@@ -13,7 +13,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Expected to receive at least 2 arguments"
+                    "[assert.className] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -30,7 +30,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Expected to receive at least 2 arguments"
+                    "[assert.className] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -135,7 +135,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected to receive at least 2 arguments"
+                    "[refute.className] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -152,7 +152,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected to receive at least 2 arguments"
+                    "[refute.className] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;

--- a/lib/assertions/exception.test.js
+++ b/lib/assertions/exception.test.js
@@ -117,7 +117,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "if not passed arguments",
-        "[assert.exception] Expected to receive at least 1 argument"
+        "[assert.exception] Expected to receive at least 1 argument(s)"
     );
 });
 
@@ -148,6 +148,6 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
 
     msg(
         "fail if not passed arguments",
-        "[refute.exception] Expected to receive at least 1 argument"
+        "[refute.exception] Expected to receive at least 1 argument(s)"
     );
 });

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -56,7 +56,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected to receive at least 2 arguments"
+                    "[assert.hasPrototype] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -73,7 +73,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected to receive at least 2 arguments"
+                    "[assert.hasPrototype] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -126,7 +126,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected to receive at least 2 arguments"
+                    "[refute.hasPrototype] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -143,7 +143,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected to receive at least 2 arguments"
+                    "[refute.hasPrototype] Expected to receive at least 2 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;

--- a/lib/assertions/is-true.test.js
+++ b/lib/assertions/is-true.test.js
@@ -73,7 +73,7 @@ describe("isTrue", function() {
         assert.equal(actual.code, "ERR_ASSERTION");
         assert.equal(
             actual.message,
-            "[assert.isTrue] Expected to receive at least 1 argument"
+            "[assert.isTrue] Expected to receive at least 1 argument(s)"
         );
     });
 });

--- a/lib/assertions/near.test.js
+++ b/lib/assertions/near.test.js
@@ -53,7 +53,7 @@ describe("assert.near", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.near] Expected to receive at least 3 arguments"
+                    "[assert.near] Expected to receive at least 3 argument(s)"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;

--- a/lib/refute.test.js
+++ b/lib/refute.test.js
@@ -16,7 +16,7 @@ describe("refute", function() {
             } catch (error) {
                 referee.assert.equals(
                     error.message,
-                    "[refute] Expected to receive at least 1 argument"
+                    "[refute] Expected to receive at least 1 argument(s)"
                 );
             }
         });
@@ -107,7 +107,7 @@ describe("refute", function() {
         } catch (e) {
             referee.assert.equals(
                 e.message,
-                "[refute] Expected to receive at least 1 argument"
+                "[refute] Expected to receive at least 1 argument(s)"
             );
         }
     });


### PR DESCRIPTION
#### Purpose (TL;DR)
Remove `customFailArg`. It's only being used in tests.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
