### PR TITLE
Improve CircleICI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
   build-common: &common-build
     docker:
       - image: node
-    environment:
-      NPM_VERSION: "5.7.0"
     working_directory: ~/source
     steps:
       - checkout
@@ -13,11 +11,8 @@ jobs:
             - v1-npm-{{ checksum "package-lock.json" }}
       - run:
           name: Install dependencies
-            # Ensure `ci` command is present
-            # Once we drop node 6, we no longer need to force install npm@6
           command: |
             if [ ! -d node_modules ]; then
-                sudo npm install -g npm@$NPM_VERSION
                 npm ci
             fi
       - save_cache:
@@ -28,7 +23,7 @@ jobs:
           name: Lint
           # ESLint only supports Node >=4
           command: |
-            if node --version | grep -q '^v10'; then
+            if node --version | grep -q '^v12'; then
                 npm run lint
             fi
       - run:
@@ -37,14 +32,9 @@ jobs:
       - run:
           name: Upload coverage report
           command: |
-            if node --version | grep -q '^v10'; then
+            if node --version | grep -q '^v12'; then
                 bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
             fi
-
-  node-6:
-    <<: *common-build
-    docker:
-      - image: circleci/node:6
 
   node-8:
     <<: *common-build
@@ -56,10 +46,17 @@ jobs:
     docker:
       - image: circleci/node:10
 
+  node-12:
+    <<: *common-build
+    docker:
+      - image: circleci/node:12
+
+
+
 workflows:
   version: 2
   build:
     jobs:
-      - node-6
       - node-8
       - node-10
+      - node-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,24 @@
 version: 2.1
+
+references:
+  x-workdir: &work-dir
+    working_directory: ~/source
+
+  x-save-workspace: &persist-step
+    persist_to_workspace:
+      root: ~/source
+      paths:
+        - .
+
+  x-attach: &attach-step
+    attach_workspace:
+      at: .
+
 jobs:
-  build-common: &common-build
+  install-dependencies:
+    <<: *work-dir
     docker:
       - image: node
-    working_directory: ~/source
     steps:
       - checkout
       - restore_cache:
@@ -19,44 +34,62 @@ jobs:
           key: v1-npm-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
+      - *persist-step
+
+  lint:
+    <<: *work-dir
+    docker:
+      - image: node
+    steps:
+      - *attach-step
       - run:
-          name: Lint
-          # ESLint only supports Node >=4
-          command: |
-            if node --version | grep -q '^v12'; then
-                npm run lint
-            fi
+          name: lint
+          command: npm run lint
+
+  node-8:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - *attach-step
       - run:
           name: Test
+          command: npm test
+
+  node-10:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - *attach-step
+      - run:
+          name: Test
+          command: npm test
+
+  node-12:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - *attach-step
+      - run:
+          name: Test with coverage
           command: npm run test-check-coverage
       - run:
           name: Upload coverage report
-          command: |
-            if node --version | grep -q '^v12'; then
-                bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
-            fi
-
-  node-8:
-    <<: *common-build
-    docker:
-      - image: circleci/node:8
-
-  node-10:
-    <<: *common-build
-    docker:
-      - image: circleci/node:10
-
-  node-12:
-    <<: *common-build
-    docker:
-      - image: circleci/node:12
-
-
+          command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
 workflows:
   version: 2
-  build:
+  referee:
     jobs:
-      - node-8
-      - node-10
-      - node-12
+      - install-dependencies
+      - lint:
+          requires:
+            - install-dependencies
+      - node-8:
+          requires:
+            - install-dependencies
+      - node-10:
+          requires:
+            - install-dependencies
+      - node-12:
+          requires:
+            - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
     <<: *work-dir
     docker:
       - image: node
+    environment:
+      HUSKY_SKIP_INSTALL: 1
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This PR improves the CircleCI setup

* Stop testing in node 6
* Start testing in node 12
* Install dependencies once
* Only run the linter once
* Only measure coverage once
* Prevent husky from installing git hooks

![2019-08-22 at 13 35](https://user-images.githubusercontent.com/20321/63511695-2a217700-c4e2-11e9-845f-b143094dec98.png)

#### How to verify - mandatory

1. If CircleCI has approved the PR, then it's good :)

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
