### PR TITLE
Replace formatio with node's util.inspect

### DIFF
--- a/lib/assert-exception-unexpected-exception.test.js
+++ b/lib/assert-exception-unexpected-exception.test.js
@@ -7,7 +7,7 @@ describe("assert.exception unexpected exception", function() {
         try {
             referee.assert.exception(
                 function() {
-                    throw new Error(":(");
+                    throw new Error("apple pie");
                 },
                 { name: "TypeError" },
                 "Wow"
@@ -16,9 +16,7 @@ describe("assert.exception unexpected exception", function() {
         } catch (e) {
             referee.assert.match(
                 e.message,
-                "[assert.exception] Wow: Expected " +
-                    '{ name: "TypeError" } but threw Error ' +
-                    "(:()\nError: :(\n"
+                "Wow: Expected { name: 'TypeError' } but threw 'Error' ('apple pie')"
             );
         }
     });
@@ -27,7 +25,7 @@ describe("assert.exception unexpected exception", function() {
         try {
             referee.assert.exception(
                 function() {
-                    throw new Error(":(");
+                    throw new Error("apple pie");
                 },
                 { name: "Error", message: "Aww" },
                 "Wow"
@@ -36,9 +34,7 @@ describe("assert.exception unexpected exception", function() {
         } catch (e) {
             referee.assert.match(
                 e.message,
-                "[assert.exception] Wow: Expected " +
-                    '{ message: "Aww", name: "Error" } but threw ' +
-                    "Error (:()\nError: :(\n"
+                "Wow: Expected { name: 'Error', message: 'Aww' } but threw 'Error' ('apple pie')"
             );
         }
     });

--- a/lib/assertions/class-name.test.js
+++ b/lib/assertions/class-name.test.js
@@ -65,7 +65,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Nope: Expected object's className to include item but was (empty string)"
+                    "[assert.className] Nope: Expected object's className to include 'item' but was ''"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.className");
@@ -94,7 +94,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Expected object's className to include item post but was feed item"
+                    "[assert.className] Expected object's className to include 'item post' but was 'feed item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.className");
@@ -209,7 +209,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item"
+                    "[refute.className] Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -234,7 +234,7 @@ describe("refute.className", function() {
                     error.message,
                     "[refute.className] " +
                         message +
-                        ": Expected object's className not to include item"
+                        ": Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -251,7 +251,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item"
+                    "[refute.className] Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -275,7 +275,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item post"
+                    "[refute.className] Expected object's className not to include 'item post'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -292,7 +292,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include e a d"
+                    "[refute.className] Expected object's className not to include 'e a d'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -313,7 +313,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.className] Expected object\'s className not to include ["e", "a", "d"]'
+                    "[refute.className] Expected object's className not to include [ 'e', 'a', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;

--- a/lib/assertions/contains.test.js
+++ b/lib/assertions/contains.test.js
@@ -17,7 +17,7 @@ describe("assert.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.contains] Expected [0, 1, 2] to contain 3"
+                    "[assert.contains] Expected [ 0, 1, 2 ] to contain 3"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -39,7 +39,7 @@ describe("assert.contains", function() {
                     error.message,
                     "[assert.contains] " +
                         message +
-                        ": Expected [0, 1, 2] to contain 3"
+                        ": Expected [ 0, 1, 2 ] to contain 3"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -66,7 +66,7 @@ describe("assert.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.contains] Expected [{  }] to contain {  }"
+                    "[assert.contains] Expected [ {} ] to contain {}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -86,7 +86,7 @@ describe("refute.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.contains] Expected [0, 1, 2] not to contain 1"
+                    "[refute.contains] Expected [ 0, 1, 2 ] not to contain 1"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");
@@ -108,7 +108,7 @@ describe("refute.contains", function() {
                     error.message,
                     "[refute.contains] " +
                         message +
-                        ": Expected [0, 1, 2] not to contain 1"
+                        ": Expected [ 0, 1, 2 ] not to contain 1"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");
@@ -132,7 +132,7 @@ describe("refute.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.contains] Expected [{  }] not to contain {  }"
+                    "[refute.contains] Expected [ {} ] not to contain {}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");

--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -151,14 +151,14 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail with understandable message",
-        "[assert.equals] {  } expected to be equal to Hey",
+        "[assert.equals] {} expected to be equal to 'Hey'",
         {},
         "Hey"
     );
 
     msg(
         "fail with custom message",
-        "[assert.equals] Here: {  } expected to be equal to Hey",
+        "[assert.equals] Here: {} expected to be equal to 'Hey'",
         {},
         "Hey",
         "Here:"
@@ -166,21 +166,21 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail for multi-line strings",
-        "[assert.equals] Yo!\\nMultiline expected to be equal to Yo!\\nHey",
+        "[assert.equals] 'Yo!\\\\nMultiline' expected to be equal to 'Yo!\\\\nHey'",
         "Yo!\nMultiline",
         "Yo!\nHey"
     );
 
     msg(
         "fail for multi-line strings with more than one newline",
-        "[assert.equals] Yo!\\nMulti-\\nline expected to be equal to Yo!\\nHey",
+        "[assert.equals] 'Yo!\\\\nMulti-\\\\nline' expected to be equal to 'Yo!\\\\nHey'",
         "Yo!\nMulti-\nline",
         "Yo!\nHey"
     );
 
     msg(
         "fail with regular message for one-line strings",
-        "[assert.equals] Yo expected to be equal to Hey",
+        "[assert.equals] 'Yo' expected to be equal to 'Hey'",
         "Yo",
         "Hey"
     );
@@ -337,14 +337,14 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail with understandable message",
-        "[refute.equals] {  } expected not to be equal to {  }",
+        "[refute.equals] {} expected not to be equal to {}",
         {},
         {}
     );
 
     msg(
         "fail with custom message",
-        "[refute.equals] Eh? {  } expected not to be equal to {  }",
+        "[refute.equals] Eh? {} expected not to be equal to {}",
         {},
         {},
         "Eh?"

--- a/lib/assertions/exception.test.js
+++ b/lib/assertions/exception.test.js
@@ -54,7 +54,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with message when not throwing",
-        '[assert.exception] Expected { name: "TypeError" } but no exception was thrown',
+        "[assert.exception] Expected { name: 'TypeError' } but no exception was thrown",
         function() {},
         { name: "TypeError" }
     );
@@ -68,7 +68,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with matcher and custom message",
-        '[assert.exception] Hmm: Expected { name: "TypeError" } but no exception was thrown',
+        "[assert.exception] Hmm: Expected { name: 'TypeError' } but no exception was thrown",
         function() {},
         { name: "TypeError" },
         "Hmm"
@@ -106,7 +106,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "when matcher function fails",
-        "[assert.exception] Expected thrown TypeError (Aright) to pass matcher function",
+        "[assert.exception] Expected thrown 'TypeError' ('Aright') to pass matcher function",
         function() {
             throw new TypeError("Aright");
         },
@@ -131,7 +131,7 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with message",
-        "[refute.exception] Expected not to throw but threw Error (:()",
+        "[refute.exception] Expected not to throw but threw 'Error' (':(')",
         function() {
             throw new Error(":(");
         }
@@ -139,7 +139,7 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with custom message",
-        "[refute.exception] Jeez: Expected not to throw but threw Error (:()",
+        "[refute.exception] Jeez: Expected not to throw but threw 'Error' (':(')",
         function() {
             throw new Error(":(");
         },

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -20,7 +20,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected {  } to have [MyThing] {  } on its prototype chain"
+                    "[assert.hasPrototype] Expected {} to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -38,7 +38,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected 3 to have [MyThing] {  } on its prototype chain"
+                    "[assert.hasPrototype] Expected 3 to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -106,7 +106,7 @@ describe("assert.hasPrototype", function() {
                     error.message,
                     "[assert.hasPrototype] " +
                         message +
-                        ": Expected {  } to have [MyThing] {  } on its prototype chain"
+                        ": Expected {} to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -160,7 +160,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -181,7 +181,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -215,7 +215,7 @@ describe("refute.hasPrototype", function() {
                     error.message,
                     "[refute.hasPrototype] " +
                         message +
-                        ": Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                        ": Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");

--- a/lib/assertions/is-array-buffer.test.js
+++ b/lib/assertions/is-array-buffer.test.js
@@ -42,7 +42,7 @@ describe("assert.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+                        "[assert.isArrayBuffer] Expected {} to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.isArrayBuffer");
@@ -63,7 +63,7 @@ describe("assert.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+                        "[assert.isArrayBuffer] Expected [Arguments] {} to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.isArrayBuffer");
@@ -86,7 +86,10 @@ describe("refute.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[refute.isArrayBuffer] Expected [ArrayBuffer] {  } not to be an ArrayBuffer"
+                        "[refute.isArrayBuffer] Expected ArrayBuffer {\n" +
+                            "  [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                            "  byteLength: 8\n" +
+                            "} not to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.isArrayBuffer");

--- a/lib/assertions/is-array-like.test.js
+++ b/lib/assertions/is-array-like.test.js
@@ -27,7 +27,7 @@ describe("assert.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArrayLike] Expected {  } to be array like"
+                    "[assert.isArrayLike] Expected {} to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArrayLike");
@@ -45,7 +45,7 @@ describe("assert.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArrayLike] Here! Expected {  } to be array like"
+                    "[assert.isArrayLike] Here! Expected {} to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArrayLike");
@@ -85,7 +85,7 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isArrayLike] Expected {  } not to be array like"
+                    "[refute.isArrayLike] Expected [Arguments] {} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");
@@ -104,7 +104,14 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.isArrayLike] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like'
+                    "[refute.isArrayLike] Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");
@@ -123,7 +130,14 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.isArrayLike] apple pie: Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like'
+                    "[refute.isArrayLike] apple pie: Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");

--- a/lib/assertions/is-array.test.js
+++ b/lib/assertions/is-array.test.js
@@ -19,7 +19,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] Expected {  } to be array"
+                    "[assert.isArray] Expected {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -37,7 +37,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] Expected {  } to be array"
+                    "[assert.isArray] Expected [Arguments] {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -55,7 +55,14 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.isArray] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } to be array'
+                    "[assert.isArray] Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -75,9 +82,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] " +
-                        message +
-                        ": Expected {  } to be array"
+                    "[assert.isArray] " + message + ": Expected {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");

--- a/lib/assertions/is-boolean.test.js
+++ b/lib/assertions/is-boolean.test.js
@@ -22,7 +22,7 @@ describe("assert.isBoolean", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isBoolean] Expected function noop() {} (function) to be boolean"
+                    "[assert.isBoolean] Expected [Function: noop] ('function') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");
@@ -40,7 +40,7 @@ describe("assert.isBoolean", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isBoolean] Expected null (object) to be boolean"
+                    "[assert.isBoolean] Expected null ('object') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");
@@ -62,7 +62,7 @@ describe("assert.isBoolean", function() {
                     error.message,
                     "[assert.isBoolean] " +
                         message +
-                        ": Expected hello (string) to be boolean"
+                        ": Expected 'hello' ('string') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");

--- a/lib/assertions/is-data-view.test.js
+++ b/lib/assertions/is-data-view.test.js
@@ -25,7 +25,10 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected [ArrayBuffer] {  } to be a DataView"
+                    "[assert.isDataView] Expected ArrayBuffer {\n" +
+                        "  [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "  byteLength: 8\n" +
+                        "} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -60,7 +63,7 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected {  } to be a DataView"
+                    "[assert.isDataView] Expected {} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -78,7 +81,7 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected {  } to be a DataView"
+                    "[assert.isDataView] Expected [Arguments] {} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -119,7 +122,14 @@ describe("refute.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isDataView] Expected [DataView] {  } not to be a DataView"
+                    "[refute.isDataView] Expected DataView {\n" +
+                        "  byteLength: 8,\n" +
+                        "  byteOffset: 0,\n" +
+                        "  buffer: ArrayBuffer {\n" +
+                        "    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "    byteLength: 8\n" +
+                        "  }\n" +
+                        "} not to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDataView");
@@ -156,7 +166,14 @@ describe("refute.isDataView", function() {
                     error.message,
                     "[refute.isDataView] " +
                         message +
-                        ": Expected [DataView] {  } not to be a DataView"
+                        ": Expected DataView {\n" +
+                        "  byteLength: 8,\n" +
+                        "  byteOffset: 0,\n" +
+                        "  buffer: ArrayBuffer {\n" +
+                        "    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "    byteLength: 8\n" +
+                        "  }\n" +
+                        "} not to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDataView");

--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -36,7 +36,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected apple pie to be a Date"
+                    "[assert.isDate] Expected 'apple pie' to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -72,7 +72,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected {  } to be a Date"
+                    "[assert.isDate] Expected {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -90,7 +90,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected {  } to be a Date"
+                    "[assert.isDate] Expected [Arguments] {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -110,9 +110,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] " +
-                        message +
-                        ": Expected {  } to be a Date"
+                    "[assert.isDate] " + message + ": Expected {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -125,13 +123,6 @@ describe("assert.isDate", function() {
 describe("refute.isDate", function() {
     it("should fail for Date", function() {
         var date = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
-        // In node 6+8 date.toString() uses "(UTC)" as suffix in UTC timezone
-        // In node 10 date.toString() uses "(Coordinated Universal Time)"
-        var suffix = date.toString().match(/\(.*\)$/)[0];
-        var expectedMessage = "[refute.isDate] Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
-            "{suffix}",
-            suffix
-        );
 
         assert.throws(
             function() {
@@ -139,7 +130,10 @@ describe("refute.isDate", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(error.message, expectedMessage);
+                assert.equal(
+                    error.message,
+                    "[refute.isDate] Expected 1899-12-31T00:00:00.000Z not to be a Date"
+                );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDate");
                 return true;
@@ -176,7 +170,7 @@ describe("refute.isDate", function() {
         var expectedMessage =
             "[refute.isDate] " +
             message +
-            ": Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
+            ": Expected 1899-12-31T00:00:00.000Z not to be a Date".replace(
                 "{suffix}",
                 suffix
             );

--- a/lib/assertions/is-error.test.js
+++ b/lib/assertions/is-error.test.js
@@ -42,7 +42,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected not an error instance to be an Error"
+                    "[assert.isError] Expected 'not an error instance' to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -78,7 +78,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected {  } to be an Error"
+                    "[assert.isError] Expected {} to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -96,7 +96,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected {  } to be an Error"
+                    "[assert.isError] Expected [Arguments] {} to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -117,7 +117,7 @@ describe("assert.isError", function() {
                     error.message,
                     "[assert.isError] " +
                         message +
-                        ": Expected not an error instance to be an Error"
+                        ": Expected 'not an error instance' to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");

--- a/lib/assertions/is-eval-error.test.js
+++ b/lib/assertions/is-eval-error.test.js
@@ -128,7 +128,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected 8759e9fa-e0d8-4bc8-b85f-09433850b830 to be an EvalError"
+                    "[assert.isEvalError] Expected '8759e9fa-e0d8-4bc8-b85f-09433850b830' to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");
@@ -164,7 +164,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected {  } to be an EvalError"
+                    "[assert.isEvalError] Expected {} to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");
@@ -182,7 +182,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected {  } to be an EvalError"
+                    "[assert.isEvalError] Expected [Arguments] {} to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");

--- a/lib/assertions/is-false.test.js
+++ b/lib/assertions/is-false.test.js
@@ -35,7 +35,7 @@ describe("assert.isFalse", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFalse] Expected (empty string) to be false"
+                    "[assert.isFalse] Expected '' to be false"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFalse");

--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected 0,0 to be a Float32Array"
+                    "[assert.isFloat32Array] Expected Float64Array [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -54,7 +54,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                    "[assert.isFloat32Array] Expected {} to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -72,7 +72,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                    "[assert.isFloat32Array] Expected [Arguments] {} to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat32Array", function() {
                     error.message,
                     "[assert.isFloat32Array] " +
                         message +
-                        ": Expected 0,0 to be a Float32Array"
+                        ": Expected Float64Array [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -114,7 +114,7 @@ describe("refute.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat32Array] Expected 0,0 not to be a Float32Array"
+                    "[refute.isFloat32Array] Expected Float32Array [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat32Array", function() {
                     error.message,
                     "[refute.isFloat32Array] " +
                         message +
-                        ": Expected 0,0 not to be a Float32Array"
+                        ": Expected Float32Array [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected 0,0 to be a Float64Array"
+                    "[assert.isFloat64Array] Expected Float32Array [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -54,7 +54,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                    "[assert.isFloat64Array] Expected {} to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -72,7 +72,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                    "[assert.isFloat64Array] Expected [Arguments] {} to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat64Array", function() {
                     error.message,
                     "[assert.isFloat64Array] " +
                         message +
-                        ": Expected 0,0 to be a Float64Array"
+                        ": Expected Float32Array [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -118,7 +118,7 @@ describe("refute.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat64Array] Expected 0,0 not to be a Float64Array"
+                    "[refute.isFloat64Array] Expected Float64Array [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat64Array", function() {
                     error.message,
                     "[refute.isFloat64Array] " +
                         message +
-                        ": Expected 0,0 not to be a Float64Array"
+                        ": Expected Float64Array [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");

--- a/lib/assertions/is-function.test.js
+++ b/lib/assertions/is-function.test.js
@@ -19,7 +19,7 @@ describe("assert.isFunction", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFunction] [object Object] (object) expected to be function"
+                    "[assert.isFunction] '[object Object]' ('object') expected to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFunction");
@@ -40,7 +40,7 @@ describe("assert.isFunction", function() {
                     error.message,
                     "[assert.isFunction] " +
                         message +
-                        ": [object Object] (object) expected to be function"
+                        ": '[object Object]' ('object') expected to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFunction");
@@ -60,7 +60,7 @@ describe("refute.isFunction", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFunction] function noop() {} expected not to be function"
+                    "[refute.isFunction] 'function noop() {}' expected not to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFunction");
@@ -85,7 +85,7 @@ describe("refute.isFunction", function() {
                     error.message,
                     "[refute.isFunction] " +
                         message +
-                        ": function noop() {} expected not to be function"
+                        ": 'function noop() {}' expected not to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFunction");

--- a/lib/assertions/is-infinity.test.js
+++ b/lib/assertions/is-infinity.test.js
@@ -72,7 +72,7 @@ describe("assert.isInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInfinity] Expected {  } to be Infinity"
+                    "[assert.isInfinity] Expected {} to be Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInfinity");
@@ -90,7 +90,7 @@ describe("assert.isInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInfinity] Expected {  } to be Infinity"
+                    "[assert.isInfinity] Expected [Arguments] {} to be Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInfinity");

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected 0,0 to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int8Array [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -36,7 +36,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected 0,0 to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int32Array [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -72,7 +72,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected {  } to be an Int16Array"
+                    "[assert.isInt16Array] Expected {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -90,7 +90,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected {  } to be an Int16Array"
+                    "[assert.isInt16Array] Expected [Arguments] {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -112,7 +112,7 @@ describe("assert.isInt16Array", function() {
                     error.message,
                     "[assert.isInt16Array] " +
                         message +
-                        ": Expected {  } to be an Int16Array"
+                        ": Expected [Arguments] {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -136,7 +136,7 @@ describe("refute.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt16Array] Expected 0,0 not to be an Int16Array"
+                    "[refute.isInt16Array] Expected Int16Array [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");
@@ -174,7 +174,7 @@ describe("refute.isInt16Array", function() {
                     error.message,
                     "[refute.isInt16Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int16Array"
+                        ": Expected Int16Array [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int8Array [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -32,7 +32,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int16Array [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -72,7 +72,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                    "[assert.isInt32Array] Expected {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -90,7 +90,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                    "[assert.isInt32Array] Expected [Arguments] {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -112,7 +112,7 @@ describe("assert.isInt32Array", function() {
                     error.message,
                     "[assert.isInt32Array] " +
                         message +
-                        ": Expected {  } to be an Int32Array"
+                        ": Expected [Arguments] {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -140,7 +140,7 @@ describe("refute.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt32Array] Expected 0,0 not to be an Int32Array"
+                    "[refute.isInt32Array] Expected Int32Array [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");
@@ -174,7 +174,7 @@ describe("refute.isInt32Array", function() {
                     error.message,
                     "[refute.isInt32Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int32Array"
+                        ": Expected Int32Array [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected 0,0 to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int16Array [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -36,7 +36,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected 0,0 to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int32Array [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -72,7 +72,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected {  } to be an Int8Array"
+                    "[assert.isInt8Array] Expected {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -90,7 +90,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected {  } to be an Int8Array"
+                    "[assert.isInt8Array] Expected [Arguments] {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -112,7 +112,7 @@ describe("assert.isInt8Array", function() {
                     error.message,
                     "[assert.isInt8Array] " +
                         message +
-                        ": Expected {  } to be an Int8Array"
+                        ": Expected [Arguments] {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -132,7 +132,7 @@ describe("refute.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt8Array] Expected 0,0 not to be an Int8Array"
+                    "[refute.isInt8Array] Expected Int8Array [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");
@@ -174,7 +174,7 @@ describe("refute.isInt8Array", function() {
                     error.message,
                     "[refute.isInt8Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int8Array"
+                        ": Expected Int8Array [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");

--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected apple pie to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected 'apple pie' to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -54,7 +54,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected {} to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -72,7 +72,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected [Arguments] {} to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -94,7 +94,7 @@ describe("assert.isIntlCollator", function() {
                     error.message,
                     "[assert.isIntlCollator] " +
                         message +
-                        ": Expected apple pie to be an Intl.Collator"
+                        ": Expected 'apple pie' to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -114,7 +114,7 @@ describe("refute.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlCollator] Expected [Collator] {  } not to be an Intl.Collator"
+                    "[refute.isIntlCollator] Expected Collator [Object] {} not to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlCollator");
@@ -151,7 +151,7 @@ describe("refute.isIntlCollator", function() {
                     error.message,
                     "[refute.isIntlCollator] " +
                         message +
-                        ": Expected [Collator] {  } not to be an Intl.Collator"
+                        ": Expected Collator [Object] {} not to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlCollator");

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected apple pie to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected 'apple pie' to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -54,7 +54,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected {} to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -72,7 +72,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected [Arguments] {} to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -94,7 +94,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                     error.message,
                     "[assert.isIntlDateTimeFormat] " +
                         message +
-                        ": Expected apple pie to be an Intl.DateTimeFormat"
+                        ": Expected 'apple pie' to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -114,7 +114,7 @@ describe("refute.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlDateTimeFormat] Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                    "[refute.isIntlDateTimeFormat] Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlDateTimeFormat");
@@ -154,7 +154,7 @@ describe("refute.isIntlDateTimeFormat", function() {
                     error.message,
                     "[refute.isIntlDateTimeFormat] " +
                         message +
-                        ": Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                        ": Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlDateTimeFormat");

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected apple pie to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected 'apple pie' to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -54,7 +54,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected {} to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -72,7 +72,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected [Arguments] {} to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -94,7 +94,7 @@ describe("assert.isIntlNumberFormat", function() {
                     error.message,
                     "[assert.isIntlNumberFormat] " +
                         message +
-                        ": Expected apple pie to be an Intl.NumberFormat"
+                        ": Expected 'apple pie' to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -114,7 +114,7 @@ describe("refute.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlNumberFormat] Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                    "[refute.isIntlNumberFormat] Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlNumberFormat");
@@ -154,7 +154,7 @@ describe("refute.isIntlNumberFormat", function() {
                     error.message,
                     "[refute.isIntlNumberFormat] " +
                         message +
-                        ": Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                        ": Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlNumberFormat");

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -18,7 +18,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected apple pie to be a Map"
+                    "[assert.isMap] Expected 'apple pie' to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -55,7 +55,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected [WeakMap] {  } to be a Map"
+                    "[assert.isMap] Expected WeakMap { <items unknown> } to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -73,7 +73,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected {  } to be a Map"
+                    "[assert.isMap] Expected {} to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -91,7 +91,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected {  } to be a Map"
+                    "[assert.isMap] Expected [Arguments] {} to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -113,7 +113,7 @@ describe("assert.isMap", function() {
                     error.message,
                     "[assert.isMap] " +
                         message +
-                        ": Expected apple pie to be a Map"
+                        ": Expected 'apple pie' to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -133,7 +133,7 @@ describe("refute.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isMap] Expected Map [] not to be a Map"
+                    "[refute.isMap] Expected Map {} not to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isMap");
@@ -175,7 +175,7 @@ describe("refute.isMap", function() {
                     error.message,
                     "[refute.isMap] " +
                         message +
-                        ": Expected Map [] not to be a Map"
+                        ": Expected Map {} not to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isMap");

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -1,186 +1,90 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
-var captureArgs = require("../test-helper/capture-args");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.isMap", function() {
-    it("should pass for Map", function() {
-        referee.assert.isMap(new Map());
+describe("isMap factory", function() {
+    beforeEach(function() {
+        this.fakeActualMessageValues = "a4bf1905-489e-4f10-a47e-5b79b7cf173a";
+
+        this.factory = proxyquire("./is-map", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should fail for String", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap("apple pie");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected 'apple pie' to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    it("calls referee.add with 'isMap' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isMap"));
     });
 
-    it("should fail for Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected [] to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".assert", function() {
+        describe("when actual is an instance of Map", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new Map());
+
+                assert.equal(result, true);
+            });
+        });
+
+        describe("when actual is not an instance of Map", function() {
+            it("returns false", function() {
+                var t = this;
+
+                [
+                    Map,
+                    WeakMap,
+                    Set,
+                    // eslint-disable-next-line ie11/no-weak-collections
+                    new WeakMap(),
+                    [],
+                    {},
+                    "apple pie",
+                    123,
+                    new Date()
+                ].forEach(function(value) {
+                    var result = t.options.assert(value);
+
+                    assert.equal(result, false);
+                });
+            });
+        });
     });
 
-    it("should fail for WeakMap", function() {
-        assert.throws(
-            function() {
-                // eslint-disable-next-line ie11/no-weak-collections
-                referee.assert.isMap(new WeakMap());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected WeakMap { <items unknown> } to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a Map'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a Map"
+            );
+        });
     });
 
-    it("should fail for Object", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap({});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected {} to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a Map'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a Map"
+            );
+        });
     });
 
-    it("should fail for arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap(captureArgs());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected [Arguments] {} to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toBeMap'", function() {
+            assert.equal(this.options.expectation, "toBeMap");
+        });
     });
 
-    it("should fail with custom message", function() {
-        var message = "4eb2174d-3faa-4095-92d1-cd8dfb7e2a58";
-
-        assert.throws(
-            function() {
-                referee.assert.isMap("apple pie", message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] " +
-                        message +
-                        ": Expected 'apple pie' to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.isMap", function() {
-    it("should fail for Map", function() {
-        assert.throws(
-            function() {
-                referee.refute.isMap(new Map());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isMap] Expected Map {} not to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isMap");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for String", function() {
-        referee.refute.isMap("apple pie");
-    });
-
-    it("should pass for Array", function() {
-        referee.refute.isMap([]);
-    });
-
-    it("should pass for WeakMap", function() {
-        // eslint-disable-next-line ie11/no-weak-collections
-        referee.refute.isMap(new WeakMap());
-    });
-
-    it("should pass for Object", function() {
-        referee.refute.isMap({});
-    });
-
-    it("should pass for arguments", function() {
-        referee.refute.isMap(captureArgs());
-    });
-
-    it("should fail with custom message", function() {
-        var message = "f84e51dd-d5af-4ef0-81ec-2d575eadd735";
-        assert.throws(
-            function() {
-                referee.refute.isMap(new Map(), message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isMap] " +
-                        message +
-                        ": Expected Map {} not to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isMap");
-                return true;
-            }
-        );
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
     });
 });

--- a/lib/assertions/is-nan.test.js
+++ b/lib/assertions/is-nan.test.js
@@ -128,7 +128,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected apple pie to be NaN"
+                    "[assert.isNaN] Expected 'apple pie' to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -146,7 +146,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected function noop() {} to be NaN"
+                    "[assert.isNaN] Expected [Function: noop] to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -182,7 +182,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected {  } to be NaN"
+                    "[assert.isNaN] Expected {} to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -200,7 +200,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected {  } to be NaN"
+                    "[assert.isNaN] Expected [Arguments] {} to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");

--- a/lib/assertions/is-negative-infinity.test.js
+++ b/lib/assertions/is-negative-infinity.test.js
@@ -72,7 +72,7 @@ describe("assert.isNegativeInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                    "[assert.isNegativeInfinity] Expected {} to be -Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNegativeInfinity");
@@ -90,7 +90,7 @@ describe("assert.isNegativeInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                    "[assert.isNegativeInfinity] Expected [Arguments] {} to be -Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNegativeInfinity");

--- a/lib/assertions/is-null.test.js
+++ b/lib/assertions/is-null.test.js
@@ -74,7 +74,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected (empty string) to be null"
+                    "[assert.isNull] Expected '' to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -92,7 +92,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected function noop() {} to be null"
+                    "[assert.isNull] Expected [Function: noop] to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -128,7 +128,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected {  } to be null"
+                    "[assert.isNull] Expected {} to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -146,7 +146,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected {  } to be null"
+                    "[assert.isNull] Expected [Arguments] {} to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");

--- a/lib/assertions/is-number.test.js
+++ b/lib/assertions/is-number.test.js
@@ -36,7 +36,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected NaN (number) to be a non-NaN number"
+                    "[assert.isNumber] Expected NaN ('number') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -54,7 +54,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected apple pie (string) to be a non-NaN number"
+                    "[assert.isNumber] Expected 'apple pie' ('string') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -72,7 +72,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected function noop() {} (function) to be a non-NaN number"
+                    "[assert.isNumber] Expected [Function: noop] ('function') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -90,7 +90,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected {  } (object) to be a non-NaN number"
+                    "[assert.isNumber] Expected [Arguments] {} ('object') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -108,7 +108,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected null (object) to be a non-NaN number"
+                    "[assert.isNumber] Expected null ('object') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -130,7 +130,7 @@ describe("assert.isNumber", function() {
                     error.message,
                     "[assert.isNumber] " +
                         message +
-                        ": Expected NaN (number) to be a non-NaN number"
+                        ": Expected NaN ('number') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");

--- a/lib/assertions/is-object.test.js
+++ b/lib/assertions/is-object.test.js
@@ -19,7 +19,7 @@ describe("assert.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isObject] function noop() {} (function) expected to be object and not null"
+                    "[assert.isObject] [Function: noop] ('function') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -37,7 +37,7 @@ describe("assert.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isObject] null (object) expected to be object and not null"
+                    "[assert.isObject] null ('object') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -59,7 +59,7 @@ describe("assert.isObject", function() {
                     error.message,
                     "[assert.isObject] " +
                         message +
-                        ": function noop() {} (function) expected to be object and not null"
+                        ": [Function: noop] ('function') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -79,7 +79,7 @@ describe("refute.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isObject] {  } expected to be null or not an object"
+                    "[refute.isObject] {} expected to be null or not an object"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isObject");
@@ -107,7 +107,7 @@ describe("refute.isObject", function() {
                     error.message,
                     "[refute.isObject] " +
                         message +
-                        ": {  } expected to be null or not an object"
+                        ": {} expected to be null or not an object"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isObject");

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -20,7 +20,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected apple pie to be a Promise"
+                    "[assert.isPromise] Expected 'apple pie' to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -56,7 +56,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected function noop() {} to be a Promise"
+                    "[assert.isPromise] Expected [Function: noop] to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -74,7 +74,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected {  } to be a Promise"
+                    "[assert.isPromise] Expected {} to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -92,7 +92,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected {  } to be a Promise"
+                    "[assert.isPromise] Expected [Arguments] {} to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -113,7 +113,7 @@ describe("assert.isPromise", function() {
                     error.message,
                     "[assert.isPromise] " +
                         message +
-                        ": Expected apple pie to be a Promise"
+                        ": Expected 'apple pie' to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -133,7 +133,7 @@ describe("refute.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isPromise] Expected [Promise] {  } not to be a Promise"
+                    "[refute.isPromise] Expected Promise { 'apple pie' } not to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isPromise");
@@ -175,7 +175,7 @@ describe("refute.isPromise", function() {
                     error.message,
                     "[refute.isPromise] " +
                         message +
-                        ": Expected [Promise] {  } not to be a Promise"
+                        ": Expected Promise { 'apple pie' } not to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isPromise");

--- a/lib/assertions/is-range-error.test.js
+++ b/lib/assertions/is-range-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected apple pie to be a RangeError"
+                    "[assert.isRangeError] Expected 'apple pie' to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");
@@ -162,7 +162,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                    "[assert.isRangeError] Expected {} to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");
@@ -180,7 +180,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                    "[assert.isRangeError] Expected [Arguments] {} to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");

--- a/lib/assertions/is-reference-error.test.js
+++ b/lib/assertions/is-reference-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected apple pie to be a ReferenceError"
+                    "[assert.isReferenceError] Expected 'apple pie' to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");
@@ -162,7 +162,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                    "[assert.isReferenceError] Expected {} to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");
@@ -180,7 +180,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                    "[assert.isReferenceError] Expected [Arguments] {} to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");

--- a/lib/assertions/is-reg-exp.test.js
+++ b/lib/assertions/is-reg-exp.test.js
@@ -23,7 +23,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Expected apple pie to be a RegExp"
+                    "[assert.isRegExp] Expected 'apple pie' to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;
@@ -41,7 +41,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Expected {  } to be a RegExp"
+                    "[assert.isRegExp] Expected [Arguments] {} to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;
@@ -59,7 +59,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Nope: Expected {  } to be a RegExp"
+                    "[assert.isRegExp] Nope: Expected {} to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;

--- a/lib/assertions/is-set.test.js
+++ b/lib/assertions/is-set.test.js
@@ -18,7 +18,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected apple pie to be a Set"
+                    "[assert.isSet] Expected 'apple pie' to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -54,7 +54,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected {  } to be a Set"
+                    "[assert.isSet] Expected {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -72,7 +72,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected {  } to be a Set"
+                    "[assert.isSet] Expected [Arguments] {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -92,7 +92,9 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] " + message + ": Expected {  } to be a Set"
+                    "[assert.isSet] " +
+                        message +
+                        ": Expected [Arguments] {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");

--- a/lib/assertions/is-string.test.js
+++ b/lib/assertions/is-string.test.js
@@ -17,7 +17,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected {  } (object) to be string"
+                    "[assert.isString] Expected {} ('object') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -35,7 +35,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected [] (object) to be string"
+                    "[assert.isString] Expected [] ('object') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -53,7 +53,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected 34 (number) to be string"
+                    "[assert.isString] Expected 34 ('number') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -71,7 +71,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected true (boolean) to be string"
+                    "[assert.isString] Expected true ('boolean') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");

--- a/lib/assertions/is-symbol.test.js
+++ b/lib/assertions/is-symbol.test.js
@@ -18,7 +18,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected apple pie to be a Symbol"
+                    "[assert.isSymbol] Expected 'apple pie' to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -54,7 +54,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected {  } to be a Symbol"
+                    "[assert.isSymbol] Expected {} to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -72,7 +72,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected {  } to be a Symbol"
+                    "[assert.isSymbol] Expected [Arguments] {} to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -94,7 +94,7 @@ describe("assert.isSymbol", function() {
                     error.message,
                     "[assert.isSymbol] " +
                         message +
-                        ": Expected apple pie to be a Symbol"
+                        ": Expected 'apple pie' to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");

--- a/lib/assertions/is-syntax-error.test.js
+++ b/lib/assertions/is-syntax-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected apple pie to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected 'apple pie' to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");
@@ -162,7 +162,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected {} to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");
@@ -180,7 +180,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected [Arguments] {} to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");

--- a/lib/assertions/is-type-error.test.js
+++ b/lib/assertions/is-type-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected apple pie to be a TypeError"
+                    "[assert.isTypeError] Expected 'apple pie' to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");
@@ -162,7 +162,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                    "[assert.isTypeError] Expected {} to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");
@@ -180,7 +180,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                    "[assert.isTypeError] Expected [Arguments] {} to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected  to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint32Array [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -36,7 +36,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected  to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint8Array [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -72,7 +72,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected {  } to be a Uint16Array"
+                    "[assert.isUint16Array] Expected {} to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -90,7 +90,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected {  } to be a Uint16Array"
+                    "[assert.isUint16Array] Expected [Arguments] {} to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -131,7 +131,7 @@ describe("refute.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint16Array] Expected  not to be a Uint16Array"
+                    "[refute.isUint16Array] Expected Uint16Array [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");
@@ -152,7 +152,7 @@ describe("refute.isUint16Array", function() {
                     error.message,
                     "[refute.isUint16Array] " +
                         message +
-                        ": Expected  not to be a Uint16Array"
+                        ": Expected Uint16Array [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected  to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint16Array [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -36,7 +36,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected  to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint8Array [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -72,7 +72,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected {  } to be a Uint32Array"
+                    "[assert.isUint32Array] Expected {} to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -90,7 +90,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected {  } to be a Uint32Array"
+                    "[assert.isUint32Array] Expected [Arguments] {} to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -131,7 +131,7 @@ describe("refute.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint32Array] Expected  not to be a Uint32Array"
+                    "[refute.isUint32Array] Expected Uint32Array [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");
@@ -152,7 +152,7 @@ describe("refute.isUint32Array", function() {
                     error.message,
                     "[refute.isUint32Array] " +
                         message +
-                        ": Expected  not to be a Uint32Array"
+                        ": Expected Uint32Array [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected  to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint16Array [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -36,7 +36,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected  to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint32Array [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -72,7 +72,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected {  } to be a Uint8Array"
+                    "[assert.isUint8Array] Expected {} to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -90,7 +90,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected {  } to be a Uint8Array"
+                    "[assert.isUint8Array] Expected [Arguments] {} to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -131,7 +131,7 @@ describe("refute.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint8Array] Expected  not to be a Uint8Array"
+                    "[refute.isUint8Array] Expected Uint8Array [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");
@@ -152,7 +152,7 @@ describe("refute.isUint8Array", function() {
                     error.message,
                     "[refute.isUint8Array] " +
                         message +
-                        ": Expected  not to be a Uint8Array"
+                        ": Expected Uint8Array [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");

--- a/lib/assertions/is-u-int-8-clamped-array.test.js
+++ b/lib/assertions/is-u-int-8-clamped-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint16Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -36,7 +36,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint32Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -54,7 +54,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint8Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -90,7 +90,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected {  } to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected {} to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -108,7 +108,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected {  } to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected [Arguments] {} to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -149,7 +149,7 @@ describe("refute.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint8ClampedArray] Expected  not to be a Uint8ClampedArray"
+                    "[refute.isUint8ClampedArray] Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8ClampedArray");
@@ -173,7 +173,7 @@ describe("refute.isUint8ClampedArray", function() {
                     error.message,
                     "[refute.isUint8ClampedArray] " +
                         message +
-                        ": Expected  not to be a Uint8ClampedArray"
+                        ": Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8ClampedArray");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -16,7 +16,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected [] (object) to be undefined"
+                    "[assert.isUndefined] Expected [] ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -33,7 +33,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected true (boolean) to be undefined"
+                    "[assert.isUndefined] Expected true ('boolean') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -50,7 +50,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected function () {} (function) to be undefined"
+                    "[assert.isUndefined] Expected [Function] ('function') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -67,7 +67,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected null (object) to be undefined"
+                    "[assert.isUndefined] Expected null ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -84,7 +84,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected 42 (number) to be undefined"
+                    "[assert.isUndefined] Expected 42 ('number') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -101,7 +101,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected {  } (object) to be undefined"
+                    "[assert.isUndefined] Expected {} ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -118,7 +118,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] fails: Expected Test (string) to be undefined"
+                    "[assert.isUndefined] fails: Expected 'Test' ('string') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected apple pie to be a URIError"
+                    "[assert.isURIError] Expected 'apple pie' to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -162,7 +162,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected {  } to be a URIError"
+                    "[assert.isURIError] Expected {} to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -180,7 +180,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected {  } to be a URIError"
+                    "[assert.isURIError] Expected [Arguments] {} to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -280,12 +280,12 @@ describe("refute.isURIError", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
+
                 assert.equal(
                     error.message,
-                    "[refute.isURIError] " +
-                        message +
-                        ": Expected URIError not to be a URIError"
+                    "[refute.isURIError] d0150e59-e58d-46c8-b932-e7d0280a0a79: Expected URIError not to be a URIError"
                 );
+
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isURIError");
                 return true;

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -17,7 +17,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] Expected Map [] to be a WeakMap"
+                    "[assert.isWeakMap] Expected Map {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");
@@ -51,7 +51,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] custom message: Expected {  } to be a WeakMap"
+                    "[assert.isWeakMap] custom message: Expected {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");
@@ -68,7 +68,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] Expected {  } to be a WeakMap"
+                    "[assert.isWeakMap] Expected [Arguments] {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -50,7 +50,7 @@ describe("assert.isWeakSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakSet] Expected {  } to be a WeakSet"
+                    "[assert.isWeakSet] Expected {} to be a WeakSet"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakSet");
@@ -67,7 +67,7 @@ describe("assert.isWeakSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakSet] Nope: Expected {  } to be a WeakSet"
+                    "[assert.isWeakSet] Nope: Expected {} to be a WeakSet"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakSet");

--- a/lib/assertions/json.test.js
+++ b/lib/assertions/json.test.js
@@ -16,7 +16,7 @@ describe("assert.json", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.json] Expected { key: "value" } to equal { key: "different" }'
+                    "[assert.json] Expected { key: 'value' } to equal { key: 'different' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.json");
@@ -33,7 +33,7 @@ describe("assert.json", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.json] Expected {something:not parsable} to be valid JSON"
+                    "[assert.json] Expected '{something:not parsable}' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.json");

--- a/lib/assertions/keys.test.js
+++ b/lib/assertions/keys.test.js
@@ -45,7 +45,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -63,7 +63,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b", "c", "d"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'c', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -81,7 +81,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b", "d"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -103,7 +103,7 @@ describe("assert.keys", function() {
                     error.message,
                     "[assert.keys] " +
                         message +
-                        ': Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]'
+                        ": Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -146,7 +146,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -186,7 +186,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -208,7 +208,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -229,7 +229,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "methodA"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'methodA' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -255,7 +255,7 @@ describe("refute.keys", function() {
                     error.message,
                     "[refute.keys] " +
                         message +
-                        ': Expected not to have exact keys ["a", "b", "c"]'
+                        ": Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");

--- a/lib/assertions/match-json.test.js
+++ b/lib/assertions/match-json.test.js
@@ -21,7 +21,7 @@ describe("assert.matchJson", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.matchJson] [object Object]: Expected (empty string) to be valid JSON"
+                    "[assert.matchJson] [object Object]: Expected '' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.matchJson");
@@ -39,7 +39,7 @@ describe("assert.matchJson", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.matchJson] Expected {something:not parsable} to be valid JSON"
+                    "[assert.matchJson] Expected '{something:not parsable}' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.matchJson");

--- a/lib/assertions/match.test.js
+++ b/lib/assertions/match.test.js
@@ -130,7 +130,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match /^[a-z]$/"
+                    "[assert.match] 'Assertions 123' expected to match /^[a-z]$/"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -166,10 +166,19 @@ describe("assert.match", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] Assertions expected to match { test: function fake() {} }"
+
+                var r = new RegExp(
+                    "\\[assert.match\\] 'Assertions' expected to match \\{\n" +
+                        "  test: \\[Function: f\\] \\{\n" +
+                        "    displayName: 'fake',\n" +
+                        "    id: 'fake#\\d+',\n" +
+                        "    callback: undefined\n" +
+                        "  \\}\n" +
+                        "\\}"
                 );
+
+                assert(r.test(error.message));
+
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
                 return true;
@@ -186,7 +195,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] [1, 2, 3] expected to match [2, 3, 4]"
+                    "[assert.match] [ 1, 2, 3 ] expected to match [ 2, 3, 4 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -204,7 +213,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] [1, 2, 3] expected to match [1, 3]"
+                    "[assert.match] [ 1, 2, 3 ] expected to match [ 1, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -244,7 +253,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match null"
+                    "[assert.match] 'Assertions 123' expected to match null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -262,7 +271,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match undefined"
+                    "[assert.match] 'Assertions 123' expected to match undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -284,7 +293,7 @@ describe("assert.match", function() {
                     error.message,
                     "[assert.match] " +
                         message +
-                        ": Assertions 123 expected to match undefined"
+                        ": 'Assertions 123' expected to match undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -302,7 +311,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match false"
+                    "[assert.match] 'Assertions 123' expected to match false"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -320,7 +329,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match 23"
+                    "[assert.match] 'Assertions 123' expected to match 23"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -338,7 +347,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] 23 expected to match 23"
+                    "[assert.match] '23' expected to match 23"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -354,10 +363,10 @@ describe("assert.match", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 23 expected to match function fake() {}"
+                var r = new RegExp(
+                    "\\[assert.match\\] '23' expected to match \\[Function: f\\] \\{ displayName: 'fake', id: 'fake#\\d+', callback: undefined \\}"
                 );
+                assert(r.test(error.message));
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
                 return true;
@@ -376,9 +385,10 @@ describe("assert.match", function() {
                     },
                     function(error) {
                         assert.equal(error.code, "ERR_ASSERTION");
-                        assert.equal(
-                            error.message,
-                            "[assert.match] 23 expected to match function fake() {}"
+                        assert(
+                            error.message.indexOf(
+                                "[assert.match] '23' expected to match [Function: f] {"
+                            ) === 0
                         );
                         assert.equal(error.name, "AssertionError");
                         assert.equal(error.operator, "assert.match");
@@ -400,7 +410,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] 23 expected to match function () {}"
+                    "[assert.match] '23' expected to match [Function]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -418,7 +428,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Vim expected to match Emacs"
+                    "[assert.match] 'Vim' expected to match 'Emacs'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -436,7 +446,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] {  } expected to match Emacs"
+                    "[assert.match] {} expected to match 'Emacs'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -458,7 +468,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Emacs expected to match Emacs"
+                    "[assert.match] 'Emacs' expected to match { toString: [Function: toString] }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -477,9 +487,7 @@ describe("assert.match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.match] " +
-                            value +
-                            " expected to match (empty string)"
+                        "[assert.match] " + value + " expected to match ''"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.match");
@@ -498,7 +506,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.match] { id: 42, name: undefined } expected to match { id: 42, name: "Apple pie" }'
+                    "[assert.match] { id: 42, name: undefined } expected to match { id: 42, name: 'Apple pie' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -518,7 +526,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions expected not to match /[a-z]/"
+                    "[refute.match] 'Assertions' expected not to match /[a-z]/"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -538,7 +546,13 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions expected not to match { test: function fake() {} }"
+                    "[refute.match] 'Assertions' expected not to match {\n" +
+                        "  test: [Function: f] {\n" +
+                        "    displayName: 'fake',\n" +
+                        "    id: 'fake#14',\n" +
+                        "    callback: undefined\n" +
+                        "  }\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -598,7 +612,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] 23 expected not to match 23"
+                    "[refute.match] 23 expected not to match '23'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -637,7 +651,11 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions 123 expected not to match function fake() {}"
+                    "[refute.match] 'Assertions 123' expected not to match [Function: f] {\n" +
+                        "  displayName: 'fake',\n" +
+                        "  id: 'fake#16',\n" +
+                        "  callback: undefined\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -683,7 +701,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Diskord expected not to match or"
+                    "[refute.match] 'Diskord' expected not to match 'or'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -701,7 +719,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Diskord expected not to match Diskord"
+                    "[refute.match] 'Diskord' expected not to match 'Diskord'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -752,7 +770,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.match] { doIt: "yes", id: 42 } expected not to match { doIt: "yes", id: 42 }'
+                    "[refute.match] { id: 42, doIt: 'yes' } expected not to match { id: 42, doIt: 'yes' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -792,7 +810,12 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.match] { owner: { hello: "ok", someDude: "Yes" } } expected not to match { owner: { hello: match(undefined), someDude: "Yes" } }'
+                    "[refute.match] { owner: { someDude: 'Yes', hello: 'ok' } } expected not to match {\n" +
+                        "  owner: {\n" +
+                        "    someDude: 'Yes',\n" +
+                        "    hello: { test: [Function], message: 'match(undefined)' }\n" +
+                        "  }\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -836,7 +859,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [1, 2, 3]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1, 2, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -854,7 +877,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [2, 3]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 2, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -872,7 +895,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [1]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -890,7 +913,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3, { id: 42 }] expected not to match [{ id: 42 }]"
+                    "[refute.match] [ 1, 2, 3, { id: 42 } ] expected not to match [ { id: 42 } ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -916,7 +939,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Emacs expected not to match mac"
+                    "[refute.match] 'Emacs' expected not to match 'mac'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");

--- a/lib/assertions/same.test.js
+++ b/lib/assertions/same.test.js
@@ -66,7 +66,7 @@ describe("assert.same", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.same] 666 expected to be the same object as 666"
+                    "[assert.same] 666 expected to be the same object as '666'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.same");

--- a/lib/assertions/tag-name.test.js
+++ b/lib/assertions/tag-name.test.js
@@ -35,7 +35,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected {  } to have tagName property"
+                    "[assert.tagName] Expected {} to have tagName property"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");
@@ -53,7 +53,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected tagName to be p but was li"
+                    "[assert.tagName] Expected tagName to be 'p' but was 'li'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");
@@ -71,7 +71,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected tagName to be i but was li"
+                    "[assert.tagName] Expected tagName to be 'i' but was 'li'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -37,12 +37,12 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (e) {
-            referee.assert.equals("[assert.custom] 2? 3!", e.message);
+            referee.assert.equals("[assert.custom] '2?' '3!'", e.message);
         }
     });
 
     it("should format interpolated property", function() {
-        var expectedMessage = "[assert.custom] 2? 3!";
+        var expectedMessage = "[assert.custom] '2?' '3!'";
         var actualMessage;
 
         referee.add("custom", {
@@ -111,7 +111,7 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (err) {
-            referee.assert.equals("[assert.custom] ${actual} B", err.message);
+            referee.assert.equals("[assert.custom] ${actual} 'B'", err.message);
         }
     });
 
@@ -129,7 +129,7 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (e) {
-            referee.assert.equals("[assert.custom] 2? 2?", e.message);
+            referee.assert.equals("[assert.custom] '2?' '2?'", e.message);
         }
     });
 

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -38,7 +38,7 @@ describe("expect", function() {
         } catch (e) {
             referee.assert.equals(
                 e.message,
-                '[expect.toEqual] { id: 42 } expected to be equal to { bleh: "Nah" }'
+                "[expect.toEqual] { id: 42 } expected to be equal to { bleh: 'Nah' }"
             );
         }
     });

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,33 +1,13 @@
 "use strict";
 
-var formatio = require("@sinonjs/formatio");
+var inspect = require("util").inspect;
 
-// Setup formatter the same way as Sinon does:
-var formatter = formatio.configure({
-    quoteStrings: false,
-    limitChildrenCount: 250
-});
-
-var customFormatter;
-
-function format() {
-    if (customFormatter) {
-        return customFormatter.apply(null, arguments);
+function format(object) {
+    if (object instanceof Error) {
+        return object.name;
     }
 
-    return formatter.ascii.apply(formatter, arguments);
+    return inspect(object);
 }
-
-format.setFormatter = function(aCustomFormatter) {
-    if (typeof aCustomFormatter !== "function") {
-        throw new Error("format.setFormatter must be called with a function");
-    }
-
-    customFormatter = aCustomFormatter;
-};
-
-format.reset = function() {
-    customFormatter = null;
-};
 
 module.exports = format;

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,55 +1,68 @@
 "use strict";
 
 var assert = require("assert");
-var format = require("./format");
-var referee = require("..");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
 describe("format", function() {
-    afterEach(function() {
-        format.reset();
+    beforeEach(function() {
+        this.fakeInspect = sinon.fake.returns(
+            "334ddc7e-9c2e-4206-8861-9253d348c81b"
+        );
+
+        this.format = proxyquire("./format", {
+            util: {
+                inspect: this.fakeInspect
+            }
+        });
     });
 
-    it("formats with formatio by default", function() {
-        assert.equal(format({ id: 42 }), "{ id: 42 }");
-    });
+    describe("when called with an instance of Error", function() {
+        it("returns the name property", function() {
+            var t = this;
+            var ERROR_TYPES = [
+                Error,
+                EvalError,
+                RangeError,
+                ReferenceError,
+                SyntaxError,
+                TypeError,
+                URIError
+            ];
 
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip("should configure formatio to use maximum 250 entries", function() {
-        // not sure how we can verify this integration with the current setup
-        // where sinon.js calls formatio as part of its loading
-        // extracting sinon.format into a separate module would make this a lot
-        // easier
-    });
+            ERROR_TYPES.forEach(function(ErrorType) {
+                var error = new ErrorType("some message");
+                var result = t.format(error);
 
-    it("formats strings without quotes", function() {
-        assert.equal(format("Hey"), "Hey");
-    });
-
-    describe("format.setFormatter", function() {
-        it("sets custom formatter", function() {
-            format.setFormatter(function() {
-                return "formatted";
+                assert.equal(result, error.name);
             });
-            assert.equal(format("Hey"), "formatted");
         });
+    });
 
-        it("throws if custom formatter is not a function", function() {
-            assert.throws(
-                function() {
-                    format.setFormatter("foo");
-                },
-                function(err) {
-                    assert.equal(
-                        err.message,
-                        "format.setFormatter must be called with a function"
-                    );
-                    return true;
-                }
-            );
-        });
+    describe("when called with other values", function() {
+        it("formats the result using `util.inspect`", function() {
+            var t = this;
 
-        it("exposes method on referee", function() {
-            assert.equal(referee.setFormatter, format.setFormatter);
+            var NON_ERROR_VALUES = [
+                "a0f33503-7939-4b9f-8fd7-efc8c3cad117",
+                1234,
+                new Date(),
+                [],
+                {},
+                new Map(),
+                new Set(),
+                Promise.resolve("02142eaa-d842-4541-af9d-7e9ab323b562")
+            ];
+
+            NON_ERROR_VALUES.forEach(function(value) {
+                t.fakeInspect.resetHistory();
+
+                var result = t.format(value);
+
+                assert(t.fakeInspect.calledOnce);
+                assert(t.fakeInspect.calledWith(value));
+                assert.equal(result, t.fakeInspect.returnValues[0]);
+            });
         });
     });
 });

--- a/lib/interpolate-properties.js
+++ b/lib/interpolate-properties.js
@@ -1,8 +1,8 @@
 "use strict";
 
 var interpolate = require("./interpolate");
-var format = require("./format");
 var reduce = require("@sinonjs/commons").prototypes.array.reduce;
+var format = require("./format");
 
 function prepareMessage(message) {
     if (!message) {

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -33,7 +33,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        '[assert.equals] { bar: true, foo: 1 } expected to be equal to { bar: typeOf("string"), foo: 1 }'
+                        "[assert.equals] { foo: 1, bar: true } expected to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.equals");
@@ -67,7 +67,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        '[refute.equals] { bar: "test", foo: 1 } expected not to be equal to { bar: typeOf("string"), foo: 1 }'
+                        "[refute.equals] { foo: 1, bar: 'test' } expected not to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.equals");

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -13,7 +13,6 @@ referee.fail = require("./create-fail")(referee);
 referee.pass = require("./create-pass")(referee);
 referee.verifier = require("./create-verifier")(referee);
 referee.match = require("@sinonjs/samsam").createMatcher;
-referee.setFormatter = require("./format").setFormatter;
 
 // add all all the built-in assertions to the API
 require("./assertions/class-name")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -60,13 +60,6 @@ describe("API", function() {
         });
     });
 
-    describe(".setFormatter", function() {
-        it("should be a unary Function named 'setFormatter'", function() {
-            assert.equal(typeof referee.setFormatter, "function");
-            assert.equal(referee.setFormatter.length, 1);
-        });
-    });
-
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
@@ -86,7 +79,6 @@ describe("API", function() {
             "once",
             "pass",
             "refute",
-            "setFormatter",
             "supervisors",
             "verifier"
         ]);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -86,4 +86,13 @@ describe("API", function() {
 
         assert.equal(actualProperties, expectedProperties);
     });
+
+    describe("assertions", function() {
+        ["isMap"].forEach(function(assertion) {
+            it("has '" + assertion + "' assertion", function() {
+                assert.equal(typeof referee.assert[assertion], "function");
+                assert.equal(typeof referee.refute[assertion], "function");
+            });
+        });
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,6 +1293,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1929,6 +1939,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
     "is-observable": {
@@ -2594,6 +2610,12 @@
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2772,6 +2794,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -3426,6 +3454,17 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
     },
     "pump": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
       "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
+      "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
         "@sinonjs/samsam": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",
-    "@sinonjs/formatio": "^4.0.1",
     "@sinonjs/samsam": "^4.2.0",
     "array-from": "2.1.1",
     "bane": "^1.x",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "npm-run-all": "^4.1.3",
     "nyc": "^15.0.0",
     "prettier": "^1.18.2",
+    "proxyquire": "^2.1.3",
     "rollup": "^1.23.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "sinon": "^8.0.2"


### PR DESCRIPTION
This PR fixes #181, it replaces `@sinonjs/formatio` with Node's `util.inspect`

#### Purpose

See if we can drop `@sinonjs/formatio` so it can be deprecated and we don't have to do as much maintenance.

#### Solution

Use Node's `util.inspect` as the object formatter


#### How to verify

1. Observe tests passing