### PR TITLE
Optional expects argument for rejects()

### DIFF
--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -12,7 +12,7 @@ module.exports = function(referee) {
     }
     referee.add("rejects", {
         assert: createAsyncAssertion(thenCallback, function(actual, expected) {
-            if (!samsam.identical(actual, expected)) {
+            if (expected !== undefined && !samsam.identical(actual, expected)) {
                 this.reject(assertMessage);
                 return;
             }

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -44,6 +44,12 @@ describe("assert.rejects", function() {
                 });
         });
     });
+
+    context("when no expected is provided", function() {
+        it("should resolve the returned promise", function() {
+            return referee.assert.rejects(Promise.reject(new Error("ignored")));
+        });
+    });
 });
 
 describe("refute.rejects", function() {

--- a/lib/create-async-assertion.js
+++ b/lib/create-async-assertion.js
@@ -1,9 +1,9 @@
 "use strict";
 
 function createAsyncAssertion(thenFunc, catchFunc) {
-    function asyncAssertion(promise, expected) {
+    function asyncAssertion(promise) {
         var self = this;
-        this.expected = expected;
+        var expected = (this.expected = arguments[1]);
         function applyCallback(callback, context) {
             return function(actual) {
                 self.actual = actual;


### PR DESCRIPTION
I want to be able to assert an async function rejects without having to detail the exact rejection value. This is primarily to deal with an async function that throws. e.g.

```js
async foo (bar) {
  if (typeof bar !== 'number') throw new TypeError('`bar` should be a number')
  ...
}

...

await referee.assert.rejects(foo('nope'))
```
