### PR TITLE
Exception in values

### DIFF
--- a/lib/assertions/match-json.js
+++ b/lib/assertions/match-json.js
@@ -29,9 +29,7 @@ module.exports = function(referee) {
             } catch (e) {
                 // Do nothing
             }
-            if (parsed) {
-                parsed = actualForMatch(parsed, matcher);
-            }
+            parsed = actualForMatch(parsed, matcher);
             return {
                 actualRaw: actual,
                 actual: parsed || actual,

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -181,4 +181,21 @@ describe("custom assertions", function() {
             referee.assert.custom(1);
         });
     });
+
+    it("should not throw if values function throws", function() {
+        referee.add("custom", {
+            assert: function(actual) {
+                return Boolean(actual);
+            },
+            assertMessage: "${0} ${0}",
+            refuteMessage: "${0} ${0}",
+            values: function() {
+                throw new Error("Oups!");
+            }
+        });
+
+        assert.doesNotThrow(function() {
+            referee.assert.custom(1);
+        });
+    });
 });

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -16,12 +16,12 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
         var args = slice(arguments, 0);
         var namedValues = {};
 
-        if (typeof messageValues === "function") {
-            namedValues = messageValues.apply(this, args);
-        }
-
         var ctx = {
             fail: function(msg) {
+                if (typeof messageValues === "function") {
+                    namedValues = messageValues.apply(this, args);
+                }
+
                 failed = true;
                 delete this.fail;
                 var message = referee[type][name][msg] || msg;


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

The `values` function should only be invoked if a failure occurred. Currently this function is invoked for passing tests as well.

I removed a superfluous conditional in `match-json.js` which was highlighted by the coverage report, now that the function isn't invoked on passing tests anymore.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
