### PR TITLE
Fix using a regexp matcher to assert exceptions

### DIFF
--- a/lib/assertions/exception.js
+++ b/lib/assertions/exception.js
@@ -45,16 +45,17 @@ module.exports = function(referee) {
             }
 
             if (typeof matcher === "object" && !samsam.match(err, matcher)) {
+                var matches = false;
                 var prop;
                 for (prop in matcher) {
-                    if (
-                        hasOwnProperty(matcher, prop) &&
-                        !samsam.match(err[prop], matcher[prop])
-                    ) {
-                        return this.fail(typeFailMessage);
+                    if (hasOwnProperty(matcher, prop)) {
+                        if (!samsam.match(err[prop], matcher[prop])) {
+                            return this.fail(typeFailMessage);
+                        }
+                        matches = true;
                     }
                 }
-                return true;
+                return matches;
             }
 
             if (typeof matcher === "function" && matcher(err) !== true) {

--- a/lib/assertions/exception.test.js
+++ b/lib/assertions/exception.test.js
@@ -119,6 +119,34 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
         "if not passed arguments",
         "[assert.exception] Expected to receive at least 1 argument(s)"
     );
+
+    pass(
+        "when matcher regexp matches",
+        function() {
+            throw new TypeError("Aright");
+        },
+        /right/
+    );
+
+    fail(
+        "when matcher regexp does not match",
+        function() {
+            throw new TypeError("Aright");
+        },
+        /nope/
+    );
+
+    function Matcher() {
+        this.name = "TypeError";
+    }
+    Matcher.prototype.message = "Nope";
+    pass(
+        "when non own property of object does not match",
+        function() {
+            throw new TypeError("Aright");
+        },
+        new Matcher()
+    );
 });
 
 testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The documentation claims that any object used to verify `assert.exception` calls is passed to the `match` API for assertion. In case that fails, we iterate over the properties of the object to check for non-matching properties. In case of a regular expression that fails the test, there are no own properties to iterate and tests always complete without error, even if the regexp does not match.

The solution is to check if at least one property was iterated.

I also had to add another test to verify the `else` case of the `hasOwnProperty` check for coverage.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
