### PR TITLE
Experiment replace formatio

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,18 +46,18 @@ jobs:
           name: lint
           command: npm run lint
 
-  node-10:
+  node-12:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - *attach-step
       - run:
           name: Test
           command: npm test
 
-  node-12:
+  node-14:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - *attach-step
       - run:
@@ -67,15 +67,6 @@ jobs:
           name: Upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
-  node-13:
-    docker:
-      - image: circleci/node:13
-    steps:
-      - *attach-step
-      - run:
-          name: Test
-          command: npm test
-
 workflows:
   version: 2
   referee:
@@ -84,12 +75,9 @@ workflows:
       - lint:
           requires:
             - install-dependencies
-      - node-10:
-          requires:
-            - install-dependencies
       - node-12:
           requires:
             - install-dependencies
-      - node-13:
+      - node-14:
           requires:
             - install-dependencies

--- a/lib/actual-for-match.test.js
+++ b/lib/actual-for-match.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var assert = require("assert");
+var actualForMatch = require("./actual-for-match");
+
+describe("actualForMatch", function() {
+    it("should return actual if actual is not an object", function() {
+        var result = actualForMatch(1, { bar: 2 });
+
+        assert.equal(result, 1);
+    });
+
+    it("should return actual if match is not an object", function() {
+        var result = actualForMatch({ foo: 1 }, 2);
+
+        assert.deepEqual(result, { foo: 1 });
+    });
+
+    it("should return diff", function() {
+        var diff = actualForMatch({ foo: 1 }, { bar: 2 });
+
+        assert.deepEqual(diff, {
+            bar: undefined
+        });
+    });
+});

--- a/lib/add.test.js
+++ b/lib/add.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var sinon = require("sinon");
 var referee = require("./referee");
 
 describe("add", function() {
@@ -128,6 +129,32 @@ describe("add", function() {
 
             assert.equal(error.message, expected);
             assert(error instanceof TypeError);
+        });
+    });
+
+    context("with assert returning a promise", function() {
+        before(function() {
+            if (typeof Promise === "undefined") {
+                this.skip();
+            }
+        });
+
+        it("returns a promise and calls referee.pass when resolved", function() {
+            var then = sinon.fake();
+            var options = {
+                assert: function(thing) {
+                    return thing && new Promise(then);
+                },
+                assertMessage: "returning a promise",
+                refuteMessage: "not returning a promise"
+            };
+            referee.add("returningPromise", options);
+
+            var result = referee.assert.returningPromise(1);
+
+            assert(result instanceof Promise);
+
+            then.firstCall.args[0](); // Get coverage on then handler
         });
     });
 });

--- a/lib/assert-exception-unexpected-exception.test.js
+++ b/lib/assert-exception-unexpected-exception.test.js
@@ -7,7 +7,7 @@ describe("assert.exception unexpected exception", function() {
         try {
             referee.assert.exception(
                 function() {
-                    throw new Error(":(");
+                    throw new Error("apple pie");
                 },
                 { name: "TypeError" },
                 "Wow"
@@ -16,9 +16,7 @@ describe("assert.exception unexpected exception", function() {
         } catch (e) {
             referee.assert.match(
                 e.message,
-                "[assert.exception] Wow: Expected " +
-                    '{ name: "TypeError" } but threw Error ' +
-                    "(:()\nError: :(\n"
+                "Wow: Expected { name: 'TypeError' } but threw 'Error' ('apple pie')"
             );
         }
     });
@@ -27,7 +25,7 @@ describe("assert.exception unexpected exception", function() {
         try {
             referee.assert.exception(
                 function() {
-                    throw new Error(":(");
+                    throw new Error("apple pie");
                 },
                 { name: "Error", message: "Aww" },
                 "Wow"
@@ -36,9 +34,7 @@ describe("assert.exception unexpected exception", function() {
         } catch (e) {
             referee.assert.match(
                 e.message,
-                "[assert.exception] Wow: Expected " +
-                    '{ message: "Aww", name: "Error" } but threw ' +
-                    "Error (:()\nError: :(\n"
+                "Wow: Expected { name: 'Error', message: 'Aww' } but threw 'Error' ('apple pie')"
             );
         }
     });

--- a/lib/assertions/class-name.test.js
+++ b/lib/assertions/class-name.test.js
@@ -65,7 +65,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Nope: Expected object's className to include item but was (empty string)"
+                    "[assert.className] Nope: Expected object's className to include 'item' but was ''"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.className");
@@ -94,7 +94,7 @@ describe("assert.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.className] Expected object's className to include item post but was feed item"
+                    "[assert.className] Expected object's className to include 'item post' but was 'feed item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.className");
@@ -209,7 +209,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item"
+                    "[refute.className] Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -234,7 +234,7 @@ describe("refute.className", function() {
                     error.message,
                     "[refute.className] " +
                         message +
-                        ": Expected object's className not to include item"
+                        ": Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -251,7 +251,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item"
+                    "[refute.className] Expected object's className not to include 'item'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -275,7 +275,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include item post"
+                    "[refute.className] Expected object's className not to include 'item post'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -292,7 +292,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.className] Expected object's className not to include e a d"
+                    "[refute.className] Expected object's className not to include 'e a d'"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;
@@ -313,7 +313,7 @@ describe("refute.className", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.className] Expected object\'s className not to include ["e", "a", "d"]'
+                    "[refute.className] Expected object's className not to include [ 'e', 'a', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 return true;

--- a/lib/assertions/contains.test.js
+++ b/lib/assertions/contains.test.js
@@ -17,7 +17,7 @@ describe("assert.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.contains] Expected [0, 1, 2] to contain 3"
+                    "[assert.contains] Expected [ 0, 1, 2 ] to contain 3"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -39,7 +39,7 @@ describe("assert.contains", function() {
                     error.message,
                     "[assert.contains] " +
                         message +
-                        ": Expected [0, 1, 2] to contain 3"
+                        ": Expected [ 0, 1, 2 ] to contain 3"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -66,7 +66,7 @@ describe("assert.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.contains] Expected [{  }] to contain {  }"
+                    "[assert.contains] Expected [ {} ] to contain {}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.contains");
@@ -86,7 +86,7 @@ describe("refute.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.contains] Expected [0, 1, 2] not to contain 1"
+                    "[refute.contains] Expected [ 0, 1, 2 ] not to contain 1"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");
@@ -108,7 +108,7 @@ describe("refute.contains", function() {
                     error.message,
                     "[refute.contains] " +
                         message +
-                        ": Expected [0, 1, 2] not to contain 1"
+                        ": Expected [ 0, 1, 2 ] not to contain 1"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");
@@ -132,7 +132,7 @@ describe("refute.contains", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.contains] Expected [{  }] not to contain {  }"
+                    "[refute.contains] Expected [ {} ] not to contain {}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.contains");

--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -151,14 +151,14 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail with understandable message",
-        "[assert.equals] {  } expected to be equal to Hey",
+        "[assert.equals] {} expected to be equal to 'Hey'",
         {},
         "Hey"
     );
 
     msg(
         "fail with custom message",
-        "[assert.equals] Here: {  } expected to be equal to Hey",
+        "[assert.equals] Here: {} expected to be equal to 'Hey'",
         {},
         "Hey",
         "Here:"
@@ -166,21 +166,21 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail for multi-line strings",
-        "[assert.equals] Yo!\\nMultiline expected to be equal to Yo!\\nHey",
+        "[assert.equals] 'Yo!\\\\nMultiline' expected to be equal to 'Yo!\\\\nHey'",
         "Yo!\nMultiline",
         "Yo!\nHey"
     );
 
     msg(
         "fail for multi-line strings with more than one newline",
-        "[assert.equals] Yo!\\nMulti-\\nline expected to be equal to Yo!\\nHey",
+        "[assert.equals] 'Yo!\\\\nMulti-\\\\nline' expected to be equal to 'Yo!\\\\nHey'",
         "Yo!\nMulti-\nline",
         "Yo!\nHey"
     );
 
     msg(
         "fail with regular message for one-line strings",
-        "[assert.equals] Yo expected to be equal to Hey",
+        "[assert.equals] 'Yo' expected to be equal to 'Hey'",
         "Yo",
         "Hey"
     );
@@ -337,14 +337,14 @@ testHelper.assertionTests("refute", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail with understandable message",
-        "[refute.equals] {  } expected not to be equal to {  }",
+        "[refute.equals] {} expected not to be equal to {}",
         {},
         {}
     );
 
     msg(
         "fail with custom message",
-        "[refute.equals] Eh? {  } expected not to be equal to {  }",
+        "[refute.equals] Eh? {} expected not to be equal to {}",
         {},
         {},
         "Eh?"

--- a/lib/assertions/exception.test.js
+++ b/lib/assertions/exception.test.js
@@ -54,7 +54,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with message when not throwing",
-        '[assert.exception] Expected { name: "TypeError" } but no exception was thrown',
+        "[assert.exception] Expected { name: 'TypeError' } but no exception was thrown",
         function() {},
         { name: "TypeError" }
     );
@@ -68,7 +68,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with matcher and custom message",
-        '[assert.exception] Hmm: Expected { name: "TypeError" } but no exception was thrown',
+        "[assert.exception] Hmm: Expected { name: 'TypeError' } but no exception was thrown",
         function() {},
         { name: "TypeError" },
         "Hmm"
@@ -106,7 +106,7 @@ testHelper.assertionTests("assert", "exception", function(pass, fail, msg) {
 
     msg(
         "when matcher function fails",
-        "[assert.exception] Expected thrown TypeError (Aright) to pass matcher function",
+        "[assert.exception] Expected thrown 'TypeError' ('Aright') to pass matcher function",
         function() {
             throw new TypeError("Aright");
         },
@@ -159,7 +159,7 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with message",
-        "[refute.exception] Expected not to throw but threw Error (:()",
+        "[refute.exception] Expected not to throw but threw 'Error' (':(')",
         function() {
             throw new Error(":(");
         }
@@ -167,7 +167,7 @@ testHelper.assertionTests("refute", "exception", function(pass, fail, msg) {
 
     msg(
         "fail with custom message",
-        "[refute.exception] Jeez: Expected not to throw but threw Error (:()",
+        "[refute.exception] Jeez: Expected not to throw but threw 'Error' (':(')",
         function() {
             throw new Error(":(");
         },

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -20,7 +20,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected {  } to have [MyThing] {  } on its prototype chain"
+                    "[assert.hasPrototype] Expected {} to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -38,7 +38,7 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected 3 to have [MyThing] {  } on its prototype chain"
+                    "[assert.hasPrototype] Expected 3 to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -106,7 +106,7 @@ describe("assert.hasPrototype", function() {
                     error.message,
                     "[assert.hasPrototype] " +
                         message +
-                        ": Expected {  } to have [MyThing] {  } on its prototype chain"
+                        ": Expected {} to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -160,7 +160,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -181,7 +181,7 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -215,7 +215,7 @@ describe("refute.hasPrototype", function() {
                     error.message,
                     "[refute.hasPrototype] " +
                         message +
-                        ": Expected [MyThing] {  } not to have [MyThing] {  } on its prototype chain"
+                        ": Expected MyThing {} not to have MyThing {} on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 
 function MyThing() {}
@@ -9,6 +10,8 @@ var otherThing = {};
 function F() {}
 F.prototype = myThing;
 var specializedThing = new F();
+
+var myThingString = inspect(MyThing.prototype);
 
 describe("assert.hasPrototype", function() {
     it("should fail when object does not inherit from prototype", function() {
@@ -20,7 +23,9 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected {} to have MyThing {} on its prototype chain"
+                    "[assert.hasPrototype] Expected {} to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -38,7 +43,9 @@ describe("assert.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.hasPrototype] Expected 3 to have MyThing {} on its prototype chain"
+                    "[assert.hasPrototype] Expected 3 to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -106,7 +113,9 @@ describe("assert.hasPrototype", function() {
                     error.message,
                     "[assert.hasPrototype] " +
                         message +
-                        ": Expected {} to have MyThing {} on its prototype chain"
+                        ": Expected {} to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.hasPrototype");
@@ -160,7 +169,9 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -181,7 +192,9 @@ describe("refute.hasPrototype", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.hasPrototype] Expected MyThing {} not to have MyThing {} on its prototype chain"
+                    "[refute.hasPrototype] Expected MyThing {} not to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");
@@ -215,7 +228,9 @@ describe("refute.hasPrototype", function() {
                     error.message,
                     "[refute.hasPrototype] " +
                         message +
-                        ": Expected MyThing {} not to have MyThing {} on its prototype chain"
+                        ": Expected MyThing {} not to have " +
+                        myThingString +
+                        " on its prototype chain"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.hasPrototype");

--- a/lib/assertions/is-array-buffer.test.js
+++ b/lib/assertions/is-array-buffer.test.js
@@ -42,7 +42,7 @@ describe("assert.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+                        "[assert.isArrayBuffer] Expected {} to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.isArrayBuffer");
@@ -63,7 +63,7 @@ describe("assert.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.isArrayBuffer] Expected {  } to be an ArrayBuffer"
+                        "[assert.isArrayBuffer] Expected [Arguments] {} to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.isArrayBuffer");
@@ -86,7 +86,10 @@ describe("refute.isArrayBuffer", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[refute.isArrayBuffer] Expected [ArrayBuffer] {  } not to be an ArrayBuffer"
+                        "[refute.isArrayBuffer] Expected ArrayBuffer {\n" +
+                            "  [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                            "  byteLength: 8\n" +
+                            "} not to be an ArrayBuffer"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.isArrayBuffer");

--- a/lib/assertions/is-array-like.test.js
+++ b/lib/assertions/is-array-like.test.js
@@ -27,7 +27,7 @@ describe("assert.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArrayLike] Expected {  } to be array like"
+                    "[assert.isArrayLike] Expected {} to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArrayLike");
@@ -45,7 +45,7 @@ describe("assert.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArrayLike] Here! Expected {  } to be array like"
+                    "[assert.isArrayLike] Here! Expected {} to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArrayLike");
@@ -85,7 +85,7 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isArrayLike] Expected {  } not to be array like"
+                    "[refute.isArrayLike] Expected [Arguments] {} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");
@@ -104,7 +104,14 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.isArrayLike] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like'
+                    "[refute.isArrayLike] Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");
@@ -123,7 +130,14 @@ describe("refute.isArrayLike", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.isArrayLike] apple pie: Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } not to be array like'
+                    "[refute.isArrayLike] apple pie: Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} not to be array like"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isArrayLike");

--- a/lib/assertions/is-array.test.js
+++ b/lib/assertions/is-array.test.js
@@ -19,7 +19,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] Expected {  } to be array"
+                    "[assert.isArray] Expected {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -37,7 +37,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] Expected {  } to be array"
+                    "[assert.isArray] Expected [Arguments] {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -55,7 +55,14 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.isArray] Expected { 0: "One", 1: "Two", 2: "Three", 3: "Four", length: 4, splice: function splice() {} } to be array'
+                    "[assert.isArray] Expected {\n" +
+                        "  '0': 'One',\n" +
+                        "  '1': 'Two',\n" +
+                        "  '2': 'Three',\n" +
+                        "  '3': 'Four',\n" +
+                        "  length: 4,\n" +
+                        "  splice: [Function: splice]\n" +
+                        "} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");
@@ -75,9 +82,7 @@ describe("assert.isArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isArray] " +
-                        message +
-                        ": Expected {  } to be array"
+                    "[assert.isArray] " + message + ": Expected {} to be array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isArray");

--- a/lib/assertions/is-boolean.test.js
+++ b/lib/assertions/is-boolean.test.js
@@ -22,7 +22,7 @@ describe("assert.isBoolean", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isBoolean] Expected function noop() {} (function) to be boolean"
+                    "[assert.isBoolean] Expected [Function: noop] ('function') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");
@@ -40,7 +40,7 @@ describe("assert.isBoolean", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isBoolean] Expected null (object) to be boolean"
+                    "[assert.isBoolean] Expected null ('object') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");
@@ -62,7 +62,7 @@ describe("assert.isBoolean", function() {
                     error.message,
                     "[assert.isBoolean] " +
                         message +
-                        ": Expected hello (string) to be boolean"
+                        ": Expected 'hello' ('string') to be boolean"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isBoolean");

--- a/lib/assertions/is-data-view.test.js
+++ b/lib/assertions/is-data-view.test.js
@@ -25,7 +25,10 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected [ArrayBuffer] {  } to be a DataView"
+                    "[assert.isDataView] Expected ArrayBuffer {\n" +
+                        "  [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "  byteLength: 8\n" +
+                        "} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -60,7 +63,7 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected {  } to be a DataView"
+                    "[assert.isDataView] Expected {} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -78,7 +81,7 @@ describe("assert.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDataView] Expected {  } to be a DataView"
+                    "[assert.isDataView] Expected [Arguments] {} to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDataView");
@@ -119,7 +122,14 @@ describe("refute.isDataView", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isDataView] Expected [DataView] {  } not to be a DataView"
+                    "[refute.isDataView] Expected DataView {\n" +
+                        "  byteLength: 8,\n" +
+                        "  byteOffset: 0,\n" +
+                        "  buffer: ArrayBuffer {\n" +
+                        "    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "    byteLength: 8\n" +
+                        "  }\n" +
+                        "} not to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDataView");
@@ -156,7 +166,14 @@ describe("refute.isDataView", function() {
                     error.message,
                     "[refute.isDataView] " +
                         message +
-                        ": Expected [DataView] {  } not to be a DataView"
+                        ": Expected DataView {\n" +
+                        "  byteLength: 8,\n" +
+                        "  byteOffset: 0,\n" +
+                        "  buffer: ArrayBuffer {\n" +
+                        "    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
+                        "    byteLength: 8\n" +
+                        "  }\n" +
+                        "} not to be a DataView"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDataView");

--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -36,7 +36,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected apple pie to be a Date"
+                    "[assert.isDate] Expected 'apple pie' to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -72,7 +72,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected {  } to be a Date"
+                    "[assert.isDate] Expected {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -90,7 +90,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] Expected {  } to be a Date"
+                    "[assert.isDate] Expected [Arguments] {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -110,9 +110,7 @@ describe("assert.isDate", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isDate] " +
-                        message +
-                        ": Expected {  } to be a Date"
+                    "[assert.isDate] " + message + ": Expected {} to be a Date"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isDate");
@@ -125,13 +123,6 @@ describe("assert.isDate", function() {
 describe("refute.isDate", function() {
     it("should fail for Date", function() {
         var date = new Date(Date.UTC(0, 0, 0, 0, 0, 0));
-        // In node 6+8 date.toString() uses "(UTC)" as suffix in UTC timezone
-        // In node 10 date.toString() uses "(Coordinated Universal Time)"
-        var suffix = date.toString().match(/\(.*\)$/)[0];
-        var expectedMessage = "[refute.isDate] Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
-            "{suffix}",
-            suffix
-        );
 
         assert.throws(
             function() {
@@ -139,7 +130,10 @@ describe("refute.isDate", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(error.message, expectedMessage);
+                assert.equal(
+                    error.message,
+                    "[refute.isDate] Expected 1899-12-31T00:00:00.000Z not to be a Date"
+                );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isDate");
                 return true;
@@ -176,7 +170,7 @@ describe("refute.isDate", function() {
         var expectedMessage =
             "[refute.isDate] " +
             message +
-            ": Expected Sun Dec 31 1899 00:00:00 GMT+0000 {suffix} not to be a Date".replace(
+            ": Expected 1899-12-31T00:00:00.000Z not to be a Date".replace(
                 "{suffix}",
                 suffix
             );

--- a/lib/assertions/is-error.test.js
+++ b/lib/assertions/is-error.test.js
@@ -42,7 +42,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected not an error instance to be an Error"
+                    "[assert.isError] Expected 'not an error instance' to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -78,7 +78,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected {  } to be an Error"
+                    "[assert.isError] Expected {} to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -96,7 +96,7 @@ describe("assert.isError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isError] Expected {  } to be an Error"
+                    "[assert.isError] Expected [Arguments] {} to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");
@@ -117,7 +117,7 @@ describe("assert.isError", function() {
                     error.message,
                     "[assert.isError] " +
                         message +
-                        ": Expected not an error instance to be an Error"
+                        ": Expected 'not an error instance' to be an Error"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isError");

--- a/lib/assertions/is-eval-error.test.js
+++ b/lib/assertions/is-eval-error.test.js
@@ -128,7 +128,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected 8759e9fa-e0d8-4bc8-b85f-09433850b830 to be an EvalError"
+                    "[assert.isEvalError] Expected '8759e9fa-e0d8-4bc8-b85f-09433850b830' to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");
@@ -164,7 +164,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected {  } to be an EvalError"
+                    "[assert.isEvalError] Expected {} to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");
@@ -182,7 +182,7 @@ describe("assert.isEvalError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isEvalError] Expected {  } to be an EvalError"
+                    "[assert.isEvalError] Expected [Arguments] {} to be an EvalError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isEvalError");

--- a/lib/assertions/is-false.test.js
+++ b/lib/assertions/is-false.test.js
@@ -35,7 +35,7 @@ describe("assert.isFalse", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFalse] Expected (empty string) to be false"
+                    "[assert.isFalse] Expected '' to be false"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFalse");

--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected 0,0 to be a Float32Array"
+                    "[assert.isFloat32Array] Expected Float64Array [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -54,7 +54,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                    "[assert.isFloat32Array] Expected {} to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -72,7 +72,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected {  } to be a Float32Array"
+                    "[assert.isFloat32Array] Expected [Arguments] {} to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat32Array", function() {
                     error.message,
                     "[assert.isFloat32Array] " +
                         message +
-                        ": Expected 0,0 to be a Float32Array"
+                        ": Expected Float64Array [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -114,7 +114,7 @@ describe("refute.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat32Array] Expected 0,0 not to be a Float32Array"
+                    "[refute.isFloat32Array] Expected Float32Array [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat32Array", function() {
                     error.message,
                     "[refute.isFloat32Array] " +
                         message +
-                        ": Expected 0,0 not to be a Float32Array"
+                        ": Expected Float32Array [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");

--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat32Array] Expected Float64Array [ 0, 0 ] to be a Float32Array"
+                    "[assert.isFloat32Array] Expected Float64Array(2) [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat32Array", function() {
                     error.message,
                     "[assert.isFloat32Array] " +
                         message +
-                        ": Expected Float64Array [ 0, 0 ] to be a Float32Array"
+                        ": Expected Float64Array(2) [ 0, 0 ] to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat32Array");
@@ -114,7 +114,7 @@ describe("refute.isFloat32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat32Array] Expected Float32Array [ 0, 0 ] not to be a Float32Array"
+                    "[refute.isFloat32Array] Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat32Array", function() {
                     error.message,
                     "[refute.isFloat32Array] " +
                         message +
-                        ": Expected Float32Array [ 0, 0 ] not to be a Float32Array"
+                        ": Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat32Array");

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected Float32Array [ 0, 0 ] to be a Float64Array"
+                    "[assert.isFloat64Array] Expected Float32Array(2) [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat64Array", function() {
                     error.message,
                     "[assert.isFloat64Array] " +
                         message +
-                        ": Expected Float32Array [ 0, 0 ] to be a Float64Array"
+                        ": Expected Float32Array(2) [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -118,7 +118,7 @@ describe("refute.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat64Array] Expected Float64Array [ 0, 0 ] not to be a Float64Array"
+                    "[refute.isFloat64Array] Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat64Array", function() {
                     error.message,
                     "[refute.isFloat64Array] " +
                         message +
-                        ": Expected Float64Array [ 0, 0 ] not to be a Float64Array"
+                        ": Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected 0,0 to be a Float64Array"
+                    "[assert.isFloat64Array] Expected Float32Array [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -54,7 +54,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                    "[assert.isFloat64Array] Expected {} to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -72,7 +72,7 @@ describe("assert.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFloat64Array] Expected {  } to be a Float64Array"
+                    "[assert.isFloat64Array] Expected [Arguments] {} to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -94,7 +94,7 @@ describe("assert.isFloat64Array", function() {
                     error.message,
                     "[assert.isFloat64Array] " +
                         message +
-                        ": Expected 0,0 to be a Float64Array"
+                        ": Expected Float32Array [ 0, 0 ] to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFloat64Array");
@@ -118,7 +118,7 @@ describe("refute.isFloat64Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFloat64Array] Expected 0,0 not to be a Float64Array"
+                    "[refute.isFloat64Array] Expected Float64Array [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");
@@ -152,7 +152,7 @@ describe("refute.isFloat64Array", function() {
                     error.message,
                     "[refute.isFloat64Array] " +
                         message +
-                        ": Expected 0,0 not to be a Float64Array"
+                        ": Expected Float64Array [ 0, 0 ] not to be a Float64Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFloat64Array");

--- a/lib/assertions/is-function.test.js
+++ b/lib/assertions/is-function.test.js
@@ -19,7 +19,7 @@ describe("assert.isFunction", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isFunction] [object Object] (object) expected to be function"
+                    "[assert.isFunction] '[object Object]' ('object') expected to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFunction");
@@ -40,7 +40,7 @@ describe("assert.isFunction", function() {
                     error.message,
                     "[assert.isFunction] " +
                         message +
-                        ": [object Object] (object) expected to be function"
+                        ": '[object Object]' ('object') expected to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isFunction");
@@ -60,7 +60,7 @@ describe("refute.isFunction", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isFunction] function noop() {} expected not to be function"
+                    "[refute.isFunction] 'function noop() {}' expected not to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFunction");
@@ -85,7 +85,7 @@ describe("refute.isFunction", function() {
                     error.message,
                     "[refute.isFunction] " +
                         message +
-                        ": function noop() {} expected not to be function"
+                        ": 'function noop() {}' expected not to be function"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isFunction");

--- a/lib/assertions/is-infinity.test.js
+++ b/lib/assertions/is-infinity.test.js
@@ -72,7 +72,7 @@ describe("assert.isInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInfinity] Expected {  } to be Infinity"
+                    "[assert.isInfinity] Expected {} to be Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInfinity");
@@ -90,7 +90,7 @@ describe("assert.isInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInfinity] Expected {  } to be Infinity"
+                    "[assert.isInfinity] Expected [Arguments] {} to be Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInfinity");

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected Int8Array [ 0, 0 ] to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int8Array(2) [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -36,7 +36,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected Int32Array [ 0, 0 ] to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int32Array(2) [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -136,7 +136,7 @@ describe("refute.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt16Array] Expected Int16Array [ 0, 0 ] not to be an Int16Array"
+                    "[refute.isInt16Array] Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");
@@ -174,7 +174,7 @@ describe("refute.isInt16Array", function() {
                     error.message,
                     "[refute.isInt16Array] " +
                         message +
-                        ": Expected Int16Array [ 0, 0 ] not to be an Int16Array"
+                        ": Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected 0,0 to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int8Array [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -36,7 +36,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected 0,0 to be an Int16Array"
+                    "[assert.isInt16Array] Expected Int32Array [ 0, 0 ] to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -72,7 +72,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected {  } to be an Int16Array"
+                    "[assert.isInt16Array] Expected {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -90,7 +90,7 @@ describe("assert.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt16Array] Expected {  } to be an Int16Array"
+                    "[assert.isInt16Array] Expected [Arguments] {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -112,7 +112,7 @@ describe("assert.isInt16Array", function() {
                     error.message,
                     "[assert.isInt16Array] " +
                         message +
-                        ": Expected {  } to be an Int16Array"
+                        ": Expected [Arguments] {} to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt16Array");
@@ -136,7 +136,7 @@ describe("refute.isInt16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt16Array] Expected 0,0 not to be an Int16Array"
+                    "[refute.isInt16Array] Expected Int16Array [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");
@@ -174,7 +174,7 @@ describe("refute.isInt16Array", function() {
                     error.message,
                     "[refute.isInt16Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int16Array"
+                        ": Expected Int16Array [ 0, 0 ] not to be an Int16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt16Array");

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int8Array [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -32,7 +32,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected 0,0 to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int16Array [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -72,7 +72,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                    "[assert.isInt32Array] Expected {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -90,7 +90,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected {  } to be an Int32Array"
+                    "[assert.isInt32Array] Expected [Arguments] {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -112,7 +112,7 @@ describe("assert.isInt32Array", function() {
                     error.message,
                     "[assert.isInt32Array] " +
                         message +
-                        ": Expected {  } to be an Int32Array"
+                        ": Expected [Arguments] {} to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -140,7 +140,7 @@ describe("refute.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt32Array] Expected 0,0 not to be an Int32Array"
+                    "[refute.isInt32Array] Expected Int32Array [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");
@@ -174,7 +174,7 @@ describe("refute.isInt32Array", function() {
                     error.message,
                     "[refute.isInt32Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int32Array"
+                        ": Expected Int32Array [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -14,7 +14,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected Int8Array [ 0, 0 ] to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int8Array(2) [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -32,7 +32,7 @@ describe("assert.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt32Array] Expected Int16Array [ 0, 0 ] to be an Int32Array"
+                    "[assert.isInt32Array] Expected Int16Array(2) [ 0, 0 ] to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt32Array");
@@ -140,7 +140,7 @@ describe("refute.isInt32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt32Array] Expected Int32Array [ 0, 0 ] not to be an Int32Array"
+                    "[refute.isInt32Array] Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");
@@ -174,7 +174,7 @@ describe("refute.isInt32Array", function() {
                     error.message,
                     "[refute.isInt32Array] " +
                         message +
-                        ": Expected Int32Array [ 0, 0 ] not to be an Int32Array"
+                        ": Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt32Array");

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected Int16Array [ 0, 0 ] to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int16Array(2) [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -36,7 +36,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected Int32Array [ 0, 0 ] to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int32Array(2) [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -132,7 +132,7 @@ describe("refute.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt8Array] Expected Int8Array [ 0, 0 ] not to be an Int8Array"
+                    "[refute.isInt8Array] Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");
@@ -174,7 +174,7 @@ describe("refute.isInt8Array", function() {
                     error.message,
                     "[refute.isInt8Array] " +
                         message +
-                        ": Expected Int8Array [ 0, 0 ] not to be an Int8Array"
+                        ": Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected 0,0 to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int16Array [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -36,7 +36,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected 0,0 to be an Int8Array"
+                    "[assert.isInt8Array] Expected Int32Array [ 0, 0 ] to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -72,7 +72,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected {  } to be an Int8Array"
+                    "[assert.isInt8Array] Expected {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -90,7 +90,7 @@ describe("assert.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isInt8Array] Expected {  } to be an Int8Array"
+                    "[assert.isInt8Array] Expected [Arguments] {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -112,7 +112,7 @@ describe("assert.isInt8Array", function() {
                     error.message,
                     "[assert.isInt8Array] " +
                         message +
-                        ": Expected {  } to be an Int8Array"
+                        ": Expected [Arguments] {} to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isInt8Array");
@@ -132,7 +132,7 @@ describe("refute.isInt8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isInt8Array] Expected 0,0 not to be an Int8Array"
+                    "[refute.isInt8Array] Expected Int8Array [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");
@@ -174,7 +174,7 @@ describe("refute.isInt8Array", function() {
                     error.message,
                     "[refute.isInt8Array] " +
                         message +
-                        ": Expected 0,0 not to be an Int8Array"
+                        ": Expected Int8Array [ 0, 0 ] not to be an Int8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isInt8Array");

--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected apple pie to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected 'apple pie' to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -54,7 +54,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected {} to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -72,7 +72,7 @@ describe("assert.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlCollator] Expected {  } to be an Intl.Collator"
+                    "[assert.isIntlCollator] Expected [Arguments] {} to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -94,7 +94,7 @@ describe("assert.isIntlCollator", function() {
                     error.message,
                     "[assert.isIntlCollator] " +
                         message +
-                        ": Expected apple pie to be an Intl.Collator"
+                        ": Expected 'apple pie' to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlCollator");
@@ -114,7 +114,7 @@ describe("refute.isIntlCollator", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlCollator] Expected [Collator] {  } not to be an Intl.Collator"
+                    "[refute.isIntlCollator] Expected Collator [Object] {} not to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlCollator");
@@ -151,7 +151,7 @@ describe("refute.isIntlCollator", function() {
                     error.message,
                     "[refute.isIntlCollator] " +
                         message +
-                        ": Expected [Collator] {  } not to be an Intl.Collator"
+                        ": Expected Collator [Object] {} not to be an Intl.Collator"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlCollator");

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected apple pie to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected 'apple pie' to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -54,7 +54,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected {} to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -72,7 +72,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlDateTimeFormat] Expected {  } to be an Intl.DateTimeFormat"
+                    "[assert.isIntlDateTimeFormat] Expected [Arguments] {} to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -94,7 +94,7 @@ describe("assert.isIntlDateTimeFormat", function() {
                     error.message,
                     "[assert.isIntlDateTimeFormat] " +
                         message +
-                        ": Expected apple pie to be an Intl.DateTimeFormat"
+                        ": Expected 'apple pie' to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -114,7 +114,7 @@ describe("refute.isIntlDateTimeFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlDateTimeFormat] Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                    "[refute.isIntlDateTimeFormat] Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlDateTimeFormat");
@@ -154,7 +154,7 @@ describe("refute.isIntlDateTimeFormat", function() {
                     error.message,
                     "[refute.isIntlDateTimeFormat] " +
                         message +
-                        ": Expected [DateTimeFormat] {  } not to be an Intl.DateTimeFormat"
+                        ": Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlDateTimeFormat");

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -18,7 +18,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected apple pie to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected 'apple pie' to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -54,7 +54,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected {} to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -72,7 +72,7 @@ describe("assert.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isIntlNumberFormat] Expected {  } to be an Intl.NumberFormat"
+                    "[assert.isIntlNumberFormat] Expected [Arguments] {} to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -94,7 +94,7 @@ describe("assert.isIntlNumberFormat", function() {
                     error.message,
                     "[assert.isIntlNumberFormat] " +
                         message +
-                        ": Expected apple pie to be an Intl.NumberFormat"
+                        ": Expected 'apple pie' to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -114,7 +114,7 @@ describe("refute.isIntlNumberFormat", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isIntlNumberFormat] Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                    "[refute.isIntlNumberFormat] Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlNumberFormat");
@@ -154,7 +154,7 @@ describe("refute.isIntlNumberFormat", function() {
                     error.message,
                     "[refute.isIntlNumberFormat] " +
                         message +
-                        ": Expected [NumberFormat] {  } not to be an Intl.NumberFormat"
+                        ": Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isIntlNumberFormat");

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -18,7 +18,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected apple pie to be a Map"
+                    "[assert.isMap] Expected 'apple pie' to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -55,7 +55,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected [WeakMap] {  } to be a Map"
+                    "[assert.isMap] Expected WeakMap { <items unknown> } to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -73,7 +73,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected {  } to be a Map"
+                    "[assert.isMap] Expected {} to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -91,7 +91,7 @@ describe("assert.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isMap] Expected {  } to be a Map"
+                    "[assert.isMap] Expected [Arguments] {} to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -113,7 +113,7 @@ describe("assert.isMap", function() {
                     error.message,
                     "[assert.isMap] " +
                         message +
-                        ": Expected apple pie to be a Map"
+                        ": Expected 'apple pie' to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isMap");
@@ -133,7 +133,7 @@ describe("refute.isMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isMap] Expected Map [] not to be a Map"
+                    "[refute.isMap] Expected Map {} not to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isMap");
@@ -175,7 +175,7 @@ describe("refute.isMap", function() {
                     error.message,
                     "[refute.isMap] " +
                         message +
-                        ": Expected Map [] not to be a Map"
+                        ": Expected Map {} not to be a Map"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isMap");

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -1,186 +1,90 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
-var captureArgs = require("../test-helper/capture-args");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.isMap", function() {
-    it("should pass for Map", function() {
-        referee.assert.isMap(new Map());
+describe("isMap factory", function() {
+    beforeEach(function() {
+        this.fakeActualMessageValues = "a4bf1905-489e-4f10-a47e-5b79b7cf173a";
+
+        this.factory = proxyquire("./is-map", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should fail for String", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap("apple pie");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected 'apple pie' to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    it("calls referee.add with 'isMap' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isMap"));
     });
 
-    it("should fail for Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected [] to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".assert", function() {
+        describe("when actual is an instance of Map", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new Map());
+
+                assert.equal(result, true);
+            });
+        });
+
+        describe("when actual is not an instance of Map", function() {
+            it("returns false", function() {
+                var t = this;
+
+                [
+                    Map,
+                    WeakMap,
+                    Set,
+                    // eslint-disable-next-line ie11/no-weak-collections
+                    new WeakMap(),
+                    [],
+                    {},
+                    "apple pie",
+                    123,
+                    new Date()
+                ].forEach(function(value) {
+                    var result = t.options.assert(value);
+
+                    assert.equal(result, false);
+                });
+            });
+        });
     });
 
-    it("should fail for WeakMap", function() {
-        assert.throws(
-            function() {
-                // eslint-disable-next-line ie11/no-weak-collections
-                referee.assert.isMap(new WeakMap());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected WeakMap { <items unknown> } to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a Map'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a Map"
+            );
+        });
     });
 
-    it("should fail for Object", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap({});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected {} to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a Map'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a Map"
+            );
+        });
     });
 
-    it("should fail for arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.isMap(captureArgs());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] Expected [Arguments] {} to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toBeMap'", function() {
+            assert.equal(this.options.expectation, "toBeMap");
+        });
     });
 
-    it("should fail with custom message", function() {
-        var message = "4eb2174d-3faa-4095-92d1-cd8dfb7e2a58";
-
-        assert.throws(
-            function() {
-                referee.assert.isMap("apple pie", message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isMap] " +
-                        message +
-                        ": Expected 'apple pie' to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isMap");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.isMap", function() {
-    it("should fail for Map", function() {
-        assert.throws(
-            function() {
-                referee.refute.isMap(new Map());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isMap] Expected Map {} not to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isMap");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for String", function() {
-        referee.refute.isMap("apple pie");
-    });
-
-    it("should pass for Array", function() {
-        referee.refute.isMap([]);
-    });
-
-    it("should pass for WeakMap", function() {
-        // eslint-disable-next-line ie11/no-weak-collections
-        referee.refute.isMap(new WeakMap());
-    });
-
-    it("should pass for Object", function() {
-        referee.refute.isMap({});
-    });
-
-    it("should pass for arguments", function() {
-        referee.refute.isMap(captureArgs());
-    });
-
-    it("should fail with custom message", function() {
-        var message = "f84e51dd-d5af-4ef0-81ec-2d575eadd735";
-        assert.throws(
-            function() {
-                referee.refute.isMap(new Map(), message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isMap] " +
-                        message +
-                        ": Expected Map {} not to be a Map"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isMap");
-                return true;
-            }
-        );
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
     });
 });

--- a/lib/assertions/is-nan.test.js
+++ b/lib/assertions/is-nan.test.js
@@ -128,7 +128,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected apple pie to be NaN"
+                    "[assert.isNaN] Expected 'apple pie' to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -146,7 +146,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected function noop() {} to be NaN"
+                    "[assert.isNaN] Expected [Function: noop] to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -182,7 +182,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected {  } to be NaN"
+                    "[assert.isNaN] Expected {} to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");
@@ -200,7 +200,7 @@ describe("assert.isNaN", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNaN] Expected {  } to be NaN"
+                    "[assert.isNaN] Expected [Arguments] {} to be NaN"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNaN");

--- a/lib/assertions/is-negative-infinity.test.js
+++ b/lib/assertions/is-negative-infinity.test.js
@@ -72,7 +72,7 @@ describe("assert.isNegativeInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                    "[assert.isNegativeInfinity] Expected {} to be -Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNegativeInfinity");
@@ -90,7 +90,7 @@ describe("assert.isNegativeInfinity", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNegativeInfinity] Expected {  } to be -Infinity"
+                    "[assert.isNegativeInfinity] Expected [Arguments] {} to be -Infinity"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNegativeInfinity");

--- a/lib/assertions/is-null.test.js
+++ b/lib/assertions/is-null.test.js
@@ -74,7 +74,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected (empty string) to be null"
+                    "[assert.isNull] Expected '' to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -92,7 +92,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected function noop() {} to be null"
+                    "[assert.isNull] Expected [Function: noop] to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -128,7 +128,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected {  } to be null"
+                    "[assert.isNull] Expected {} to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");
@@ -146,7 +146,7 @@ describe("assert.isNull", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNull] Expected {  } to be null"
+                    "[assert.isNull] Expected [Arguments] {} to be null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNull");

--- a/lib/assertions/is-number.test.js
+++ b/lib/assertions/is-number.test.js
@@ -36,7 +36,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected NaN (number) to be a non-NaN number"
+                    "[assert.isNumber] Expected NaN ('number') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -54,7 +54,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected apple pie (string) to be a non-NaN number"
+                    "[assert.isNumber] Expected 'apple pie' ('string') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -72,7 +72,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected function noop() {} (function) to be a non-NaN number"
+                    "[assert.isNumber] Expected [Function: noop] ('function') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -90,7 +90,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected {  } (object) to be a non-NaN number"
+                    "[assert.isNumber] Expected [Arguments] {} ('object') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -108,7 +108,7 @@ describe("assert.isNumber", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isNumber] Expected null (object) to be a non-NaN number"
+                    "[assert.isNumber] Expected null ('object') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");
@@ -130,7 +130,7 @@ describe("assert.isNumber", function() {
                     error.message,
                     "[assert.isNumber] " +
                         message +
-                        ": Expected NaN (number) to be a non-NaN number"
+                        ": Expected NaN ('number') to be a non-NaN number"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isNumber");

--- a/lib/assertions/is-object.test.js
+++ b/lib/assertions/is-object.test.js
@@ -19,7 +19,7 @@ describe("assert.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isObject] function noop() {} (function) expected to be object and not null"
+                    "[assert.isObject] [Function: noop] ('function') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -37,7 +37,7 @@ describe("assert.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isObject] null (object) expected to be object and not null"
+                    "[assert.isObject] null ('object') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -59,7 +59,7 @@ describe("assert.isObject", function() {
                     error.message,
                     "[assert.isObject] " +
                         message +
-                        ": function noop() {} (function) expected to be object and not null"
+                        ": [Function: noop] ('function') expected to be object and not null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isObject");
@@ -79,7 +79,7 @@ describe("refute.isObject", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isObject] {  } expected to be null or not an object"
+                    "[refute.isObject] {} expected to be null or not an object"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isObject");
@@ -107,7 +107,7 @@ describe("refute.isObject", function() {
                     error.message,
                     "[refute.isObject] " +
                         message +
-                        ": {  } expected to be null or not an object"
+                        ": {} expected to be null or not an object"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isObject");

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -20,7 +20,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected apple pie to be a Promise"
+                    "[assert.isPromise] Expected 'apple pie' to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -56,7 +56,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected function noop() {} to be a Promise"
+                    "[assert.isPromise] Expected [Function: noop] to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -74,7 +74,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected {  } to be a Promise"
+                    "[assert.isPromise] Expected {} to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -92,7 +92,7 @@ describe("assert.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isPromise] Expected {  } to be a Promise"
+                    "[assert.isPromise] Expected [Arguments] {} to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -113,7 +113,7 @@ describe("assert.isPromise", function() {
                     error.message,
                     "[assert.isPromise] " +
                         message +
-                        ": Expected apple pie to be a Promise"
+                        ": Expected 'apple pie' to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isPromise");
@@ -133,7 +133,7 @@ describe("refute.isPromise", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isPromise] Expected [Promise] {  } not to be a Promise"
+                    "[refute.isPromise] Expected Promise { 'apple pie' } not to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isPromise");
@@ -175,7 +175,7 @@ describe("refute.isPromise", function() {
                     error.message,
                     "[refute.isPromise] " +
                         message +
-                        ": Expected [Promise] {  } not to be a Promise"
+                        ": Expected Promise { 'apple pie' } not to be a Promise"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isPromise");

--- a/lib/assertions/is-range-error.test.js
+++ b/lib/assertions/is-range-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected apple pie to be a RangeError"
+                    "[assert.isRangeError] Expected 'apple pie' to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");
@@ -162,7 +162,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                    "[assert.isRangeError] Expected {} to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");
@@ -180,7 +180,7 @@ describe("assert.isRangeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isRangeError] Expected {  } to be a RangeError"
+                    "[assert.isRangeError] Expected [Arguments] {} to be a RangeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isRangeError");

--- a/lib/assertions/is-reference-error.test.js
+++ b/lib/assertions/is-reference-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected apple pie to be a ReferenceError"
+                    "[assert.isReferenceError] Expected 'apple pie' to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");
@@ -162,7 +162,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                    "[assert.isReferenceError] Expected {} to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");
@@ -180,7 +180,7 @@ describe("assert.isReferenceError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isReferenceError] Expected {  } to be a ReferenceError"
+                    "[assert.isReferenceError] Expected [Arguments] {} to be a ReferenceError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isReferenceError");

--- a/lib/assertions/is-reg-exp.test.js
+++ b/lib/assertions/is-reg-exp.test.js
@@ -23,7 +23,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Expected apple pie to be a RegExp"
+                    "[assert.isRegExp] Expected 'apple pie' to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;
@@ -41,7 +41,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Expected {  } to be a RegExp"
+                    "[assert.isRegExp] Expected [Arguments] {} to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;
@@ -59,7 +59,7 @@ describe("assert.isRegExp", function() {
                 assert.equal(error.name, "AssertionError");
                 assert.equal(
                     error.message,
-                    "[assert.isRegExp] Nope: Expected {  } to be a RegExp"
+                    "[assert.isRegExp] Nope: Expected {} to be a RegExp"
                 );
                 assert.equal(error.operator, "assert.isRegExp");
                 return true;

--- a/lib/assertions/is-set.test.js
+++ b/lib/assertions/is-set.test.js
@@ -18,7 +18,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected apple pie to be a Set"
+                    "[assert.isSet] Expected 'apple pie' to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -54,7 +54,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected {  } to be a Set"
+                    "[assert.isSet] Expected {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -72,7 +72,7 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] Expected {  } to be a Set"
+                    "[assert.isSet] Expected [Arguments] {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");
@@ -92,7 +92,9 @@ describe("assert.isSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSet] " + message + ": Expected {  } to be a Set"
+                    "[assert.isSet] " +
+                        message +
+                        ": Expected [Arguments] {} to be a Set"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSet");

--- a/lib/assertions/is-string.test.js
+++ b/lib/assertions/is-string.test.js
@@ -17,7 +17,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected {  } (object) to be string"
+                    "[assert.isString] Expected {} ('object') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -35,7 +35,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected [] (object) to be string"
+                    "[assert.isString] Expected [] ('object') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -53,7 +53,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected 34 (number) to be string"
+                    "[assert.isString] Expected 34 ('number') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");
@@ -71,7 +71,7 @@ describe("isString", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isString] Expected true (boolean) to be string"
+                    "[assert.isString] Expected true ('boolean') to be string"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isString");

--- a/lib/assertions/is-symbol.test.js
+++ b/lib/assertions/is-symbol.test.js
@@ -18,7 +18,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected apple pie to be a Symbol"
+                    "[assert.isSymbol] Expected 'apple pie' to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -54,7 +54,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected {  } to be a Symbol"
+                    "[assert.isSymbol] Expected {} to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -72,7 +72,7 @@ describe("assert.isSymbol", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSymbol] Expected {  } to be a Symbol"
+                    "[assert.isSymbol] Expected [Arguments] {} to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");
@@ -94,7 +94,7 @@ describe("assert.isSymbol", function() {
                     error.message,
                     "[assert.isSymbol] " +
                         message +
-                        ": Expected apple pie to be a Symbol"
+                        ": Expected 'apple pie' to be a Symbol"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSymbol");

--- a/lib/assertions/is-syntax-error.test.js
+++ b/lib/assertions/is-syntax-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected apple pie to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected 'apple pie' to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");
@@ -162,7 +162,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected {} to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");
@@ -180,7 +180,7 @@ describe("assert.isSyntaxError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isSyntaxError] Expected {  } to be a SyntaxError"
+                    "[assert.isSyntaxError] Expected [Arguments] {} to be a SyntaxError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isSyntaxError");

--- a/lib/assertions/is-type-error.test.js
+++ b/lib/assertions/is-type-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected apple pie to be a TypeError"
+                    "[assert.isTypeError] Expected 'apple pie' to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");
@@ -162,7 +162,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                    "[assert.isTypeError] Expected {} to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");
@@ -180,7 +180,7 @@ describe("assert.isTypeError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isTypeError] Expected {  } to be a TypeError"
+                    "[assert.isTypeError] Expected [Arguments] {} to be a TypeError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isTypeError");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected  to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint32Array [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -36,7 +36,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected  to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint8Array [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -72,7 +72,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected {  } to be a Uint16Array"
+                    "[assert.isUint16Array] Expected {} to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -90,7 +90,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected {  } to be a Uint16Array"
+                    "[assert.isUint16Array] Expected [Arguments] {} to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -131,7 +131,7 @@ describe("refute.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint16Array] Expected  not to be a Uint16Array"
+                    "[refute.isUint16Array] Expected Uint16Array [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");
@@ -152,7 +152,7 @@ describe("refute.isUint16Array", function() {
                     error.message,
                     "[refute.isUint16Array] " +
                         message +
-                        ": Expected  not to be a Uint16Array"
+                        ": Expected Uint16Array [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected Uint32Array [] to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint32Array(0) [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -36,7 +36,7 @@ describe("assert.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint16Array] Expected Uint8Array [] to be a Uint16Array"
+                    "[assert.isUint16Array] Expected Uint8Array(0) [] to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint16Array");
@@ -131,7 +131,7 @@ describe("refute.isUint16Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint16Array] Expected Uint16Array [] not to be a Uint16Array"
+                    "[refute.isUint16Array] Expected Uint16Array(0) [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");
@@ -152,7 +152,7 @@ describe("refute.isUint16Array", function() {
                     error.message,
                     "[refute.isUint16Array] " +
                         message +
-                        ": Expected Uint16Array [] not to be a Uint16Array"
+                        ": Expected Uint16Array(0) [] not to be a Uint16Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint16Array");

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected  to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint16Array [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -36,7 +36,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected  to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint8Array [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -72,7 +72,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected {  } to be a Uint32Array"
+                    "[assert.isUint32Array] Expected {} to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -90,7 +90,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected {  } to be a Uint32Array"
+                    "[assert.isUint32Array] Expected [Arguments] {} to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -131,7 +131,7 @@ describe("refute.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint32Array] Expected  not to be a Uint32Array"
+                    "[refute.isUint32Array] Expected Uint32Array [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");
@@ -152,7 +152,7 @@ describe("refute.isUint32Array", function() {
                     error.message,
                     "[refute.isUint32Array] " +
                         message +
-                        ": Expected  not to be a Uint32Array"
+                        ": Expected Uint32Array [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected Uint16Array [] to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint16Array(0) [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -36,7 +36,7 @@ describe("assert.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint32Array] Expected Uint8Array [] to be a Uint32Array"
+                    "[assert.isUint32Array] Expected Uint8Array(0) [] to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint32Array");
@@ -131,7 +131,7 @@ describe("refute.isUint32Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint32Array] Expected Uint32Array [] not to be a Uint32Array"
+                    "[refute.isUint32Array] Expected Uint32Array(0) [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");
@@ -152,7 +152,7 @@ describe("refute.isUint32Array", function() {
                     error.message,
                     "[refute.isUint32Array] " +
                         message +
-                        ": Expected Uint32Array [] not to be a Uint32Array"
+                        ": Expected Uint32Array(0) [] not to be a Uint32Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint32Array");

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected  to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint16Array [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -36,7 +36,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected  to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint32Array [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -72,7 +72,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected {  } to be a Uint8Array"
+                    "[assert.isUint8Array] Expected {} to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -90,7 +90,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected {  } to be a Uint8Array"
+                    "[assert.isUint8Array] Expected [Arguments] {} to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -131,7 +131,7 @@ describe("refute.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint8Array] Expected  not to be a Uint8Array"
+                    "[refute.isUint8Array] Expected Uint8Array [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");
@@ -152,7 +152,7 @@ describe("refute.isUint8Array", function() {
                     error.message,
                     "[refute.isUint8Array] " +
                         message +
-                        ": Expected  not to be a Uint8Array"
+                        ": Expected Uint8Array [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected Uint16Array [] to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint16Array(0) [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -36,7 +36,7 @@ describe("assert.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8Array] Expected Uint32Array [] to be a Uint8Array"
+                    "[assert.isUint8Array] Expected Uint32Array(0) [] to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8Array");
@@ -131,7 +131,7 @@ describe("refute.isUint8Array", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint8Array] Expected Uint8Array [] not to be a Uint8Array"
+                    "[refute.isUint8Array] Expected Uint8Array(0) [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");
@@ -152,7 +152,7 @@ describe("refute.isUint8Array", function() {
                     error.message,
                     "[refute.isUint8Array] " +
                         message +
-                        ": Expected Uint8Array [] not to be a Uint8Array"
+                        ": Expected Uint8Array(0) [] not to be a Uint8Array"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8Array");

--- a/lib/assertions/is-u-int-8-clamped-array.test.js
+++ b/lib/assertions/is-u-int-8-clamped-array.test.js
@@ -1,208 +1,88 @@
 "use strict";
 
 var assert = require("assert");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
+
 var captureArgs = require("../test-helper/capture-args");
-var referee = require("../referee");
 
-describe("assert.isUint8ClampedArray", function() {
-    it("should pass for Uint8ClampedArray", function() {
-        referee.assert.isUint8ClampedArray(new Uint8ClampedArray());
+describe("isUint8ClampedArray factory", function() {
+    beforeEach(function() {
+        this.fakeActualMessageValues = "a4bf1905-489e-4f10-a47e-5b79b7cf173a";
+
+        this.factory = proxyquire("./is-u-int-8-clamped-array", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should fail for Uint16Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray(new Uint16Array());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected Uint16Array [] to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
+    it("calls referee.add with 'isUint8ClampedArray' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isUint8ClampedArray"));
     });
 
-    it("should fail for Uint32Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray(new Uint32Array());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected Uint32Array [] to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
+    describe(".assert", function() {
+        describe("when actual is an instance of Uint8ClampedArray", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new Uint8ClampedArray());
+
+                assert.equal(result, true);
+            });
+        });
+
+        describe("when actual is not an instance of Uint8ClampedArray", function() {
+            it("returns false", function() {
+                var t = this;
+
+                [
+                    new Uint16Array(),
+                    new Uint32Array(),
+                    new Uint8Array(),
+                    [],
+                    {},
+                    captureArgs()
+                ].forEach(function(value) {
+                    var result = t.options.assert(value);
+
+                    assert.equal(result, false);
+                });
+            });
+        });
     });
 
-    it("should fail for Uint8Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray(new Uint8Array());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected Uint8Array [] to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a Uint8ClampedArray'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a Uint8ClampedArray"
+            );
+        });
     });
 
-    it("should fail for Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected [] to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a Uint8ClampedArray'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a Uint8ClampedArray"
+            );
+        });
     });
 
-    it("should fail for Object", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray({});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected {} to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toBeUint8ClampedArray'", function() {
+            assert.equal(this.options.expectation, "toBeUint8ClampedArray");
+        });
     });
 
-    it("should fail for arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray(captureArgs());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] Expected [Arguments] {} to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message", function() {
-        var message = "b8895750-3ba7-40f6-bda5-5e769d6c0b62";
-        assert.throws(
-            function() {
-                referee.assert.isUint8ClampedArray([], message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isUint8ClampedArray] " +
-                        message +
-                        ": Expected [] to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isUint8ClampedArray");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.isUint8ClampedArray", function() {
-    it("should fail for isUint8ClampedArray", function() {
-        assert.throws(
-            function() {
-                referee.refute.isUint8ClampedArray(new Uint8ClampedArray());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isUint8ClampedArray] Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isUint8ClampedArray");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message", function() {
-        var message = "9ddf1b4c-4382-4744-ae88-d14c69f20626";
-        assert.throws(
-            function() {
-                referee.refute.isUint8ClampedArray(
-                    new Uint8ClampedArray(),
-                    message
-                );
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isUint8ClampedArray] " +
-                        message +
-                        ": Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isUint8ClampedArray");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for Uint16Array", function() {
-        referee.refute.isUint8ClampedArray(new Uint16Array());
-    });
-
-    it("should pass for Uint32Array", function() {
-        referee.refute.isUint8ClampedArray(new Uint32Array());
-    });
-
-    it("should pass for Uint8Array", function() {
-        referee.refute.isUint8ClampedArray(new Uint8Array());
-    });
-
-    it("should pass for Array", function() {
-        referee.refute.isUint8ClampedArray([]);
-    });
-
-    it("should pass for Object", function() {
-        referee.refute.isUint8ClampedArray({});
-    });
-
-    it("should pass for arguments", function() {
-        referee.refute.isUint8ClampedArray(captureArgs());
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
     });
 });

--- a/lib/assertions/is-u-int-8-clamped-array.test.js
+++ b/lib/assertions/is-u-int-8-clamped-array.test.js
@@ -18,7 +18,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint16Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -36,7 +36,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint32Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -54,7 +54,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected  to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected Uint8Array [] to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -90,7 +90,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected {  } to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected {} to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -108,7 +108,7 @@ describe("assert.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUint8ClampedArray] Expected {  } to be a Uint8ClampedArray"
+                    "[assert.isUint8ClampedArray] Expected [Arguments] {} to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUint8ClampedArray");
@@ -149,7 +149,7 @@ describe("refute.isUint8ClampedArray", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.isUint8ClampedArray] Expected  not to be a Uint8ClampedArray"
+                    "[refute.isUint8ClampedArray] Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8ClampedArray");
@@ -173,7 +173,7 @@ describe("refute.isUint8ClampedArray", function() {
                     error.message,
                     "[refute.isUint8ClampedArray] " +
                         message +
-                        ": Expected  not to be a Uint8ClampedArray"
+                        ": Expected Uint8ClampedArray [] not to be a Uint8ClampedArray"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isUint8ClampedArray");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -2,6 +2,7 @@
 
 var referee = require("../referee");
 var assert = require("assert");
+var anonymousFunction = require("../test-helper/anonymous-function-string");
 
 describe("assert.isUndefined", function() {
     it("should pass for undefined", function() {
@@ -50,7 +51,9 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected [Function (anonymous)] ('function') to be undefined"
+                    "[assert.isUndefined] Expected " +
+                        anonymousFunction +
+                        " ('function') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -16,7 +16,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected [] (object) to be undefined"
+                    "[assert.isUndefined] Expected [] ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -33,7 +33,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected true (boolean) to be undefined"
+                    "[assert.isUndefined] Expected true ('boolean') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -50,7 +50,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected function () {} (function) to be undefined"
+                    "[assert.isUndefined] Expected [Function] ('function') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -67,7 +67,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected null (object) to be undefined"
+                    "[assert.isUndefined] Expected null ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -84,7 +84,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected 42 (number) to be undefined"
+                    "[assert.isUndefined] Expected 42 ('number') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -101,7 +101,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected {  } (object) to be undefined"
+                    "[assert.isUndefined] Expected {} ('object') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");
@@ -118,7 +118,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] fails: Expected Test (string) to be undefined"
+                    "[assert.isUndefined] fails: Expected 'Test' ('string') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -50,7 +50,7 @@ describe("assert.isUndefined", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isUndefined] Expected [Function] ('function') to be undefined"
+                    "[assert.isUndefined] Expected [Function (anonymous)] ('function') to be undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isUndefined");

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -53,7 +53,7 @@ describe("isURIError factory", function() {
                     captureArgs()
                 ];
 
-                nonWeakSetValues.forEach(function(value) {
+                nonURIErrorValues.forEach(function(value) {
                     assert.equal(t.options.assert(value), false);
                 });
             });

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -39,7 +39,7 @@ describe("isURIError factory", function() {
         context("when called with a non-URIError instance", function() {
             it("retunrns false", function() {
                 var t = this;
-                var nonWeakSetValues = [
+                var nonURIErrorValues = [
                     [],
                     {},
                     "7b210c59-abb9-44b2-8c89-f6d3d5880d0f",

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -1,295 +1,92 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
+
 var captureArgs = require("../test-helper/capture-args");
 
-describe("assert.isURIError", function() {
-    it("should fail for Error", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new Error());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected Error to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+describe("isURIError factory", function() {
+    beforeEach(function() {
+        this.fakeActualMessageValues = "2e88944c-d6a6-4925-8f74-bb9703f56a51";
+
+        this.factory = proxyquire("./is-uri-error", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should fail for EvalError", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new EvalError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected EvalError to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+    it("calls referee.add with 'isURIError' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isURIError"));
     });
 
-    it("should fal for RangeError", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new RangeError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected RangeError to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+    describe(".assert", function() {
+        context("when called with a URIError instance", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new URIError());
+
+                assert.equal(result, true);
+            });
+        });
+
+        context("when called with a non-URIError instance", function() {
+            it("retunrns false", function() {
+                var t = this;
+                var nonWeakSetValues = [
+                    [],
+                    {},
+                    "7b210c59-abb9-44b2-8c89-f6d3d5880d0f",
+                    URIError,
+                    new Error(),
+                    new EvalError(),
+                    new RangeError(),
+                    new ReferenceError(),
+                    new SyntaxError(),
+                    new TypeError(),
+                    captureArgs()
+                ];
+
+                nonWeakSetValues.forEach(function(value) {
+                    assert.equal(t.options.assert(value), false);
+                });
+            });
+        });
     });
 
-    it("should fail for ReferenceError", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new ReferenceError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected ReferenceError to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a URIError'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a URIError"
+            );
+        });
     });
 
-    it("should fail for SyntaxError", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new SyntaxError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected SyntaxError to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a URIError'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a URIError"
+            );
+        });
     });
 
-    it("should fail for TypeError", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new TypeError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected TypeError to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toBeURIError'", function() {
+            assert.equal(this.options.expectation, "toBeURIError");
+        });
     });
 
-    it("should pass for URIError", function() {
-        referee.assert.isURIError(new URIError());
-    });
-
-    it("should fail for String", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError("apple pie");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected 'apple pie' to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected [] to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for Object", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError({});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected {} to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.isURIError(captureArgs());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] Expected [Arguments] {} to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message", function() {
-        var message = "0bedeb92-f9c8-4440-95f7-e54ab7ecf728";
-
-        assert.throws(
-            function() {
-                referee.assert.isURIError(new Error(), message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isURIError] " +
-                        message +
-                        ": Expected Error to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isURIError");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.isURIError", function() {
-    it("should pass for Error", function() {
-        referee.refute.isURIError(new Error());
-    });
-
-    it("should pass for EvalError", function() {
-        referee.refute.isURIError(new EvalError());
-    });
-
-    it("should pass for RangeError", function() {
-        referee.refute.isURIError(new RangeError());
-    });
-
-    it("should pass for ReferenceError", function() {
-        referee.refute.isURIError(new ReferenceError());
-    });
-
-    it("should fail for SyntaxError", function() {
-        referee.refute.isURIError(new SyntaxError());
-    });
-
-    it("should fail for TypeError", function() {
-        referee.refute.isURIError(new TypeError());
-    });
-
-    it("should pass for URIError", function() {
-        assert.throws(
-            function() {
-                referee.refute.isURIError(new URIError());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.isURIError] Expected URIError not to be a URIError"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isURIError");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for String", function() {
-        referee.refute.isURIError("apple pie");
-    });
-
-    it("should pass for Array", function() {
-        referee.refute.isURIError([]);
-    });
-
-    it("should pass for Object", function() {
-        referee.refute.isURIError({});
-    });
-
-    it("should pass for arguments", function() {
-        referee.refute.isURIError(captureArgs());
-    });
-
-    it("should fail with custom message", function() {
-        var message = "d0150e59-e58d-46c8-b932-e7d0280a0a79";
-
-        assert.throws(
-            function() {
-                referee.refute.isURIError(new URIError(), message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-
-                assert.equal(
-                    error.message,
-                    "[refute.isURIError] d0150e59-e58d-46c8-b932-e7d0280a0a79: Expected URIError not to be a URIError"
-                );
-
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.isURIError");
-                return true;
-            }
-        );
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
     });
 });

--- a/lib/assertions/is-uri-error.test.js
+++ b/lib/assertions/is-uri-error.test.js
@@ -126,7 +126,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected apple pie to be a URIError"
+                    "[assert.isURIError] Expected 'apple pie' to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -162,7 +162,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected {  } to be a URIError"
+                    "[assert.isURIError] Expected {} to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -180,7 +180,7 @@ describe("assert.isURIError", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isURIError] Expected {  } to be a URIError"
+                    "[assert.isURIError] Expected [Arguments] {} to be a URIError"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isURIError");
@@ -280,12 +280,12 @@ describe("refute.isURIError", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
+
                 assert.equal(
                     error.message,
-                    "[refute.isURIError] " +
-                        message +
-                        ": Expected URIError not to be a URIError"
+                    "[refute.isURIError] d0150e59-e58d-46c8-b932-e7d0280a0a79: Expected URIError not to be a URIError"
                 );
+
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.isURIError");
                 return true;

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -44,7 +44,7 @@ describe("isWeakMap factory", function() {
         context("when called with a non-WeakMap instance", function() {
             it("retunrns false", function() {
                 var t = this;
-                var nonWeakSetValues = [
+                var nonWeakMapValues = [
                     [],
                     {},
                     Set,

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -1,79 +1,94 @@
+/* eslint-disable ie11/no-weak-collections */
 "use strict";
 
-var referee = require("../referee");
 var assert = require("assert");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.isWeakMap", function() {
-    it("should pass for WeakMap", function() {
-        // eslint-disable-next-line ie11/no-weak-collections
-        referee.assert.isWeakMap(new WeakMap());
+describe("isWeakMap factory", function() {
+    before(function() {
+        if (typeof WeakMap === "undefined") {
+            this.skip();
+        }
     });
-    it("should fail for Map", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakMap(new Map());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakMap] Expected Map {} to be a WeakMap"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakMap");
-                return true;
-            }
-        );
+
+    beforeEach(function() {
+        this.fakeActualMessageValues = "b7da1d7b-a90a-43ba-854e-199e11151437";
+
+        this.factory = proxyquire("./is-weak-map", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
-    it("should fail for array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakMap([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakMap] Expected [] to be a WeakMap"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakMap");
-                return true;
-            }
-        );
+
+    it("calls referee.add with 'isWeakMap' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isWeakMap"));
     });
-    it("should fail for object with a custom message", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakMap({}, "custom message");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakMap] custom message: Expected {} to be a WeakMap"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakMap");
-                return true;
-            }
-        );
+
+    describe(".assert", function() {
+        context("when called with a WeakMap instance", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new WeakMap());
+
+                assert.equal(result, true);
+            });
+        });
+
+        context("when called with a non-WeakMap instance", function() {
+            it("retunrns false", function() {
+                var t = this;
+                var nonWeakSetValues = [
+                    [],
+                    {},
+                    Set,
+                    WeakSet,
+                    new WeakSet(),
+                    new Set(),
+                    new Map()
+                ];
+
+                nonWeakSetValues.forEach(function(value) {
+                    assert.equal(t.options.assert(value), false);
+                });
+            });
+        });
     });
-    it("should fail for arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakMap(arguments);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakMap] Expected [Arguments] {} to be a WeakMap"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakMap");
-                return true;
-            }
-        );
+
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a WeakMap'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a WeakMap"
+            );
+        });
     });
+
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a WeakMap'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a WeakMap"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toBeWeakMap'", function() {
+            assert.equal(this.options.expectation, "toBeWeakMap");
+        });
+    });
+
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
+    });
+
 });

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -90,5 +90,4 @@ describe("isWeakMap factory", function() {
             assert.equal(this.options.values, this.fakeActualMessageValues);
         });
     });
-
 });

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -54,7 +54,7 @@ describe("isWeakMap factory", function() {
                     new Map()
                 ];
 
-                nonWeakSetValues.forEach(function(value) {
+                nonWeakMapValues.forEach(function(value) {
                     assert.equal(t.options.assert(value), false);
                 });
             });

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -17,7 +17,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] Expected Map [] to be a WeakMap"
+                    "[assert.isWeakMap] Expected Map {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");
@@ -51,7 +51,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] custom message: Expected {  } to be a WeakMap"
+                    "[assert.isWeakMap] custom message: Expected {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");
@@ -68,7 +68,7 @@ describe("assert.isWeakMap", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakMap] Expected {  } to be a WeakMap"
+                    "[assert.isWeakMap] Expected [Arguments] {} to be a WeakMap"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakMap");

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -49,6 +49,7 @@ describe("isWeakSet factory", function() {
                     {},
                     Set,
                     WeakSet,
+                    new WeakMap(),
                     new Set(),
                     new Map()
                 ];

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -50,7 +50,7 @@ describe("assert.isWeakSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakSet] Expected {  } to be a WeakSet"
+                    "[assert.isWeakSet] Expected {} to be a WeakSet"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakSet");
@@ -67,7 +67,7 @@ describe("assert.isWeakSet", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.isWeakSet] Nope: Expected {  } to be a WeakSet"
+                    "[assert.isWeakSet] Nope: Expected {} to be a WeakSet"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.isWeakSet");

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -1,78 +1,92 @@
+/* eslint-disable ie11/no-weak-collections */
 "use strict";
 
-var referee = require("../referee");
 var assert = require("assert");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.isWeakSet", function() {
-    it("should pass for WeakSet", function() {
-        referee.assert.isWeakSet(new WeakSet()); // eslint-disable-line ie11/no-weak-collections
+describe("isWeakSet factory", function() {
+    before(function() {
+        if (typeof WeakSet === "undefined") {
+            this.skip();
+        }
     });
-    it("should fail for Set", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakSet(new Set());
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakSet] Expected Set {} to be a WeakSet"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakSet");
-                return true;
-            }
-        );
+
+    beforeEach(function() {
+        this.fakeActualMessageValues = "f9f4851c-7a48-4712-ae23-a2502d8ee159";
+
+        this.factory = proxyquire("./is-weak-set", {
+            "../actual-message-values": this.fakeActualMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
-    it("should fail for Array", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakSet([]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakSet] Expected [] to be a WeakSet"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakSet");
-                return true;
-            }
-        );
+
+    it("calls referee.add with 'isWeakSet' as name", function() {
+        assert(this.fakeReferee.add.calledWith("isWeakSet"));
     });
-    it("should fail for object", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakSet({});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakSet] Expected {} to be a WeakSet"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakSet");
-                return true;
-            }
-        );
+
+    describe(".assert", function() {
+        context("when called with a WeakSet instance", function() {
+            it("returns true", function() {
+                var result = this.options.assert(new WeakSet());
+
+                assert.equal(result, true);
+            });
+        });
+
+        context("when called with a non-WeakSet instance", function() {
+            it("retunrns false", function() {
+                var t = this;
+                var nonWeakSetValues = [
+                    [],
+                    {},
+                    Set,
+                    WeakSet,
+                    new Set(),
+                    new Map()
+                ];
+
+                nonWeakSetValues.forEach(function(value) {
+                    assert.equal(t.options.assert(value), false);
+                });
+            });
+        });
     });
-    it("should fail for object with a custom message", function() {
-        assert.throws(
-            function() {
-                referee.assert.isWeakSet({}, "Nope");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.isWeakSet] Nope: Expected {} to be a WeakSet"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.isWeakSet");
-                return true;
-            }
-        );
+
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be a WeakSet'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be a WeakSet"
+            );
+        });
+    });
+
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be a WeakSet'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be a WeakSet"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toBeWeakSet'", function() {
+            assert.equal(this.options.expectation, "toBeWeakSet");
+        });
+    });
+
+    describe(".values", function() {
+        it("delegates to '../actual-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualMessageValues);
+        });
     });
 });

--- a/lib/assertions/json.test.js
+++ b/lib/assertions/json.test.js
@@ -1,44 +1,150 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.json", function() {
-    it("should pass when json string equal object", function() {
-        referee.assert.json('{"key":"value"}', { key: "value" });
+describe("json factory", function() {
+    beforeEach(function() {
+        this.fakeSamsam = {
+            deepEqual: sinon.fake.returns(
+                "70b2de6c-c281-4913-91f4-330f156a3ccc"
+            )
+        };
+
+        var factory = proxyquire("./json", {
+            "@sinonjs/samsam": this.fakeSamsam
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake(),
+            fail: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
-    it("should fail when json string does not equal object with descriptive message", function() {
-        assert.throws(
-            function() {
-                referee.assert.json('{"key":"value"}', { key: "different" });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.json] Expected { key: 'value' } to equal { key: 'different' }"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.json");
-                return true;
-            }
-        );
+
+    it("calls referee.add with 'json' as name", function() {
+        assert(this.fakeReferee.add.calledWith("json"));
     });
-    it("should fail when json string cannot be parsed", function() {
-        assert.throws(
-            function() {
-                referee.assert.json("{something:not parsable}", {});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
+
+    describe(".assert", function() {
+        context("when json string is parsable", function() {
+            it("returns the result of calling samsam.deepEqual with the parsed string and the matcher", function() {
                 assert.equal(
-                    error.message,
-                    "[assert.json] Expected '{something:not parsable}' to be valid JSON"
+                    this.options.assert('{"key":"value"}', { key: "value" }),
+                    this.fakeSamsam.deepEqual.returnValues[0]
                 );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.json");
-                return true;
-            }
-        );
+            });
+        });
+
+        context("when json string cannot be parsed", function() {
+            it("it calls the fail helper", function() {
+                this.options.assert.call(
+                    this.fakeReferee,
+                    "{something:not parsable}",
+                    {}
+                );
+
+                assert(
+                    this.fakeReferee.fail.calledOnceWithExactly,
+                    "${customMessage}Expected ${actual} to be valid JSON"
+                );
+            });
+        });
+    });
+
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to equal ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to equal ${expected}"
+            );
+        });
+    });
+
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to equal ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to equal ${expected}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toEqualJson'", function() {
+            assert.equal(this.options.expectation, "toEqualJson");
+        });
+    });
+
+    describe(".values", function() {
+        it("is a ternary function", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 3);
+        });
+
+        it("returns a values object", function() {
+            var actual = "56f9c024-ddfb-4184-816f-a00c16d544d4";
+            var expected = "e46b227d-6ec4-4e19-9850-2ebe49c92a8b";
+            var message = "15641444-8ffc-42cc-9abb-39fb6824795b";
+            var result = this.options.values(actual, expected, message);
+
+            assert.equal(typeof result, "object");
+        });
+
+        it("returns actual argument as actualRaw property", function() {
+            var actual = "898878f9-29f6-41d9-b8df-bf28115a3775";
+            var expected = "15472423-fc15-42f6-a74e-022670f7ad5f";
+            var message = "f77075c5-e2c2-4e12-a34b-0b7fd25ad69a";
+            var result = this.options.values(actual, expected, message);
+
+            assert.equal(result.actualRaw, actual);
+        });
+
+        context("when actual argument can be parsed as JSON", function() {
+            it("returns the parsed value of actual argument as actual property", function() {
+                var actual = '{"name": "value"}';
+                var matcher = "bf221a03-fda2-409d-99c8-63e7cf1c5ba7";
+                var message = "2a5b557f-6cc7-40cd-ad0d-c14316c5d327";
+                var result = this.options.values(actual, matcher, message);
+
+                assert.equal(
+                    JSON.stringify(result.actual),
+                    JSON.stringify(JSON.parse(actual))
+                );
+            });
+        });
+
+        context("when actual argument cannot be parsed as JSON", function() {
+            it("returns actual argument as actual property", function() {
+                var actual = '{"unparsable"}';
+                var matcher = "2f756ce6-9b2e-4751-bb8e-11cc19ec726b";
+                var message = "8544eb15-31e7-4a49-9daf-4d26f9610337";
+                var result = this.options.values(actual, matcher, message);
+
+                assert.equal(result.actual, actual);
+            });
+        });
+
+        it("returns expected argument as expected property", function() {
+            var actual = "1cbcc519-b0da-48c3-8ac8-e4659f7adb8e";
+            var matcher = "b50670b1-b576-41d8-bc2a-8772a35337c7";
+            var message = "2915f974-bfd7-424a-8660-c71a9177018c";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(result.expected, matcher);
+        });
+
+        it("returns message argument as customMessage property", function() {
+            var actual = "110a04c0-d827-4d08-bf06-e4d9bd9ad3ec";
+            var matcher = "5d384546-011d-4fd7-8a49-694fb79c2ad1";
+            var message = "5c2099c9-6ed3-4d92-b8f6-a06247724002";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(result.customMessage, message);
+        });
     });
 });

--- a/lib/assertions/json.test.js
+++ b/lib/assertions/json.test.js
@@ -16,7 +16,7 @@ describe("assert.json", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.json] Expected { key: "value" } to equal { key: "different" }'
+                    "[assert.json] Expected { key: 'value' } to equal { key: 'different' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.json");
@@ -33,7 +33,7 @@ describe("assert.json", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.json] Expected {something:not parsable} to be valid JSON"
+                    "[assert.json] Expected '{something:not parsable}' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.json");

--- a/lib/assertions/keys.test.js
+++ b/lib/assertions/keys.test.js
@@ -45,7 +45,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -63,7 +63,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b", "c", "d"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'c', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -81,7 +81,7 @@ describe("assert.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b", "d"]'
+                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'd' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -103,7 +103,7 @@ describe("assert.keys", function() {
                     error.message,
                     "[assert.keys] " +
                         message +
-                        ': Expected { a: 1, b: 2, c: 3 } to have exact keys ["a", "b"]'
+                        ": Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.keys");
@@ -146,7 +146,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -186,7 +186,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -208,7 +208,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "b", "c"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -229,7 +229,7 @@ describe("refute.keys", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.keys] Expected not to have exact keys ["a", "methodA"]'
+                    "[refute.keys] Expected not to have exact keys [ 'a', 'methodA' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");
@@ -255,7 +255,7 @@ describe("refute.keys", function() {
                     error.message,
                     "[refute.keys] " +
                         message +
-                        ': Expected not to have exact keys ["a", "b", "c"]'
+                        ": Expected not to have exact keys [ 'a', 'b', 'c' ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.keys");

--- a/lib/assertions/keys.test.js
+++ b/lib/assertions/keys.test.js
@@ -1,9 +1,11 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var sinon = require("sinon");
 
-describe("assert.keys", function() {
+var factory = require("./keys");
+
+describe("keys factory", function() {
     // by defining this here, it only exists inside this closure and cannot
     // accidentally be modified by other tests
     function Klass(o) {
@@ -16,251 +18,178 @@ describe("assert.keys", function() {
     Klass.prototype.methodA = function() {};
     Klass.prototype.methodB = function() {};
 
-    it("should pass when keys are exact", function() {
-        referee.assert.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "c"]);
+    beforeEach(function() {
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should pass when there are no keys", function() {
-        referee.assert.keys({}, []);
+    it("calls referee.add with 'keys' as name", function() {
+        assert(this.fakeReferee.add.calledWith("keys"));
     });
 
-    it("should pass when values are special", function() {
-        referee.assert.keys({ a: -1, b: null, c: undefined }, ["a", "b", "c"]);
-    });
-
-    it("should ignore prototype methods", function() {
-        referee.assert.keys(new Klass({ a: 1, b: 2, c: 3 }), ["a", "b", "c"]);
-    });
-
-    it("should allow overriding prototype methods", function() {
-        referee.assert.keys(new Klass({ a: 1, methodA: 2 }), ["a", "methodA"]);
-    });
-
-    it("should fail when keys are missing", function() {
-        assert.throws(
-            function() {
-                referee.assert.keys({ a: 1, b: 2, c: 3 }, ["a", "b"]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
+    describe(".assert", function() {
+        context("when keys are exact", function() {
+            it("returns true", function() {
+                assert(
+                    this.options.assert({ a: 1, b: 2, c: 3 }, ["a", "b", "c"])
                 );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.keys");
-                return true;
-            }
-        );
-    });
+            });
+        });
 
-    it("should fail when keys are excess", function() {
-        assert.throws(
-            function() {
-                referee.assert.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "c", "d"]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'c', 'd' ]"
+        context("when there are no keys", function() {
+            it("returns true", function() {
+                assert(this.options.assert({}, []));
+            });
+        });
+
+        context("when values are special", function() {
+            it("returns true", function() {
+                assert(
+                    this.options.assert({ a: -1, b: null, c: undefined }, [
+                        "a",
+                        "b",
+                        "c"
+                    ])
                 );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.keys");
-                return true;
-            }
-        );
-    });
+            });
+        });
 
-    it("should fail when keys are not exact", function() {
-        assert.throws(
-            function() {
-                referee.assert.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "d"]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.keys] Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b', 'd' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.keys");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message", function() {
-        var message = "704322e5-0fa8-47c3-8cfe-2033ad3cab2d";
-
-        assert.throws(
-            function() {
-                referee.assert.keys({ a: 1, b: 2, c: 3 }, ["a", "b"], message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.keys] " +
-                        message +
-                        ": Expected { a: 1, b: 2, c: 3 } to have exact keys [ 'a', 'b' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.keys");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.keys", function() {
-    // by defining this here, it only exists inside this closure and cannot
-    // accidentally be modified by other tests
-    function Klass(o) {
-        for (var key in o) {
-            if (o.hasOwnProperty(key)) {
-                this[key] = o[key];
-            }
-        }
-    }
-    Klass.prototype.methodA = function() {};
-    Klass.prototype.methodB = function() {};
-
-    it("should pass when keys are not exact", function() {
-        referee.refute.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "d"]);
-    });
-
-    it("should pass when keys are missing", function() {
-        referee.refute.keys({ a: 1, b: 2, c: 3 }, ["a", "b"]);
-    });
-    it("should pass when keys are excess", function() {
-        referee.refute.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "c", "d"]);
-    });
-
-    it("should fail when keys are exact", function() {
-        assert.throws(
-            function() {
-                referee.refute.keys({ a: 1, b: 2, c: 3 }, ["a", "b", "c"]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when there are no keys", function() {
-        assert.throws(
-            function() {
-                referee.refute.keys({}, []);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.keys] Expected not to have exact keys []"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when values are special", function() {
-        assert.throws(
-            function() {
-                referee.refute.keys({ a: -1, b: null, c: undefined }, [
+        it("ignores prototype methods", function() {
+            assert(
+                this.options.assert(new Klass({ a: 1, b: 2, c: 3 }), [
                     "a",
                     "b",
                     "c"
-                ]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
-    });
+                ])
+            );
+        });
 
-    it("should fail for prototype methods", function() {
-        assert.throws(
-            function() {
-                referee.refute.keys(new Klass({ a: 1, b: 2, c: 3 }), [
-                    "a",
-                    "b",
-                    "c"
-                ]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.keys] Expected not to have exact keys [ 'a', 'b', 'c' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for overridden prototype methods", function() {
-        assert.throws(
-            function() {
-                referee.refute.keys(new Klass({ a: 1, methodA: 2 }), [
+        it("allows overriding prototype methods", function() {
+            assert(
+                this.options.assert(new Klass({ a: 1, methodA: 2 }), [
                     "a",
                     "methodA"
-                ]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
+                ])
+            );
+        });
+
+        context("when keys are missing", function() {
+            it("returns false", function() {
                 assert.equal(
-                    error.message,
-                    "[refute.keys] Expected not to have exact keys [ 'a', 'methodA' ]"
+                    this.options.assert({ a: 1, b: 2, c: 3 }, ["a", "b"]),
+                    false
                 );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
+            });
+        });
+
+        context("when there are excess keys", function() {
+            it("returns false", function() {
+                assert.equal(
+                    this.options.assert({ a: 1, b: 2, c: 3 }, [
+                        "a",
+                        "b",
+                        "c",
+                        "d"
+                    ]),
+                    false
+                );
+            });
+        });
+
+        context("when keys are not exact", function() {
+            it("returns false", function() {
+                assert.equal(
+                    this.options.assert({ a: 1, b: 2, c: 3 }, ["a", "b", "d"]),
+                    false
+                );
+            });
+        });
     });
 
-    it("should fail with custom message", function() {
-        var message = "c6ef101e-7fb8-4cb2-99d1-c3c5b9c39319";
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actualObject} to have exact keys ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actualObject} to have exact keys ${expected}"
+            );
+        });
+    });
 
-        assert.throws(
-            function() {
-                referee.refute.keys(
-                    { a: 1, b: 2, c: 3 },
-                    ["a", "b", "c"],
-                    message
-                );
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.keys] " +
-                        message +
-                        ": Expected not to have exact keys [ 'a', 'b', 'c' ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.keys");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected not to have exact keys ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected not to have exact keys ${expected}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toHaveKeys'", function() {
+            assert.equal(this.options.expectation, "toHaveKeys");
+        });
+    });
+
+    describe(".values", function() {
+        it("is a ternary function", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 3);
+        });
+
+        it("returns a values object", function() {
+            var actual = "ae7ab1bf-9127-4796-8ee2-a2df2dbc0c1b";
+            var keys = "f7c4145d-c358-4dcc-87d4-5308086ef1f5";
+            var message = "9ce0c066-ecf7-43a5-ad85-5c20555b4e68";
+            var result = this.options.values(actual, keys, message);
+
+            assert.equal(typeof result, "object");
+        });
+
+        it("returns the actual argument as the actualObject property", function() {
+            var actual = "b37c7885-572e-4a8e-83bd-f22346426c50";
+            var keys = "4a04c64e-01d7-4096-b5e3-619c80ac4145";
+            var message = "b7cef6b7-44ac-4cef-bb0c-dc6ba2108448";
+            var result = this.options.values(actual, keys, message);
+
+            assert.equal(result.actualObject, actual);
+        });
+
+        it("returns the keys of actual argument as the actual property", function() {
+            var actual = {
+                one: "05951a97-4845-4d56-a956-8602d668aab4",
+                two: "a81b03c6-1431-40d3-9513-9a2b596f674d"
+            };
+            var keys = "e33178a1-cd66-4fa3-a04d-5970fe7d6cad";
+            var message = "bed89d3c-2f95-4e8f-9a7f-322b02db8708";
+            var result = this.options.values(actual, keys, message);
+
+            assert.equal(
+                JSON.stringify(result.actual),
+                JSON.stringify(Object.keys(actual))
+            );
+        });
+
+        it("returns the keys argument as the expected property", function() {
+            var actual = "d912a671-e5af-47f2-8cc9-46d928ab0529";
+            var keys = "c725c913-82e8-4bdf-a768-8e58edc4d95d";
+            var message = "1d863f70-ee16-4485-9bbf-0f4803a44abb";
+            var result = this.options.values(actual, keys, message);
+
+            assert.equal(result.expected, keys);
+        });
+
+        it("returns the message argument as the customMessage property", function() {
+            var actual = "d912a671-e5af-47f2-8cc9-46d928ab0529";
+            var keys = "c725c913-82e8-4bdf-a768-8e58edc4d95d";
+            var message = "1d863f70-ee16-4485-9bbf-0f4803a44abb";
+            var result = this.options.values(actual, keys, message);
+
+            assert.equal(result.customMessage, message);
+        });
     });
 });

--- a/lib/assertions/less.test.js
+++ b/lib/assertions/less.test.js
@@ -1,118 +1,79 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.less", function() {
-    it("should pass when less", function() {
-        referee.assert.less(1, 2);
+describe("less factory", function() {
+    beforeEach(function() {
+        this.fakeActualAndExpectedMessageValues =
+            "bbedde65-07b1-451a-9ba1-afe28b07786d";
+
+        this.factory = proxyquire("./less", {
+            "../actual-and-expected-message-values": this
+                .fakeActualAndExpectedMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should fail when greater than", function() {
-        assert.throws(
-            function() {
-                referee.assert.less(2, 1);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.less] Expected 2 to be less than 1"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.less");
-                return true;
-            }
-        );
+    it("calls referee.add with 'less' as name", function() {
+        assert(this.fakeReferee.add.calledWith("less"));
     });
 
-    it("should fail when equal", function() {
-        assert.throws(
-            function() {
-                referee.assert.less(1, 1);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.less] Expected 1 to be less than 1"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.less");
-                return true;
-            }
-        );
+    describe(".assert", function() {
+        context("when less than", function() {
+            it("returns true", function() {
+                assert(this.options.assert(1, 2));
+            });
+        });
+
+        context("when greater than", function() {
+            it("returns false", function() {
+                assert.equal(this.options.assert(2, 1), false);
+            });
+        });
+
+        context("when equal", function() {
+            it("returns false", function() {
+                assert.equal(this.options.assert(2, 2), false);
+            });
+        });
     });
 
-    it("should fail with custom message", function() {
-        var message = "b89674ea-cae2-4d88-9a70-74ad0af29bc2";
-
-        assert.throws(
-            function() {
-                referee.assert.less(2, 1, message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.less] " +
-                        message +
-                        ": Expected 2 to be less than 1"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.less");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.less", function() {
-    it("should pass when greater", function() {
-        referee.refute.less(2, 1);
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be less than ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be less than ${expected}"
+            );
+        });
     });
 
-    it("should pass when equal", function() {
-        referee.refute.less(1, 1);
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be greater than or equal to ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} to be greater than or equal to ${expected}"
+            );
+        });
     });
 
-    it("should fail when less", function() {
-        assert.throws(
-            function() {
-                referee.refute.less(1, 2);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.less] Expected 1 to be greater than or equal to 2"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.less");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toBeLessThan'", function() {
+            assert.equal(this.options.expectation, "toBeLessThan");
+        });
     });
 
-    it("should fail with custom message", function() {
-        var message = "e5f75904-424c-44b3-b757-710b06d88637";
-
-        assert.throws(
-            function() {
-                referee.refute.less(1, 2, message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.less] " +
-                        message +
-                        ": Expected 1 to be greater than or equal to 2"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.less");
-                return true;
-            }
-        );
+    describe(".values", function() {
+        it("delegates to '../actual-and-expected-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualAndExpectedMessageValues);
+        });
     });
 });

--- a/lib/assertions/less.test.js
+++ b/lib/assertions/less.test.js
@@ -73,7 +73,10 @@ describe("less factory", function() {
 
     describe(".values", function() {
         it("delegates to '../actual-and-expected-message-values'", function() {
-            assert.equal(this.options.values, this.fakeActualAndExpectedMessageValues);
+            assert.equal(
+                this.options.values,
+                this.fakeActualAndExpectedMessageValues
+            );
         });
     });
 });

--- a/lib/assertions/match-json.test.js
+++ b/lib/assertions/match-json.test.js
@@ -21,7 +21,7 @@ describe("assert.matchJson", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.matchJson] [object Object]: Expected (empty string) to be valid JSON"
+                    "[assert.matchJson] [object Object]: Expected '' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.matchJson");
@@ -39,7 +39,7 @@ describe("assert.matchJson", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.matchJson] Expected {something:not parsable} to be valid JSON"
+                    "[assert.matchJson] Expected '{something:not parsable}' to be valid JSON"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.matchJson");

--- a/lib/assertions/match-json.test.js
+++ b/lib/assertions/match-json.test.js
@@ -1,50 +1,161 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
-describe("assert.matchJson", function() {
-    it("should pass when json string matches object", function() {
-        referee.assert.matchJson('{"key":"value","and":42}', {
-            key: "value"
+function prepareTest(t, fakeActualForMatch) {
+    t.fakeSamsam = {
+        match: sinon.fake.returns("c7288c0f-b8c7-443f-bdee-c78098283ed1")
+    };
+    t.fakeActualForMatch = fakeActualForMatch || sinon.fake.returns(
+        "aea9cafb-23d1-4953-97a2-d8c7134ebfde"
+    );
+
+    var factory = proxyquire("./match-json", {
+        "@sinonjs/samsam": t.fakeSamsam,
+        "../actual-for-match": t.fakeActualForMatch
+    });
+
+    t.fakeReferee = {
+        add: sinon.fake(),
+        fail: sinon.fake()
+    };
+
+    factory(t.fakeReferee);
+
+    t.options = t.fakeReferee.add.args[0][1];
+}
+
+describe("matchJson factory", function() {
+    beforeEach(function() {
+        prepareTest(this);
+    });
+
+    describe(".assert", function() {
+        context("when json string is parsable", function() {
+            it("returns the result of calling samsam.match with the parsed string and the matcher", function() {
+                assert.equal(
+                    this.options.assert('{"key":"value","and":42}', {
+                        key: "value"
+                    }),
+                    this.fakeSamsam.match.returnValues[0]
+                );
+            });
+        });
+
+        context("when json string cannot be parsed", function() {
+            it("it calls the fail helper", function() {
+                this.options.assert.call(
+                    this.fakeReferee,
+                    "{something:not parsable}",
+                    {}
+                );
+
+                assert(
+                    this.fakeReferee.fail.calledOnceWithExactly,
+                    "${customMessage}Expected ${actual} to be valid JSON"
+                );
+            });
         });
     });
 
-    it("should fail when json string does not equal object", function() {
-        assert.throws(
-            function() {
-                referee.assert.matchJson("", '{"key":"value","and":42}', {
-                    key: "different"
-                });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.matchJson] [object Object]: Expected '' to be valid JSON"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.matchJson");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to match ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to match ${expected}"
+            );
+        });
     });
 
-    it("should fail when json string cannot be parsed", function() {
-        assert.throws(
-            function() {
-                referee.assert.matchJson("{something:not parsable}", {});
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.matchJson] Expected '{something:not parsable}' to be valid JSON"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.matchJson");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to match ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to match ${expected}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toMatchJson'", function() {
+            assert.equal(this.options.expectation, "toMatchJson");
+        });
+    });
+
+    describe(".values", function() {
+        it("is a ternary function", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 3);
+        });
+
+        it("returns a values object", function() {
+            var actual = "8effa0bb-0cf3-49d5-92f6-051fe72d7e49";
+            var matcher = "58b507b6-c895-4822-a865-7e57d72e7839";
+            var message = "d41cb10d-9c11-467f-bb1b-ba419fbb0416";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(typeof result, "object");
+        });
+
+        it("returns actual argument as actualRaw property", function() {
+            var actual = "34106ea7-68ff-4a65-b26d-84786f0d0584";
+            var matcher = "31aa8559-2cd0-4ce8-b0da-7d5dba8c621a";
+            var message = "f6781da4-8adf-435e-ac47-bb623c7e30f4";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(result.actualRaw, actual);
+        });
+
+        context("when actualForMatch returns a truthy value", function() {
+            beforeEach("", function() {
+                this.expected = "014ada52-5c1f-4f37-aa26-9ad15abf3c50";
+                prepareTest(this, sinon.fake.returns(this.expected));
+            });
+
+            it("returns the result of actualForMatch as the actual property", function() {
+                var actual = "33a9105d-7631-4b79-a376-b5a7879692e7";
+                var matcher = "6f8b8300-7f5e-462e-bbf3-c83973202403";
+                var message = "a758b0b6-1044-4a1d-8081-446c36bdb06e";
+                var result = this.options.values(actual, matcher, message);
+
+                assert.equal(result.actual, this.expected);
+            });
+        });
+
+        context("when actualForMatch returns a falsy value", function() {
+            beforeEach("", function() {
+                this.expected = undefined;
+                prepareTest(this, sinon.fake.returns(this.expected));
+            });
+
+            it("returns actual argument as the actual property", function() {
+                var actual = "081d6837-d9b2-49c5-a037-395e2e6b5efa";
+                var matcher = "d847fd58-2452-44cd-86b6-a448ba6cac69";
+                var message = "d1dbae8d-4ec8-490b-a8ce-9e4293b75b2b";
+                var result = this.options.values(actual, matcher, message);
+
+                assert.equal(result.actual, actual);
+            });
+        });
+
+        it("returns matcher argument as expected property", function() {
+            var actual = "2ebfbeb5-a484-47c7-81e4-cffa11714bc0";
+            var matcher = "271bab10-c7c1-48e0-94e9-78e2a9da2a43";
+            var message = "689c8c8d-1208-4151-900b-ff820fec8ca7";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(result.expected, matcher);
+        });
+
+        it("returns message argument as customMessage property", function() {
+            var actual = "6855652d-1579-4e8e-8633-38d899bd5dd5";
+            var matcher = "c70d1c50-034f-47c1-8564-eaf64a7a0d6c";
+            var message = "d2d531cb-3195-4c08-878f-46ea9bb87d98";
+            var result = this.options.values(actual, matcher, message);
+
+            assert.equal(result.customMessage, message);
+        });
     });
 });

--- a/lib/assertions/match-json.test.js
+++ b/lib/assertions/match-json.test.js
@@ -8,9 +8,9 @@ function prepareTest(t, fakeActualForMatch) {
     t.fakeSamsam = {
         match: sinon.fake.returns("c7288c0f-b8c7-443f-bdee-c78098283ed1")
     };
-    t.fakeActualForMatch = fakeActualForMatch || sinon.fake.returns(
-        "aea9cafb-23d1-4953-97a2-d8c7134ebfde"
-    );
+    t.fakeActualForMatch =
+        fakeActualForMatch ||
+        sinon.fake.returns("aea9cafb-23d1-4953-97a2-d8c7134ebfde");
 
     var factory = proxyquire("./match-json", {
         "@sinonjs/samsam": t.fakeSamsam,

--- a/lib/assertions/match-json.test.js
+++ b/lib/assertions/match-json.test.js
@@ -32,6 +32,10 @@ describe("matchJson factory", function() {
         prepareTest(this);
     });
 
+    it("calls referee.add with 'matchJson' as name", function() {
+        assert(this.fakeReferee.add.calledWith("matchJson"));
+    });
+
     describe(".assert", function() {
         context("when json string is parsable", function() {
             it("returns the result of calling samsam.match with the parsed string and the matcher", function() {

--- a/lib/assertions/match.js
+++ b/lib/assertions/match.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var samsam = require("@sinonjs/samsam");
-
 var actualForMatch = require("../actual-for-match");
 
 module.exports = function(referee) {

--- a/lib/assertions/match.test.js
+++ b/lib/assertions/match.test.js
@@ -1,950 +1,138 @@
 "use strict";
 
 var assert = require("assert");
-var samsam = require("@sinonjs/samsam");
+var proxyquire = require("proxyquire").noCallThru();
 var sinon = require("sinon");
 
-var referee = require("../referee");
-
 describe("assert.match", function() {
-    it("should pass for matching regexp", function() {
-        referee.assert.match("Assertions", /[a-z]/);
+    beforeEach(function() {
+        this.fakeSamsam = {
+            match: sinon.fake.returns("07228bdd-f7c1-48a3-a7bc-b4c6d6d900f5")
+        };
+        this.fakeActualForMatch = sinon.fake.returns(
+            "52efec5b-aab3-4c14-b4cb-4b0d26fdcf56"
+        );
+
+        this.factory = proxyquire("./match", {
+            "@sinonjs/samsam": this.fakeSamsam,
+            "../actual-for-match": this.fakeActualForMatch
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        this.factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should pass for generic object with test method returning true", function() {
-        referee.assert.match("Assertions", {
-            test: sinon.fake.returns(true)
+    afterEach(function() {
+        sinon.resetHistory();
+    });
+
+    it("calls referee.add with 'match' as name", function() {
+        assert(this.fakeReferee.add.calledWith("match"));
+    });
+
+    describe(".assert", function() {
+        it("calls samsam.match with `actual` and `matcher` arguments", function() {
+            var actual = {};
+            var matcher = {};
+
+            this.options.assert(actual, matcher);
+
+            assert(this.fakeSamsam.match.calledOnce);
+            assert(this.fakeSamsam.match.calledWith(actual, matcher));
+        });
+
+        it("returns the return value of samsam.match", function() {
+            var actual = {};
+            var matcher = {};
+            var result = this.options.assert(actual, matcher);
+
+            assert.equal(result, this.fakeSamsam.match.returnValues[0]);
         });
     });
 
-    it("should pass matching boolean", function() {
-        referee.assert.match(true, true);
-        referee.assert.match(false, false);
-    });
-
-    it("should pass if matching a number against itself", function() {
-        referee.assert.match(23, 23);
-    });
-
-    it("should pass if matcher is a function that returns true", function() {
-        referee.assert.match("Assertions 123", sinon.fake.returns(true));
-    });
-
-    it("should call matcher with assertion argument", function() {
-        var listener = sinon.fake.returns(true);
-
-        referee.assert.match("Assertions 123", listener);
-
-        sinon.assert.calledWith(listener, "Assertions 123");
-    });
-
-    it("should pass if matcher is substring of matchee", function() {
-        referee.assert.match("Diskord", "or");
-    });
-
-    it("should pass if matcher is string equal to matchee", function() {
-        referee.assert.match("Diskord", "Diskord");
-    });
-
-    it("should pass for strings ignoring case", function() {
-        referee.assert.match(
-            "Look ma, case-insensitive",
-            "LoOk Ma, CaSe-InSenSiTiVe"
-        );
-    });
-
-    it("should pass if object contains all properties in matcher", function() {
-        var object = {
-            id: 42,
-            name: "Christian",
-            doIt: "yes",
-
-            speak: function() {
-                return this.name;
-            }
-        };
-        var matcher = {
-            id: 42,
-            doIt: "yes"
-        };
-
-        referee.assert.match(object, matcher);
-    });
-
-    it("should pass for nested matcher", function() {
-        var object = {
-            id: 42,
-            name: "Christian",
-            doIt: "yes",
-            owner: {
-                someDude: "Yes",
-                hello: "ok"
-            },
-
-            speak: function() {
-                return this.name;
-            }
-        };
-        var matcher = {
-            owner: {
-                someDude: "Yes",
-                hello: samsam.createMatcher(function(value) {
-                    return value === "ok";
-                })
-            }
-        };
-
-        referee.assert.match(object, matcher);
-    });
-
-    it("should pass for empty strings", function() {
-        referee.assert.match("", "");
-    });
-
-    it("should pass for empty strings as object properties", function() {
-        referee.assert.match({ foo: "" }, { foo: "" });
-    });
-
-    it("should pass for similar arrays", function() {
-        referee.assert.match([1, 2, 3], [1, 2, 3]);
-    });
-
-    it("should pass for array subset", function() {
-        referee.assert.match([1, 2, 3], [2, 3]);
-    });
-
-    it("for single-element array subset", function() {
-        referee.assert.match([1, 2, 3], [1]);
-    });
-
-    it("for matching array subset", function() {
-        referee.assert.match([1, 2, 3, { id: 42 }], [{ id: 42 }]);
-    });
-
-    it("should fail for non-matching regexp", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", /^[a-z]$/);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Assertions 123' expected to match /^[a-z]$/"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for mis-matching boolean", function() {
-        assert.throws(
-            function() {
-                referee.assert.match(true, false);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] true expected to match false"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for generic object with test method returning false", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions", {
-                    test: sinon.fake.returns(false)
-                });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-
-                var r = new RegExp(
-                    "\\[assert.match\\] 'Assertions' expected to match \\{\n" +
-                        "  test: \\[Function: f\\] \\{\n" +
-                        "    displayName: 'fake',\n" +
-                        "    id: 'fake#\\d+',\n" +
-                        "    callback: undefined\n" +
-                        "  \\}\n" +
-                        "\\}"
-                );
-
-                assert(r.test(error.message));
-
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for mis-matching array", function() {
-        assert.throws(
-            function() {
-                referee.assert.match([1, 2, 3], [2, 3, 4]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] [ 1, 2, 3 ] expected to match [ 2, 3, 4 ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for mis-ordered array 'subset'", function() {
-        assert.throws(
-            function() {
-                referee.assert.match([1, 2, 3], [1, 3]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] [ 1, 2, 3 ] expected to match [ 1, 3 ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message", function() {
-        var message = "2ea8ea3b-9a13-4f45-aa54-19e58f12a460";
-
-        assert.throws(
-            function() {
-                referee.assert.match(true, false, message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] " +
-                        message +
-                        ": true expected to match false"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when match object is null", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", null);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Assertions 123' expected to match null"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when match object is undefined", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", undefined);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Assertions 123' expected to match undefined"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail with custom message when match object is undefined", function() {
-        var message = "a6801b52-f6fd-4e26-906a-f596b3d38156";
-
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", undefined, message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] " +
-                        message +
-                        ": 'Assertions 123' expected to match undefined"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when match object is false", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", false);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Assertions 123' expected to match false"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matching a number against a string", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Assertions 123", 23);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Assertions 123' expected to match 23"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matching a number against a similar string", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("23", 23);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] '23' expected to match 23"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matcher is a function that returns false", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("23", sinon.fake.returns(false));
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                var r = new RegExp(
-                    "\\[assert.match\\] '23' expected to match \\[Function: f\\] \\{ displayName: 'fake', id: 'fake#\\d+', callback: undefined \\}"
-                );
-                assert(r.test(error.message));
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    // verify all falsy values
-    [false, "", 0, null, undefined].forEach(function(value) {
-        it(
-            "should fail when matcher is a function that returns" + value,
-            function() {
-                assert.throws(
-                    function() {
-                        referee.assert.match("23", sinon.fake.returns(value));
-                    },
-                    function(error) {
-                        assert.equal(error.code, "ERR_ASSERTION");
-                        assert(
-                            error.message.indexOf(
-                                "[assert.match] '23' expected to match [Function: f] {"
-                            ) === 0
-                        );
-                        assert.equal(error.name, "AssertionError");
-                        assert.equal(error.operator, "assert.match");
-                        return true;
-                    }
-                );
-            }
-        );
-    });
-
-    it("should fail when matcher does not return explicit true", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("23", function() {
-                    return "Hey";
-                });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] '23' expected to match [Function]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when match string is not substring of matchee", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Vim", "Emacs");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Vim' expected to match 'Emacs'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when match string is not substring of object", function() {
-        assert.throws(
-            function() {
-                referee.assert.match({}, "Emacs");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] {} expected to match 'Emacs'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail matcher is substring of object.toString", function() {
-        assert.throws(
-            function() {
-                referee.assert.match("Emacs", {
-                    toString: function() {
-                        return "Emacs";
-                    }
-                });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 'Emacs' expected to match { toString: [Function: toString] }"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-
-    [null, undefined, false, 0, NaN].forEach(function(value) {
-        it("should fail for " + value + " and empty string", function() {
-            assert.throws(
-                function() {
-                    referee.assert.match(value, "");
-                },
-                function(error) {
-                    assert.equal(error.code, "ERR_ASSERTION");
-                    assert.equal(
-                        error.message,
-                        "[assert.match] " + value + " expected to match ''"
-                    );
-                    assert.equal(error.name, "AssertionError");
-                    assert.equal(error.operator, "assert.match");
-                    return true;
-                }
+    describe(".assertMessage", function() {
+        it("is '${customMessage}${actual} expected to match ${expected}", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}${actual} expected to match ${expected}"
             );
         });
     });
 
-    it("should fail when object does not contain all properties in matcher", function() {
-        assert.throws(
-            function() {
-                referee.assert.match({ id: 42 }, { id: 42, name: "Apple pie" });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] { id: 42, name: undefined } expected to match { id: 42, name: 'Apple pie' }"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.match");
-                return true;
-            }
-        );
-    });
-});
-
-describe("refute.match", function() {
-    it("should fail for matching regexp", function() {
-        assert.throws(
-            function() {
-                referee.refute.match("Assertions", /[a-z]/);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Assertions' expected not to match /[a-z]/"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for generic object with test method returning true", function() {
-        assert.throws(
-            function() {
-                referee.refute.match("Assertions", {
-                    test: sinon.fake.returns(true)
-                });
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Assertions' expected not to match {\n" +
-                        "  test: [Function: f] {\n" +
-                        "    displayName: 'fake',\n" +
-                        "    id: 'fake#14',\n" +
-                        "    callback: undefined\n" +
-                        "  }\n" +
-                        "}"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for non-matching regexp", function() {
-        referee.refute.match("Assertions 123", /^[a-z]$/);
-    });
-
-    it("should pass for generic object with test method returning false", function() {
-        referee.refute.match("Assertions", {
-            test: sinon.fake.returns(false)
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}${actual} expected not to match ${expected}", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}${actual} expected not to match ${expected}"
+            );
         });
     });
 
-    it("should fail for with custom message", function() {
-        var message = "8998cc8e-615a-4c29-bbe5-77888b287d9a";
-
-        assert.throws(
-            function() {
-                referee.refute.match(true, true, message);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] " +
-                        message +
-                        ": true expected not to match true"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    [null, undefined, false].forEach(function(value) {
-        it("should pass when match object is " + value, function() {
-            referee.refute.match("Assertions 123", value);
+    describe(".expectation", function() {
+        it("is 'toMatch'", function() {
+            assert.equal(this.options.expectation, "toMatch");
         });
     });
 
-    it("should pass when matching a number against a string", function() {
-        referee.refute.match("Assertions 23", 23);
-    });
-
-    it("should fail when matching a number against a similar string", function() {
-        assert.throws(
-            function() {
-                referee.refute.match(23, "23");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 23 expected not to match '23'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matching a number against itself", function() {
-        assert.throws(
-            function() {
-                referee.refute.match(23, 23);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 23 expected not to match 23"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matcher is a function that returns true", function() {
-        assert.throws(
-            function() {
-                referee.refute.match(
-                    "Assertions 123",
-                    sinon.fake.returns(true)
-                );
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Assertions 123' expected not to match [Function: f] {\n" +
-                        "  displayName: 'fake',\n" +
-                        "  id: 'fake#16',\n" +
-                        "  callback: undefined\n" +
-                        "}"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    // verify all falsy values
-    [false, "", 0, null, undefined].forEach(function(value) {
-        it(
-            "should pass matcher is a function that returns " + value,
-            function() {
-                referee.refute.match(
-                    "Assertions 123",
-                    sinon.fake.returns(value)
-                );
-            }
-        );
-    });
-
-    it("should pass when matcher does not return explicit true", function() {
-        referee.refute.match("Assertions 123", function() {
-            return "Hey";
+    describe(".values", function() {
+        it("is a ternary function", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 3);
         });
-    });
 
-    it("should call matcher wtih assertion argument", function() {
-        var actual = "Assertions 123";
-        var listener = sinon.fake();
+        it("returns a values object", function() {
+            var actual = "1f774102-1478-4c8d-91a3-e564558bd0a8";
+            var matcher = "122c315e-578f-4063-a6be-70898a379637";
+            var message = "27f5d147-b403-4778-a4b4-c851da0fa677";
+            var result = this.options.values(actual, matcher, message);
 
-        referee.refute.match(actual, listener);
-
-        sinon.assert.calledWith(listener, actual);
-    });
-
-    it("should fail when matcher is substring of matchee", function() {
-        assert.throws(
-            function() {
-                referee.refute.match("Diskord", "or");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Diskord' expected not to match 'or'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when matcher is string equal to matchee", function() {
-        assert.throws(
-            function() {
-                referee.refute.match("Diskord", "Diskord");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Diskord' expected not to match 'Diskord'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should pass when match string is not substring of matchee", function() {
-        referee.refute.match("Vim", "Emacs");
-    });
-
-    it("should pass when match string is not substring of object", function() {
-        referee.refute.match("Vim", {
-            toString: sinon.fake.returns("Emacs")
+            assert.equal(typeof result, "object");
         });
-    });
 
-    [null, undefined, false, 0, NaN].forEach(function(value) {
-        it(
-            "should pass when matching an empty string with " + value,
-            function() {
-                referee.refute.match("", value);
-            }
-        );
-    });
+        it("calls actualForMatch with `actual`, `matcher` arguments", function() {
+            var actual = "8d2b1903-ec44-4c4f-8e6d-d223b6412c09";
+            var matcher = "39b545c0-46ea-4221-b5f5-73d76a98c9fb";
+            var message = "6770d8f4-bd2c-4bdb-8839-77fca389a94f";
 
-    it("should fail when object contains all properties in matcher", function() {
-        assert.throws(
-            function() {
-                var object = {
-                    id: 42,
-                    name: "Christian",
-                    doIt: "yes",
+            this.options.values(actual, matcher, message);
 
-                    speak: function() {
-                        return this.name;
-                    }
-                };
-                var matcher = {
-                    id: 42,
-                    doIt: "yes"
-                };
+            assert(this.fakeActualForMatch.calledOnce);
+            assert(this.fakeActualForMatch.calledWith(actual, matcher));
+        });
 
-                referee.refute.match(object, matcher);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] { id: 42, doIt: 'yes' } expected not to match { id: 42, doIt: 'yes' }"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
+        it("returns the return value of actualForMatch as the `actual` property", function() {
+            var actual = "be4b7ea4-2d58-49e0-8c96-09e4f34e3d63";
+            var matcher = "4367d84d-8dab-4510-808a-c5e368b21b99";
+            var message = "c6308fee-81f7-4e1e-9d8d-8d8f598466b1";
+            var result = this.options.values(actual, matcher, message);
 
-    it("should fail for nested matcher", function() {
-        assert.throws(
-            function() {
-                var object = {
-                    id: 42,
-                    name: "Christian",
-                    doIt: "yes",
-                    owner: {
-                        someDude: "Yes",
-                        hello: "ok"
-                    },
+            assert.equal(
+                result.actual,
+                this.fakeActualForMatch.returnValues[0]
+            );
+        });
 
-                    speak: function() {
-                        return this.name;
-                    }
-                };
-                var matcher = {
-                    owner: {
-                        someDude: "Yes",
-                        hello: samsam.createMatcher(function(value) {
-                            return value === "ok";
-                        })
-                    }
-                };
+        it("returns `matcher` argument as `expected` property", function() {
+            var actual = "1a5cdd2a-b54f-49e7-aae3-d714796f1c7b";
+            var matcher = "341c11a8-298f-4b90-9c10-206dabe577ce";
+            var message = "d2f80b1b-a735-48af-b9a7-26eed8c9742b";
+            var result = this.options.values(actual, matcher, message);
 
-                referee.refute.match(object, matcher);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] { owner: { someDude: 'Yes', hello: 'ok' } } expected not to match {\n" +
-                        "  owner: {\n" +
-                        "    someDude: 'Yes',\n" +
-                        "    hello: { test: [Function], message: 'match(undefined)' }\n" +
-                        "  }\n" +
-                        "}"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
+            assert.equal(result.expected, matcher);
+        });
 
-    it("should pass for nested matcher with mismatching properties", function() {
-        var object = {
-            id: 42,
-            name: "Christian",
-            doIt: "yes",
-            owner: {
-                someDude: "Yes",
-                hello: "ok"
-            },
+        it("returns `message` argument as `customMessage` property", function() {
+            var actual = "1a5cdd2a-b54f-49e7-aae3-d714796f1c7b";
+            var matcher = "341c11a8-298f-4b90-9c10-206dabe577ce";
+            var message = "d2f80b1b-a735-48af-b9a7-26eed8c9742b";
+            var result = this.options.values(actual, matcher, message);
 
-            speak: function() {
-                return this.name;
-            }
-        };
-        var matcher = {
-            owner: {
-                someDude: "No",
-                hello: function(value) {
-                    return value === "ok";
-                }
-            }
-        };
-
-        referee.refute.match(object, matcher);
-    });
-
-    it("fail for similar arrays", function() {
-        assert.throws(
-            function() {
-                referee.refute.match([1, 2, 3], [1, 2, 3]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1, 2, 3 ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("for array subset", function() {
-        assert.throws(
-            function() {
-                referee.refute.match([1, 2, 3], [2, 3]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 2, 3 ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("for single-element array subset", function() {
-        assert.throws(
-            function() {
-                referee.refute.match([1, 2, 3], [1]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1 ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should fail for matching array subset", function() {
-        assert.throws(
-            function() {
-                referee.refute.match([1, 2, 3, { id: 42 }], [{ id: 42 }]);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] [ 1, 2, 3, { id: 42 } ] expected not to match [ { id: 42 } ]"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
-    });
-
-    it("should pass for mis-matching array 'subset'", function() {
-        referee.refute.match([1, 2, 3], [2, 3, 4]);
-    });
-
-    it("should pass for mis-ordered array 'subset'", function() {
-        referee.refute.match([1, 2, 3], [1, 3]);
-    });
-
-    it("should fail when match string is substring of matchee", function() {
-        assert.throws(
-            function() {
-                referee.refute.match("Emacs", "mac");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[refute.match] 'Emacs' expected not to match 'mac'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "refute.match");
-                return true;
-            }
-        );
+            assert.equal(result.expected, matcher);
+        });
     });
 });

--- a/lib/assertions/match.test.js
+++ b/lib/assertions/match.test.js
@@ -130,7 +130,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match /^[a-z]$/"
+                    "[assert.match] 'Assertions 123' expected to match /^[a-z]$/"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -166,10 +166,19 @@ describe("assert.match", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] Assertions expected to match { test: function fake() {} }"
+
+                var r = new RegExp(
+                    "\\[assert.match\\] 'Assertions' expected to match \\{\n" +
+                        "  test: \\[Function: f\\] \\{\n" +
+                        "    displayName: 'fake',\n" +
+                        "    id: 'fake#\\d+',\n" +
+                        "    callback: undefined\n" +
+                        "  \\}\n" +
+                        "\\}"
                 );
+
+                assert(r.test(error.message));
+
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
                 return true;
@@ -186,7 +195,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] [1, 2, 3] expected to match [2, 3, 4]"
+                    "[assert.match] [ 1, 2, 3 ] expected to match [ 2, 3, 4 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -204,7 +213,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] [1, 2, 3] expected to match [1, 3]"
+                    "[assert.match] [ 1, 2, 3 ] expected to match [ 1, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -244,7 +253,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match null"
+                    "[assert.match] 'Assertions 123' expected to match null"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -262,7 +271,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match undefined"
+                    "[assert.match] 'Assertions 123' expected to match undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -284,7 +293,7 @@ describe("assert.match", function() {
                     error.message,
                     "[assert.match] " +
                         message +
-                        ": Assertions 123 expected to match undefined"
+                        ": 'Assertions 123' expected to match undefined"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -302,7 +311,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match false"
+                    "[assert.match] 'Assertions 123' expected to match false"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -320,7 +329,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Assertions 123 expected to match 23"
+                    "[assert.match] 'Assertions 123' expected to match 23"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -338,7 +347,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] 23 expected to match 23"
+                    "[assert.match] '23' expected to match 23"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -354,10 +363,10 @@ describe("assert.match", function() {
             },
             function(error) {
                 assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.match] 23 expected to match function fake() {}"
+                var r = new RegExp(
+                    "\\[assert.match\\] '23' expected to match \\[Function: f\\] \\{ displayName: 'fake', id: 'fake#\\d+', callback: undefined \\}"
                 );
+                assert(r.test(error.message));
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
                 return true;
@@ -376,9 +385,10 @@ describe("assert.match", function() {
                     },
                     function(error) {
                         assert.equal(error.code, "ERR_ASSERTION");
-                        assert.equal(
-                            error.message,
-                            "[assert.match] 23 expected to match function fake() {}"
+                        assert(
+                            error.message.indexOf(
+                                "[assert.match] '23' expected to match [Function: f] {"
+                            ) === 0
                         );
                         assert.equal(error.name, "AssertionError");
                         assert.equal(error.operator, "assert.match");
@@ -400,7 +410,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] 23 expected to match function () {}"
+                    "[assert.match] '23' expected to match [Function]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -418,7 +428,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Vim expected to match Emacs"
+                    "[assert.match] 'Vim' expected to match 'Emacs'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -436,7 +446,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] {  } expected to match Emacs"
+                    "[assert.match] {} expected to match 'Emacs'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -458,7 +468,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.match] Emacs expected to match Emacs"
+                    "[assert.match] 'Emacs' expected to match { toString: [Function: toString] }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -477,9 +487,7 @@ describe("assert.match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.match] " +
-                            value +
-                            " expected to match (empty string)"
+                        "[assert.match] " + value + " expected to match ''"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.match");
@@ -498,7 +506,7 @@ describe("assert.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[assert.match] { id: 42, name: undefined } expected to match { id: 42, name: "Apple pie" }'
+                    "[assert.match] { id: 42, name: undefined } expected to match { id: 42, name: 'Apple pie' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.match");
@@ -518,7 +526,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions expected not to match /[a-z]/"
+                    "[refute.match] 'Assertions' expected not to match /[a-z]/"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -538,7 +546,13 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions expected not to match { test: function fake() {} }"
+                    "[refute.match] 'Assertions' expected not to match {\n" +
+                        "  test: [Function: f] {\n" +
+                        "    displayName: 'fake',\n" +
+                        "    id: 'fake#14',\n" +
+                        "    callback: undefined\n" +
+                        "  }\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -598,7 +612,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] 23 expected not to match 23"
+                    "[refute.match] 23 expected not to match '23'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -637,7 +651,11 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Assertions 123 expected not to match function fake() {}"
+                    "[refute.match] 'Assertions 123' expected not to match [Function: f] {\n" +
+                        "  displayName: 'fake',\n" +
+                        "  id: 'fake#16',\n" +
+                        "  callback: undefined\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -683,7 +701,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Diskord expected not to match or"
+                    "[refute.match] 'Diskord' expected not to match 'or'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -701,7 +719,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Diskord expected not to match Diskord"
+                    "[refute.match] 'Diskord' expected not to match 'Diskord'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -752,7 +770,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.match] { doIt: "yes", id: 42 } expected not to match { doIt: "yes", id: 42 }'
+                    "[refute.match] { id: 42, doIt: 'yes' } expected not to match { id: 42, doIt: 'yes' }"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -792,7 +810,12 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    '[refute.match] { owner: { hello: "ok", someDude: "Yes" } } expected not to match { owner: { hello: match(undefined), someDude: "Yes" } }'
+                    "[refute.match] { owner: { someDude: 'Yes', hello: 'ok' } } expected not to match {\n" +
+                        "  owner: {\n" +
+                        "    someDude: 'Yes',\n" +
+                        "    hello: { test: [Function], message: 'match(undefined)' }\n" +
+                        "  }\n" +
+                        "}"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -836,7 +859,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [1, 2, 3]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1, 2, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -854,7 +877,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [2, 3]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 2, 3 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -872,7 +895,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3] expected not to match [1]"
+                    "[refute.match] [ 1, 2, 3 ] expected not to match [ 1 ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -890,7 +913,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] [1, 2, 3, { id: 42 }] expected not to match [{ id: 42 }]"
+                    "[refute.match] [ 1, 2, 3, { id: 42 } ] expected not to match [ { id: 42 } ]"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");
@@ -916,7 +939,7 @@ describe("refute.match", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[refute.match] Emacs expected not to match mac"
+                    "[refute.match] 'Emacs' expected not to match 'mac'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "refute.match");

--- a/lib/assertions/near.test.js
+++ b/lib/assertions/near.test.js
@@ -1,63 +1,123 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var sinon = require("sinon");
 
-describe("assert.near", function() {
-    it("should pass for equal numbers", function() {
-        referee.assert.near(3, 3, 0);
+var factory = require("./near");
+
+describe("near factory", function() {
+    beforeEach(function() {
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
-    it("should pass for numbers in delta range", function() {
-        referee.assert.near(2, 3, 1);
+
+    it("calls referee.add with 'near' as name", function() {
+        assert(this.fakeReferee.add.calledWith("near"));
     });
-    it("should fail for numbers out of delta range", function() {
-        assert.throws(
-            function() {
-                referee.assert.near(2, 3, 0.5);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.near] Expected 2 to be equal to 3 +/- 0.5"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.near");
-                return true;
-            }
-        );
+
+    describe(".assert", function() {
+        context("when called with equal numbers", function() {
+            it("should return true", function() {
+                assert(this.options.assert(3, 3, 0));
+            });
+        });
+
+        context("when called with numbers in delta range", function() {
+            it("should return true", function() {
+                assert(this.options.assert(2, 3, 1));
+            });
+        });
+
+        context("when called with numbers out of delta range", function() {
+            it("should return false", function() {
+                assert.equal(this.options.assert(2, 3, 0.5), false);
+            });
+        });
     });
-    it("should fail with custom range", function() {
-        assert.throws(
-            function() {
-                referee.assert.near(3, 2, 0.6, "Ho!");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.near] Ho! Expected 3 to be equal to 2 +/- 0.6"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.near");
-                return true;
-            }
-        );
+
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected ${actual} to be equal to ${expected} +/- ${delta}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected ${actual} to be equal to ${expected} +/- ${delta}"
+            );
+        });
     });
-    it("should fail if not passed any arguments", function() {
-        assert.throws(
-            function() {
-                referee.assert.near();
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.near] Expected to receive at least 3 argument(s)"
-                );
-                assert.equal(error.name, "AssertionError");
-                return true;
-            }
-        );
+
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected ${actual} not to be equal to ${expected} +/- ${delta}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected ${actual} not to be equal to ${expected} +/- ${delta}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toBeNear'", function() {
+            assert.equal(this.options.expectation, "toBeNear");
+        });
+    });
+
+    describe(".values", function() {
+        it("is function with an arity of 4", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 4);
+        });
+
+        it("returns a values object", function() {
+            var actual = "7ebf3834-e7cf-4a1f-a79e-a49d13cf1179";
+            var expected = "24f1d545-5df2-4647-93f0-d3e5a59a2cf8";
+            var delta = "de264d3d-f3ac-42af-9e19-950822ffd5ab";
+            var message = "f6acff98-2074-4df5-94bf-f3b424aabecb";
+            var result = this.options.values(actual, expected, delta, message);
+
+            assert.equal(typeof result, "object");
+        });
+
+        it("returns the actual argument as the actual property", function() {
+            var actual = "accec083-dff6-4827-9592-91ee695c088b";
+            var expected = "5dbf3ab3-472a-45b4-9b2a-1de4b4ad4606";
+            var delta = "ed5ec214-9dac-4d71-b00c-849d3e2e4376";
+            var message = "c228ad1a-0bc3-4147-8bce-b4f17d9263cd";
+            var result = this.options.values(actual, expected, delta, message);
+
+            assert.equal(result.actual, actual);
+        });
+
+        it("returns the expected argument as the expected property", function() {
+            var actual = "a232829f-26c8-4300-a984-fdbd596418c3";
+            var expected = "6ccf012b-b848-4863-b176-074654bb4fb6";
+            var delta = "0f80dc73-dc3c-4c84-bdf9-9485a74510ce";
+            var message = "84f73bca-4543-4a6b-abb6-808c1fb2e87a";
+            var result = this.options.values(actual, expected, delta, message);
+
+            assert.equal(result.expected, expected);
+        });
+
+        it("returns the delta argument as the delta property", function() {
+            var actual = "53c5da9d-63f6-4fa9-9e39-fa98c81dd6da";
+            var expected = "a7068a5d-a011-41c6-959a-13dcf740bccf";
+            var delta = "c5573a4d-2956-409f-98f8-4f84022e8705";
+            var message = "4d8b70ce-19a4-4595-8aaa-78628c2a2794";
+            var result = this.options.values(actual, expected, delta, message);
+
+            assert.equal(result.delta, delta);
+        });
+
+        it("returns the message argument as the customMessage property", function() {
+            var actual = "5b7fe457-407b-4331-8096-5f99f9d63c9c";
+            var expected = "cf7b988d-4a8c-470c-99e7-138abfe45611";
+            var delta = "96391e41-b986-4389-99db-9ad60919fb47";
+            var message = "7fbb1a0b-38e9-42d6-8707-9b34aef7a974";
+            var result = this.options.values(actual, expected, delta, message);
+
+            assert.equal(result.customMessage, message);
+        });
     });
 });

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -1,94 +1,147 @@
 "use strict";
 
-var referee = require("../referee");
+var assert = require("assert");
+var sinon = require("sinon");
 
-describe("assert.rejects", function() {
-    it("should return a promise", function() {
-        var assertion = referee.assert.rejects(Promise.reject("test"), "test");
-        referee.assert.isPromise(assertion);
+var factory = require("./rejects");
+
+describe("rejects factory", function() {
+    beforeEach(function() {
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    context("when promise argument rejects to value argument", function() {
-        it("should resolve the returned promise", function() {
-            return referee.assert.rejects(Promise.reject("test"), "test");
+    it("calls referee.add with 'rejects' as name", function() {
+        assert(this.fakeReferee.add.calledWith("rejects"));
+    });
+
+    describe(".assert", function() {
+        it("should return a promise", function() {
+            var result = this.options.assert(Promise.reject("test"), "test");
+
+            assert(result instanceof Promise);
+
+            return result;
         });
-    });
 
-    context(
-        "when promise argument does not reject to value argument",
-        function() {
+        context("when promise argument rejects to value argument", function() {
+            it("should resolve the returned promise", function() {
+                return this.options.assert(Promise.reject("test"), "test");
+            });
+        });
+
+        context(
+            "when promise argument does not reject to value argument",
+            function() {
+                it("should reject the returned promise", function() {
+                    return this.options
+                        .assert(Promise.reject("test"), "test2")
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                        });
+                });
+            }
+        );
+
+        context("when promise argument is not a promise", function() {
             it("should reject the returned promise", function() {
-                return referee.assert
-                    .rejects(Promise.reject("test"), "test2")
+                return this.options.assert({}, "test").catch(function(e) {
+                    assert(e instanceof Error);
+                });
+            });
+        });
+
+        context("when promise argument does not reject", function() {
+            it("should reject the returned promise", function() {
+                return this.options
+                    .assert(Promise.resolve(), "test")
                     .catch(function(e) {
-                        referee.assert.isError(e);
+                        assert(e instanceof Error);
                     });
             });
-        }
-    );
-
-    context("when promise argument is not a promise", function() {
-        it("should reject the returned promise", function() {
-            return referee.assert.rejects({}, "test").catch(function(e) {
-                referee.assert.isError(e);
-            });
         });
     });
 
-    context("when promise argument does not reject", function() {
-        it("should reject the returned promise", function() {
-            return referee.assert
-                .rejects(Promise.resolve(), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
+    describe(".refute", function() {
+        it("should return a promise", function() {
+            var result = this.options.refute(Promise.reject("test"), "test2");
+
+            assert(result instanceof Promise);
+
+            return result;
+        });
+
+        context(
+            "when promise argument does not rejects to value argument",
+            function() {
+                it("should resolve the returned promise", function() {
+                    return this.options.refute(Promise.reject("test"), "test2");
                 });
-        });
-    });
-});
-
-describe("refute.rejects", function() {
-    it("should return a promise", function() {
-        var refutation = referee.refute.rejects(
-            Promise.reject("test"),
-            "test2"
+            }
         );
-        referee.assert.isPromise(refutation);
-    });
 
-    context(
-        "when promise argument does not rejects to value argument",
-        function() {
-            it("should resolve the returned promise", function() {
-                return referee.refute.rejects(Promise.reject("test"), "test2");
-            });
-        }
-    );
-
-    context("when promise argument rejects to value argument", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute
-                .rejects(Promise.reject("test"), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
-                });
-        });
-    });
-
-    context("when promise argument is not a promise", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute.rejects({}, "test").catch(function(e) {
-                referee.assert.isError(e);
+        context("when promise argument rejects to value argument", function() {
+            it("should reject the returned promise", function() {
+                return this.options
+                    .refute(Promise.reject("test"), "test")
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                    });
             });
         });
-    });
 
-    context("when promise argument does not reject", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute
-                .rejects(Promise.resolve(), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
+        context("when promise argument is not a promise", function() {
+            it("should reject the returned promise", function() {
+                return this.options.refute({}, "test").catch(function(e) {
+                    assert(e instanceof Error);
                 });
+            });
+        });
+
+        context("when promise argument does not reject", function() {
+            it("should reject the returned promise", function() {
+                return this.options
+                    .refute(Promise.resolve(), "test")
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                    });
+            });
         });
     });
+
+    describe(".assertMessage", function() {
+        it("is '${actual} is not identical to ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${actual} is not identical to ${expected}"
+            );
+        });
+    });
+
+    describe(".refuteMessage", function() {
+        it("is '${actual} is identical to ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${actual} is identical to ${expected}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toRejectWith'", function() {
+            assert.equal(this.options.expectation, "toRejectWith");
+        });
+    });
+
+    describe(".values", function() {
+        it("does not define a values property", function() {
+            assert.equal(this.options.values, undefined);
+        });
+    });
+
 });

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -143,5 +143,4 @@ describe("rejects factory", function() {
             assert.equal(this.options.values, undefined);
         });
     });
-
 });

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -1,102 +1,152 @@
 "use strict";
 
-var referee = require("../referee");
+var assert = require("assert");
+var sinon = require("sinon");
 
-describe("assert.resolves", function() {
-    it("should return a promise", function() {
-        var assertion = referee.assert.resolves(
-            Promise.resolve("test"),
-            "test"
-        );
-        referee.assert.isPromise(assertion);
+var factory = require("./resolves");
+
+describe("resolves factory", function() {
+    beforeEach(function() {
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    context("when promise argument resolves to value argument", function() {
-        it("should resolve the returned promise", function() {
-            return referee.assert.resolves(Promise.resolve("test"), "test");
+    it("calls referee.add with 'resolves' as name", function() {
+        assert(this.fakeReferee.add.calledWith("resolves"));
+    });
+
+    describe(".assert", function() {
+        it("returns a promise", function() {
+            var result = this.options.assert(
+                Promise.resolve("apple pie"),
+                "apple pie"
+            );
+
+            assert(result instanceof Promise);
+
+            return result;
         });
-    });
 
-    context(
-        "when promise argument does not resolves to value argument",
-        function() {
+        context("when promise argument resolves to value argument", function() {
+            it("should resolve the returned promise", function() {
+                return this.options.assert(Promise.resolve("test"), "test");
+            });
+        });
+
+        context(
+            "when promise argument does not resolves to value argument",
+            function() {
+                it("should reject the returned promise", function() {
+                    return this.options
+                        .assert(Promise.resolve("test"), "test2")
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                        });
+                });
+            }
+        );
+
+        context("when promise argument is not a promise", function() {
             it("should reject the returned promise", function() {
-                return referee.assert
-                    .resolves(Promise.resolve("test"), "test2")
+                return this.options.assert({}, "test").catch(function(e) {
+                    assert(e instanceof Error);
+                });
+            });
+        });
+
+        context("when promise argument does not resolve", function() {
+            it("should reject the returned promise", function() {
+                return this.options
+                    .assert(Promise.reject(), "test")
                     .catch(function(e) {
-                        referee.assert.isError(e);
+                        assert(e instanceof Error);
                     });
             });
-        }
-    );
-
-    context("when promise argument is not a promise", function() {
-        it("should reject the returned promise", function() {
-            return referee.assert.resolves({}, "test").catch(function(e) {
-                referee.assert.isError(e);
-            });
         });
     });
 
-    context("when promise argument does not resolve", function() {
-        it("should reject the returned promise", function() {
-            return referee.assert
-                .resolves(Promise.reject(), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
+    describe(".refute", function() {
+        it("returns a promise", function() {
+            var result = this.options.refute(Promise.resolve("test"), "test2");
+
+            assert(result instanceof Promise);
+
+            return result;
+        });
+
+        context(
+            "when promise argument does not resolve to value argument",
+            function() {
+                it("resolves the returned promise", function() {
+                    return this.options.refute(
+                        Promise.resolve("test"),
+                        "test2"
+                    );
                 });
-        });
-    });
-});
-
-describe("refute.resolves", function() {
-    it("should return a promise", function() {
-        var refutation = referee.refute.resolves(
-            Promise.resolve("test"),
-            "test2"
+            }
         );
-        referee.assert.isPromise(refutation);
 
-        return refutation;
-    });
-
-    context(
-        "when promise argument does not resolve to value argument",
-        function() {
-            it("should resolve the returned promise", function() {
-                return referee.refute.resolves(
-                    Promise.resolve("test"),
-                    "test2"
-                );
+        context("when promise argument resolves to value argument", function() {
+            it("rejects the returned promise", function() {
+                return this.options
+                    .refute(Promise.resolve("test"), "test")
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                    });
             });
-        }
-    );
-
-    context("when promise argument resolves to value argument", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute
-                .resolves(Promise.resolve("test"), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
-                });
         });
-    });
 
-    context("when promise argument is not a promise", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute.resolves({}, "test").catch(function(e) {
-                referee.assert.isError(e);
+        context("when promise argument is not a promise", function() {
+            it("should reject the returned promise", function() {
+                return this.options.refute({}, "test").catch(function(e) {
+                    assert(e instanceof Error);
+                });
+            });
+        });
+
+        context("when promise argument does not resolve", function() {
+            it("should reject the returned promise", function() {
+                return this.options
+                    .refute(Promise.reject(), "test")
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                    });
             });
         });
     });
 
-    context("when promise argument does not resolve", function() {
-        it("should reject the returned promise", function() {
-            return referee.refute
-                .resolves(Promise.reject(), "test")
-                .catch(function(e) {
-                    referee.assert.isError(e);
-                });
+    describe(".assertMessage", function() {
+        it("is '${actual} is not identical to ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${actual} is not identical to ${expected}"
+            );
+        });
+    });
+
+    describe(".refuteMessage", function() {
+        it("is '${actual} is identical to ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${actual} is identical to ${expected}"
+            );
+        });
+    });
+
+    describe(".expectation", function() {
+        it("is 'toResolveWith'", function() {
+            assert.equal(this.options.expectation, "toResolveWith");
+        });
+    });
+
+    describe(".values", function() {
+        it("does not define a values property", function() {
+            assert.equal(this.options.values, undefined);
         });
     });
 });

--- a/lib/assertions/same.test.js
+++ b/lib/assertions/same.test.js
@@ -66,7 +66,7 @@ describe("assert.same", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.same] 666 expected to be the same object as 666"
+                    "[assert.same] 666 expected to be the same object as '666'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.same");

--- a/lib/assertions/same.test.js
+++ b/lib/assertions/same.test.js
@@ -1,95 +1,132 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
 var obj = { id: 42 };
 var obj2 = { id: 42 };
 
-describe("assert.same", function() {
-    it("should pass when comparing object to itself", function() {
-        referee.assert.same(obj, obj);
+describe("same factory", function() {
+    beforeEach(function() {
+        this.fakeActualAndExpectedMessageValues =
+            "866c5b01-0028-4cf2-8dd7-9ef99bbc53b0";
+
+        var factory = proxyquire("./same", {
+            "../actual-and-expected-message-values": this
+                .fakeActualAndExpectedMessageValues
+        });
+
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should pass when comparing strings", function() {
-        referee.assert.same("Hey", "Hey");
+    it("calls referee.add with 'same' as name", function() {
+        assert(this.fakeReferee.add.calledWith("same"));
     });
 
-    it("should pass when comparing booleans", function() {
-        referee.assert.same(true, true);
+    describe(".assert", function() {
+        context("when comparing object to itself", function() {
+            it("returns true", function() {
+                assert(this.options.assert(obj, obj));
+            });
+        });
+
+        context("when comparing strings", function() {
+            it("returns true", function() {
+                assert(this.options.assert("Hey", "Hey"));
+            });
+        });
+
+        context("when comparing booleans", function() {
+            it("returns true", function() {
+                assert(this.options.assert(true, true));
+                assert(this.options.assert(false, false));
+            });
+        });
+
+        context("when comparing Infinity", function() {
+            it("returns true", function() {
+                assert(this.options.assert(Infinity, Infinity));
+            });
+        });
+
+        context("when comparing numbers", function() {
+            it("returns true", function() {
+                assert(this.options.assert(32, 32));
+            });
+        });
+
+        context("when comparing null with null", function() {
+            it("returns true", function() {
+                assert(this.options.assert(null, null));
+            });
+        });
+
+        context("when comparing undefined with undefined", function() {
+            it("returns true", function() {
+                assert(this.options.assert(undefined, undefined));
+            });
+        });
+
+        context("when comparing NaN with NaN", function() {
+            it("returns true", function() {
+                assert(this.options.assert(NaN, NaN));
+            });
+        });
+
+        context("when comparing different objects", function() {
+            it("returns false", function() {
+                assert.equal(this.options.assert(obj, obj2), false);
+            });
+        });
+
+        context("when comparing without coercion", function() {
+            it("returns false", function() {
+                assert.equal(this.options.assert(666, "666"), false);
+                assert.equal(this.options.assert("666", 666), false);
+            });
+        });
+
+        context("when comparing -0 to +0", function() {
+            it("returns false", function() {
+                assert.equal(this.options.assert(-0, +0), false);
+            });
+        });
     });
 
-    it("should pass when comparing infinity", function() {
-        referee.assert.same(Infinity, Infinity);
+    describe(".assertMessage", function() {
+        it("is '${customMessage}${actual} expected to be the same object as ${expected}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}${actual} expected to be the same object as ${expected}"
+            );
+        });
     });
 
-    it("should pass when comparing numbers", function() {
-        referee.assert.same(32, 32);
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}${actual} expected not to be the same object as ${expected}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}${actual} expected not to be the same object as ${expected}"
+            );
+        });
     });
 
-    it("should pass when comparing null to null", function() {
-        referee.assert.same(null, null);
+    describe(".expectation", function() {
+        it("is 'toBe'", function() {
+            assert.equal(this.options.expectation, "toBe");
+        });
     });
 
-    it("should pass when comparing undefined to undefined", function() {
-        referee.assert.same(undefined, undefined);
-    });
-
-    it("should pass when comparing NaN to NaN", function() {
-        referee.assert.same(NaN, NaN);
-    });
-
-    it("should fail when comparing different objects", function() {
-        assert.throws(
-            function() {
-                referee.assert.same(obj, obj2);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.same] { id: 42 } expected to be the same object as { id: 42 }"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.same");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when comparing without coercion", function() {
-        assert.throws(
-            function() {
-                referee.assert.same(666, "666");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.same] 666 expected to be the same object as '666'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.same");
-                return true;
-            }
-        );
-    });
-
-    it("should fail when comparing -0 to +0", function() {
-        assert.throws(
-            function() {
-                referee.assert.same(-0, +0);
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.same] -0 expected to be the same object as 0"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.same");
-                return true;
-            }
-        );
+    describe(".values", function() {
+        it("delegates to '../actual-and-expected-message-values'", function() {
+            assert.equal(this.options.values, this.fakeActualAndExpectedMessageValues);
+        });
     });
 });

--- a/lib/assertions/same.test.js
+++ b/lib/assertions/same.test.js
@@ -126,7 +126,10 @@ describe("same factory", function() {
 
     describe(".values", function() {
         it("delegates to '../actual-and-expected-message-values'", function() {
-            assert.equal(this.options.values, this.fakeActualAndExpectedMessageValues);
+            assert.equal(
+                this.options.values,
+                this.fakeActualAndExpectedMessageValues
+            );
         });
     });
 });

--- a/lib/assertions/tag-name.test.js
+++ b/lib/assertions/tag-name.test.js
@@ -1,82 +1,167 @@
 "use strict";
 
 var assert = require("assert");
-var referee = require("../referee");
+var factory = require("./tag-name");
+var sinon = require("sinon");
 
-describe("tagName", function() {
-    it("should pass for matching tag names", function() {
-        referee.assert.tagName({ tagName: "li" }, "li");
+describe("tagName factory", function() {
+    beforeEach(function() {
+        this.fakeReferee = {
+            add: sinon.fake()
+        };
+
+        factory(this.fakeReferee);
+
+        this.options = this.fakeReferee.add.args[0][1];
     });
 
-    it("should pass for case-insensitive matching tag names", function() {
-        referee.assert.tagName({ tagName: "LI" }, "li");
+    it("calls referee.add with 'isMap' as name", function() {
+        assert(this.fakeReferee.add.calledWith("tagName"));
     });
 
-    it("should pass for case-insensitive matching tag names #2", function() {
-        referee.assert.tagName({ tagName: "li" }, "LI");
-    });
-
-    if (typeof document !== "undefined") {
-        it("should pass for DOM elements", function() {
-            referee.assert.tagName(document.createElement("li"), "li");
+    describe(".assert", function() {
+        context("with matching tag names", function() {
+            it("returns true", function() {
+                assert.equal(
+                    this.options.assert({ tagName: "li" }, "li"),
+                    true
+                );
+            });
         });
-    }
 
-    it("should pass for uppercase matching tag names", function() {
-        referee.assert.tagName({ tagName: "LI" }, "LI");
+        context("with case-insensitive matching tag names", function() {
+            it("returns true", function() {
+                assert.equal(
+                    this.options.assert({ tagName: "LI" }, "li"),
+                    true
+                );
+            });
+        });
+
+        context("with case-insensitive matching tag names #2", function() {
+            it("returns true", function() {
+                assert.equal(
+                    this.options.assert({ tagName: "li" }, "LI"),
+                    true
+                );
+            });
+        });
+
+        if (typeof document !== "undefined") {
+            context("with matching DOM elements", function() {
+                it("returns true", function() {
+                    assert.equal(
+                        this.options.assert(document.createElement("li"), "li"),
+                        true
+                    );
+                });
+            });
+        }
+
+        context("with uppercase matching tag names", function() {
+            it("returns true", function() {
+                assert.equal(
+                    this.options.assert({ tagName: "LI" }, "LI"),
+                    true
+                );
+            });
+        });
+
+        context("with mismatched tag names", function() {
+            it("returns false", function() {
+                var t = this;
+                var tagName = "1d83c5fe-b2f9-4711-9e7e-1633d59bf5b8";
+                var nonMatchingValues = [
+                    { tagName: "23acdc5d-7f7e-42b1-a611-b1bbbef7a794" },
+                    { tagName: "7ee81413-9c89-45e6-8934-dff61ed17820" }
+                ];
+
+                if (typeof document !== "undefined") {
+                    nonMatchingValues.push(document.createElement("li"));
+                }
+
+                nonMatchingValues.forEach(function(value) {
+                    assert.equal(t.options.assert(value, tagName), false);
+                });
+            });
+        });
     });
 
-    it("should fail if no tag name is passed", function() {
-        assert.throws(
-            function() {
-                referee.assert.tagName({}, "LI");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.tagName] Expected {} to have tagName property"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.tagName");
-                return true;
-            }
-        );
+    describe(".assertMessage", function() {
+        it("is '${customMessage}Expected tagName to be ${expected} but was ${actual}'", function() {
+            assert.equal(
+                this.options.assertMessage,
+                "${customMessage}Expected tagName to be ${expected} but was ${actual}"
+            );
+        });
     });
 
-    it("should fail for non-matching tag names", function() {
-        assert.throws(
-            function() {
-                referee.assert.tagName({ tagName: "li" }, "p");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.tagName] Expected tagName to be 'p' but was 'li'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.tagName");
-                return true;
-            }
-        );
+    describe(".refuteMessage", function() {
+        it("is '${customMessage}Expected tagName not to be ${actual}'", function() {
+            assert.equal(
+                this.options.refuteMessage,
+                "${customMessage}Expected tagName not to be ${actual}"
+            );
+        });
     });
 
-    it("should fail for substring matches in tag names", function() {
-        assert.throws(
-            function() {
-                referee.assert.tagName({ tagName: "li" }, "i");
-            },
-            function(error) {
-                assert.equal(error.code, "ERR_ASSERTION");
-                assert.equal(
-                    error.message,
-                    "[assert.tagName] Expected tagName to be 'i' but was 'li'"
-                );
-                assert.equal(error.name, "AssertionError");
-                assert.equal(error.operator, "assert.tagName");
-                return true;
-            }
-        );
+    describe(".expectation", function() {
+        it("is 'toHaveTagName'", function() {
+            assert.equal(this.options.expectation, "toHaveTagName");
+        });
+    });
+
+    describe(".values", function() {
+        it("is a ternary function", function() {
+            assert.equal(typeof this.options.values, "function");
+            assert.equal(this.options.values.length, 3);
+        });
+
+        it("returns a values object", function() {
+            var element = "09088de3-966d-4359-bb14-9a308a2eefa4";
+            var tagName = "e35b667b-5924-479b-9336-4649410ba012";
+            var message = "42ac2ec5-cde8-4a9e-8871-50d77d78a28d";
+            var result = this.options.values(element, tagName, message);
+
+            assert.equal(typeof result, "object");
+        });
+
+        it("returns the element argument as the actualElement property", function() {
+            var element = "e500905e-52a9-4f33-ba04-c38ab83031a9";
+            var tagName = "8cef21db-a983-490a-a7db-4f022493f529";
+            var message = "fa513aca-cda4-4462-9e14-b7beb4bd0e2d";
+            var result = this.options.values(element, tagName, message);
+
+            assert.equal(result.actualElement, element);
+        });
+
+        it("returns the element argument's tagName as the actual property", function() {
+            var element = {
+                tagName: "ba550a5b-2779-4c43-a7c2-4e23967052b5"
+            };
+            var tagName = "8cef21db-a983-490a-a7db-4f022493f529";
+            var message = "fa513aca-cda4-4462-9e14-b7beb4bd0e2d";
+            var result = this.options.values(element, tagName, message);
+
+            assert.equal(result.actual, element.tagName);
+        });
+
+        it("returns the tagName argument as the expected property", function() {
+            var element = "34668e7a-2b92-4390-ba18-b0a532614b14";
+            var tagName = "817cf619-8e09-4f68-8450-0dc0b81cc7a8";
+            var message = "ae6bfec7-d067-4299-aa46-388b6a5becdc";
+            var result = this.options.values(element, tagName, message);
+
+            assert.equal(result.expected, tagName);
+        });
+
+        it("returns the message argument as the customMessage property", function() {
+            var element = "4365870b-e123-4dd0-910a-5176e4affd60";
+            var tagName = "493c27b4-15d6-4c3e-9938-a3a2c5fe8d85";
+            var message = "35144761-d76f-43b0-a462-aae9d22b3964";
+            var result = this.options.values(element, tagName, message);
+
+            assert.equal(result.customMessage, message);
+        });
     });
 });

--- a/lib/assertions/tag-name.test.js
+++ b/lib/assertions/tag-name.test.js
@@ -20,6 +20,20 @@ describe("tagName factory", function() {
     });
 
     describe(".assert", function() {
+        context("with object missing tagName", function() {
+            it("invokes fail with 'no tag name' message", function() {
+                this.options.fail = sinon.fake();
+
+                this.options.assert({}, "li");
+
+                sinon.assert.calledOnce(this.options.fail);
+                sinon.assert.calledWith(
+                    this.options.fail,
+                    "${customMessage}Expected ${actualElement} to have tagName property"
+                );
+            });
+        });
+
         context("with matching tag names", function() {
             it("returns true", function() {
                 assert.equal(

--- a/lib/assertions/tag-name.test.js
+++ b/lib/assertions/tag-name.test.js
@@ -35,7 +35,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected {  } to have tagName property"
+                    "[assert.tagName] Expected {} to have tagName property"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");
@@ -53,7 +53,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected tagName to be p but was li"
+                    "[assert.tagName] Expected tagName to be 'p' but was 'li'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");
@@ -71,7 +71,7 @@ describe("tagName", function() {
                 assert.equal(error.code, "ERR_ASSERTION");
                 assert.equal(
                     error.message,
-                    "[assert.tagName] Expected tagName to be i but was li"
+                    "[assert.tagName] Expected tagName to be 'i' but was 'li'"
                 );
                 assert.equal(error.name, "AssertionError");
                 assert.equal(error.operator, "assert.tagName");

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -151,6 +151,42 @@ describe("custom assertions", function() {
         }
     });
 
+    it("should interpolate ... placeholders with array value", function() {
+        referee.add("custom", {
+            assert: function(actual) {
+                this.args = [1, 2];
+                return false;
+            },
+            assertMessage: "with args ${...args}",
+            refuteMessage: "ignored"
+        });
+
+        try {
+            referee.assert.custom(2, 3);
+            throw new Error("Didn't throw");
+        } catch (e) {
+            referee.assert.equals("[assert.custom] with args 1, 2", e.message);
+        }
+    });
+
+    it("should interpolate ... placeholders with object value", function() {
+        referee.add("custom", {
+            assert: function(actual) {
+                this.args = { some: 42 };
+                return false;
+            },
+            assertMessage: "with args ${...args}",
+            refuteMessage: "ignored"
+        });
+
+        try {
+            referee.assert.custom(2, 3);
+            throw new Error("Didn't throw");
+        } catch (e) {
+            referee.assert.equals("[assert.custom] with args { some: 42 }", e.message);
+        }
+    });
+
     it("should add expectation if expect property is set", function() {
         referee.add("custom", {
             assert: function(actual) {

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -154,6 +154,7 @@ describe("custom assertions", function() {
     it("should interpolate ... placeholders with array value", function() {
         referee.add("custom", {
             assert: function(actual) {
+                this.actual = actual;
                 this.args = [1, 2];
                 return false;
             },
@@ -172,6 +173,7 @@ describe("custom assertions", function() {
     it("should interpolate ... placeholders with object value", function() {
         referee.add("custom", {
             assert: function(actual) {
+                this.actual = actual;
                 this.args = { some: 42 };
                 return false;
             },
@@ -183,7 +185,10 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (e) {
-            referee.assert.equals("[assert.custom] with args { some: 42 }", e.message);
+            referee.assert.equals(
+                "[assert.custom] with args { some: 42 }",
+                e.message
+            );
         }
     });
 

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -37,12 +37,12 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (e) {
-            referee.assert.equals("[assert.custom] 2? 3!", e.message);
+            referee.assert.equals("[assert.custom] '2?' '3!'", e.message);
         }
     });
 
     it("should format interpolated property", function() {
-        var expectedMessage = "[assert.custom] 2? 3!";
+        var expectedMessage = "[assert.custom] '2?' '3!'";
         var actualMessage;
 
         referee.add("custom", {
@@ -111,7 +111,7 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (err) {
-            referee.assert.equals("[assert.custom] ${actual} B", err.message);
+            referee.assert.equals("[assert.custom] ${actual} 'B'", err.message);
         }
     });
 
@@ -129,7 +129,7 @@ describe("custom assertions", function() {
             referee.assert.custom(2, 3);
             throw new Error("Didn't throw");
         } catch (e) {
-            referee.assert.equals("[assert.custom] 2? 2?", e.message);
+            referee.assert.equals("[assert.custom] '2?' '2?'", e.message);
         }
     });
 

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -38,7 +38,7 @@ describe("expect", function() {
         } catch (e) {
             referee.assert.equals(
                 e.message,
-                '[expect.toEqual] { id: 42 } expected to be equal to { bleh: "Nah" }'
+                "[expect.toEqual] { id: 42 } expected to be equal to { bleh: 'Nah' }"
             );
         }
     });

--- a/lib/format.js
+++ b/lib/format.js
@@ -1,33 +1,13 @@
 "use strict";
 
-var formatio = require("@sinonjs/formatio");
+var inspect = require("util").inspect;
 
-// Setup formatter the same way as Sinon does:
-var formatter = formatio.configure({
-    quoteStrings: false,
-    limitChildrenCount: 250
-});
-
-var customFormatter;
-
-function format() {
-    if (customFormatter) {
-        return customFormatter.apply(null, arguments);
+function format(object) {
+    if (object instanceof Error) {
+        return object.name;
     }
 
-    return formatter.ascii.apply(formatter, arguments);
+    return inspect(object);
 }
-
-format.setFormatter = function(aCustomFormatter) {
-    if (typeof aCustomFormatter !== "function") {
-        throw new Error("format.setFormatter must be called with a function");
-    }
-
-    customFormatter = aCustomFormatter;
-};
-
-format.reset = function() {
-    customFormatter = null;
-};
 
 module.exports = format;

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,55 +1,68 @@
 "use strict";
 
 var assert = require("assert");
-var format = require("./format");
-var referee = require("..");
+var proxyquire = require("proxyquire").noCallThru();
+var sinon = require("sinon");
 
 describe("format", function() {
-    afterEach(function() {
-        format.reset();
+    beforeEach(function() {
+        this.fakeInspect = sinon.fake.returns(
+            "334ddc7e-9c2e-4206-8861-9253d348c81b"
+        );
+
+        this.format = proxyquire("./format", {
+            util: {
+                inspect: this.fakeInspect
+            }
+        });
     });
 
-    it("formats with formatio by default", function() {
-        assert.equal(format({ id: 42 }), "{ id: 42 }");
-    });
+    describe("when called with an instance of Error", function() {
+        it("returns the name property", function() {
+            var t = this;
+            var ERROR_TYPES = [
+                Error,
+                EvalError,
+                RangeError,
+                ReferenceError,
+                SyntaxError,
+                TypeError,
+                URIError
+            ];
 
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip("should configure formatio to use maximum 250 entries", function() {
-        // not sure how we can verify this integration with the current setup
-        // where sinon.js calls formatio as part of its loading
-        // extracting sinon.format into a separate module would make this a lot
-        // easier
-    });
+            ERROR_TYPES.forEach(function(ErrorType) {
+                var error = new ErrorType("some message");
+                var result = t.format(error);
 
-    it("formats strings without quotes", function() {
-        assert.equal(format("Hey"), "Hey");
-    });
-
-    describe("format.setFormatter", function() {
-        it("sets custom formatter", function() {
-            format.setFormatter(function() {
-                return "formatted";
+                assert.equal(result, error.name);
             });
-            assert.equal(format("Hey"), "formatted");
         });
+    });
 
-        it("throws if custom formatter is not a function", function() {
-            assert.throws(
-                function() {
-                    format.setFormatter("foo");
-                },
-                function(err) {
-                    assert.equal(
-                        err.message,
-                        "format.setFormatter must be called with a function"
-                    );
-                    return true;
-                }
-            );
-        });
+    describe("when called with other values", function() {
+        it("formats the result using `util.inspect`", function() {
+            var t = this;
 
-        it("exposes method on referee", function() {
-            assert.equal(referee.setFormatter, format.setFormatter);
+            var NON_ERROR_VALUES = [
+                "a0f33503-7939-4b9f-8fd7-efc8c3cad117",
+                1234,
+                new Date(),
+                [],
+                {},
+                new Map(),
+                new Set(),
+                Promise.resolve("02142eaa-d842-4541-af9d-7e9ab323b562")
+            ];
+
+            NON_ERROR_VALUES.forEach(function(value) {
+                t.fakeInspect.resetHistory();
+
+                var result = t.format(value);
+
+                assert(t.fakeInspect.calledOnce);
+                assert(t.fakeInspect.calledWith(value));
+                assert.equal(result, t.fakeInspect.returnValues[0]);
+            });
         });
     });
 });

--- a/lib/interpolate-pos-arg.js
+++ b/lib/interpolate-pos-arg.js
@@ -1,20 +1,15 @@
 "use strict";
 
-var interpolate = require("./interpolate");
-var reduce = require("@sinonjs/commons").prototypes.array.reduce;
+var format = require("./format");
 
 // Interpolate positional arguments. Replaces occurences of ${<index>} in
 // the string with the corresponding entry in values[<index>]
 function interpolatePosArg(message, values) {
-    return reduce(
-        values,
-        function(msg, value, index) {
-            var stringifiedMessage =
-                value && value.toString ? String(value) : JSON.stringify(value);
-            return interpolate(msg, index, stringifiedMessage);
-        },
-        message
-    );
+    return message.replace(/\${([0-9]+)}/gi, function (match, num) {
+        var index = parseInt(num, 10);
+        var value = values[index];
+        return format(value);
+    });
 }
 
 module.exports = interpolatePosArg;

--- a/lib/interpolate-pos-arg.js
+++ b/lib/interpolate-pos-arg.js
@@ -5,7 +5,7 @@ var format = require("./format");
 // Interpolate positional arguments. Replaces occurences of ${<index>} in
 // the string with the corresponding entry in values[<index>]
 function interpolatePosArg(message, values) {
-    return message.replace(/\${([0-9]+)}/gi, function (match, num) {
+    return message.replace(/\${([0-9]+)}/gi, function(match, num) {
         var index = parseInt(num, 10);
         var value = values[index];
         return format(value);

--- a/lib/interpolate-properties.js
+++ b/lib/interpolate-properties.js
@@ -1,8 +1,8 @@
 "use strict";
 
 var interpolate = require("./interpolate");
-var format = require("./format");
 var reduce = require("@sinonjs/commons").prototypes.array.reduce;
+var format = require("./format");
 
 function prepareMessage(message) {
     if (!message) {

--- a/lib/interpolate-properties.js
+++ b/lib/interpolate-properties.js
@@ -12,12 +12,19 @@ function prepareMessage(message) {
 }
 
 function interpolateProperties(referee, message, properties) {
-    return message.replace(/\${?([a-z]+)}/gi, function (match, name) {
+    return message.replace(/\${(\.\.\.)?([a-z]+)}/gi, function(
+        match,
+        prefix,
+        name
+    ) {
         if (!hasOwnProperty(properties, name)) {
             return match;
         }
         var value = properties[name];
-        if (name === 'customMessage') {
+        if (prefix && Array.isArray(value)) {
+            return value.map(format).join(", ");
+        }
+        if (name === "customMessage") {
             return prepareMessage(value);
         }
         return format(value);

--- a/lib/interpolate-properties.js
+++ b/lib/interpolate-properties.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var interpolate = require("./interpolate");
-var reduce = require("@sinonjs/commons").prototypes.array.reduce;
+var hasOwnProperty = require("@sinonjs/commons").prototypes.object
+    .hasOwnProperty;
 var format = require("./format");
 
 function prepareMessage(message) {
@@ -12,17 +12,16 @@ function prepareMessage(message) {
 }
 
 function interpolateProperties(referee, message, properties) {
-    return reduce(
-        Object.keys(properties),
-        function(str, name) {
-            var formattedValue =
-                name === "customMessage"
-                    ? prepareMessage(properties[name])
-                    : format(properties[name]);
-            return interpolate(str, name, formattedValue);
-        },
-        message
-    );
+    return message.replace(/\${?([a-z]+)}/gi, function (match, name) {
+        if (!hasOwnProperty(properties, name)) {
+            return match;
+        }
+        var value = properties[name];
+        if (name === 'customMessage') {
+            return prepareMessage(value);
+        }
+        return format(value);
+    });
 }
 
 module.exports = interpolateProperties;

--- a/lib/interpolate.js
+++ b/lib/interpolate.js
@@ -1,7 +1,0 @@
-"use strict";
-
-function interpolate(string, prop, value) {
-    return string.replace(new RegExp("\\$\\{" + prop + "\\}", "g"), value);
-}
-
-module.exports = interpolate;

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -33,7 +33,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        '[assert.equals] { bar: true, foo: 1 } expected to be equal to { bar: typeOf("string"), foo: 1 }'
+                        "[assert.equals] { foo: 1, bar: true } expected to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.equals");
@@ -67,7 +67,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        '[refute.equals] { bar: "test", foo: 1 } expected not to be equal to { bar: typeOf("string"), foo: 1 }'
+                        "[refute.equals] { foo: 1, bar: 'test' } expected not to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.equals");

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var samsam = require("@sinonjs/samsam");
 var referee = require("./referee");
+var anonymousFunction = require("./test-helper/anonymous-function-string");
 
 describe("match", function() {
     it("should be createMatcher from @sinonjs/samsam", function() {
@@ -20,11 +21,12 @@ describe("match", function() {
         });
 
         it("should fail match.string in object", function() {
-            var object = { foo: 1, bar: true };
+            var object = { some: "string", foo: 1, bar: true };
 
             assert.throws(
                 function() {
                     referee.assert.equals(object, {
+                        some: "string",
                         foo: 1,
                         bar: referee.match.string
                     });
@@ -33,7 +35,9 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.equals] { foo: 1, bar: true } expected to be equal to {\n  foo: 1,\n  bar: { test: [Function (anonymous)], message: 'typeOf(\"string\")' }\n}"
+                        "[assert.equals] { some: 'string', foo: 1, bar: true } expected to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: " +
+                            anonymousFunction +
+                            ", message: 'typeOf(\"string\")' }\n}"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.equals");
@@ -54,11 +58,12 @@ describe("match", function() {
         });
 
         it("should fail match.string in object", function() {
-            var object = { foo: 1, bar: "test" };
+            var object = { some: "string", foo: 1, bar: "test" };
 
             assert.throws(
                 function() {
                     referee.refute.equals(object, {
+                        some: "string",
                         foo: 1,
                         bar: referee.match.string
                     });
@@ -67,7 +72,9 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[refute.equals] { foo: 1, bar: 'test' } expected not to be equal to {\n  foo: 1,\n  bar: { test: [Function (anonymous)], message: 'typeOf(\"string\")' }\n}"
+                        "[refute.equals] { some: 'string', foo: 1, bar: 'test' } expected not to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: " +
+                            anonymousFunction +
+                            ", message: 'typeOf(\"string\")' }\n}"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.equals");

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -33,7 +33,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[assert.equals] { foo: 1, bar: true } expected to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
+                        "[assert.equals] { foo: 1, bar: true } expected to be equal to {\n  foo: 1,\n  bar: { test: [Function (anonymous)], message: 'typeOf(\"string\")' }\n}"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "assert.equals");
@@ -67,7 +67,7 @@ describe("match", function() {
                     assert.equal(error.code, "ERR_ASSERTION");
                     assert.equal(
                         error.message,
-                        "[refute.equals] { foo: 1, bar: 'test' } expected not to be equal to { foo: 1, bar: { test: [Function], message: 'typeOf(\"string\")' } }"
+                        "[refute.equals] { foo: 1, bar: 'test' } expected not to be equal to {\n  foo: 1,\n  bar: { test: [Function (anonymous)], message: 'typeOf(\"string\")' }\n}"
                     );
                     assert.equal(error.name, "AssertionError");
                     assert.equal(error.operator, "refute.equals");

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -14,7 +14,6 @@ referee.pass = require("./create-pass")(referee);
 referee.verifier = require("./create-verifier")(referee);
 referee.equals = require("@sinonjs/samsam").deepEqual;
 referee.match = require("@sinonjs/samsam").createMatcher;
-referee.setFormatter = require("./format").setFormatter;
 
 // add all all the built-in assertions to the API
 require("./assertions/class-name")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -103,6 +103,7 @@ describe("API", function() {
             "isMap",
             "isUint8ClampedArray",
             "match",
+            "rejects",
             "resolves",
             "same",
             "tagName"

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -97,4 +97,13 @@ describe("API", function() {
 
         assert.ok(referee instanceof EventEmitter);
     });
+
+    describe("assertions", function() {
+        ["isMap"].forEach(function(assertion) {
+            it("has '" + assertion + "' assertion", function() {
+                assert.equal(typeof referee.assert[assertion], "function");
+                assert.equal(typeof referee.refute[assertion], "function");
+            });
+        });
+    });
 });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "isWeakSet",
             "json",
             "keys",
             "less",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -99,7 +99,7 @@ describe("API", function() {
     });
 
     describe("assertions", function() {
-        ["isMap"].forEach(function(assertion) {
+        ["isMap", "match"].forEach(function(assertion) {
             it("has '" + assertion + "' assertion", function() {
                 assert.equal(typeof referee.assert[assertion], "function");
                 assert.equal(typeof referee.refute[assertion], "function");

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "isURIError",
             "isWeakMap",
             "isWeakSet",
             "json",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "matchJson",
             "match",
             "near",
             "rejects",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -99,7 +99,7 @@ describe("API", function() {
     });
 
     describe("assertions", function() {
-        ["isMap", "match"].forEach(function(assertion) {
+        ["isMap", "isUint8ClampedArray", "match"].forEach(function(assertion) {
             it("has '" + assertion + "' assertion", function() {
                 assert.equal(typeof referee.assert[assertion], "function");
                 assert.equal(typeof referee.refute[assertion], "function");

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "keys",
             "less",
             "matchJson",
             "match",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -99,13 +99,18 @@ describe("API", function() {
     });
 
     describe("assertions", function() {
-        ["isMap", "isUint8ClampedArray", "match", "same", "tagName"].forEach(
-            function(assertion) {
-                it("has '" + assertion + "' assertion", function() {
-                    assert.equal(typeof referee.assert[assertion], "function");
-                    assert.equal(typeof referee.refute[assertion], "function");
-                });
-            }
-        );
+        [
+            "isMap",
+            "isUint8ClampedArray",
+            "match",
+            "resolves",
+            "same",
+            "tagName"
+        ].forEach(function(assertion) {
+            it("has '" + assertion + "' assertion", function() {
+                assert.equal(typeof referee.assert[assertion], "function");
+                assert.equal(typeof referee.refute[assertion], "function");
+            });
+        });
     });
 });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "isWeakMap",
             "isWeakSet",
             "json",
             "keys",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -99,13 +99,13 @@ describe("API", function() {
     });
 
     describe("assertions", function() {
-        ["isMap", "isUint8ClampedArray", "match", "tagName"].forEach(function(
-            assertion
-        ) {
-            it("has '" + assertion + "' assertion", function() {
-                assert.equal(typeof referee.assert[assertion], "function");
-                assert.equal(typeof referee.refute[assertion], "function");
-            });
-        });
+        ["isMap", "isUint8ClampedArray", "match", "same", "tagName"].forEach(
+            function(assertion) {
+                it("has '" + assertion + "' assertion", function() {
+                    assert.equal(typeof referee.assert[assertion], "function");
+                    assert.equal(typeof referee.refute[assertion], "function");
+                });
+            }
+        );
     });
 });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -68,13 +68,6 @@ describe("API", function() {
         });
     });
 
-    describe(".setFormatter", function() {
-        it("should be a unary Function named 'setFormatter'", function() {
-            assert.equal(typeof referee.setFormatter, "function");
-            assert.equal(referee.setFormatter.length, 1);
-        });
-    });
-
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
@@ -88,6 +81,7 @@ describe("API", function() {
             "pass",
             "refute",
             "setFormatter",
+            "supervisors",
             "verifier"
         ]);
 

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "less",
             "matchJson",
             "match",
             "near",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -103,6 +103,7 @@ describe("API", function() {
             "isMap",
             "isUint8ClampedArray",
             "match",
+            "near",
             "rejects",
             "resolves",
             "same",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -102,6 +102,7 @@ describe("API", function() {
         [
             "isMap",
             "isUint8ClampedArray",
+            "json",
             "keys",
             "less",
             "matchJson",

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -80,8 +80,6 @@ describe("API", function() {
             "match",
             "pass",
             "refute",
-            "setFormatter",
-            "supervisors",
             "verifier"
         ]);
 

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -99,7 +99,9 @@ describe("API", function() {
     });
 
     describe("assertions", function() {
-        ["isMap", "isUint8ClampedArray", "match"].forEach(function(assertion) {
+        ["isMap", "isUint8ClampedArray", "match", "tagName"].forEach(function(
+            assertion
+        ) {
             it("has '" + assertion + "' assertion", function() {
                 assert.equal(typeof referee.assert[assertion], "function");
                 assert.equal(typeof referee.refute[assertion], "function");

--- a/lib/test-helper/anonymous-function-string.js
+++ b/lib/test-helper/anonymous-function-string.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var inspect = require("util").inspect;
+
+module.exports = inspect(function() {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,31 +5,33 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
-      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.7",
-        "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.7",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.6",
+        "@babel/helper-module-transforms": "^7.11.0",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.11.5",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.13",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -44,130 +46,199 @@
       }
     },
     "@babel/generator": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4",
+        "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.11.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.11.0"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
     "@babel/helpers": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-      "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
       "dev": true
     },
-    "@babel/runtime": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+      "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helper-function-name": "^7.7.4",
-        "@babel/helper-split-export-declaration": "^7.7.4",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
       }
     },
     "@babel/types": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
@@ -186,19 +257,10 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
-    "@samverschueren/stream-to-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
-      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
-      "dev": true,
-      "requires": {
-        "any-observable": "^0.3.0"
-      }
-    },
     "@sinonjs/commons": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
-      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "requires": {
         "type-detect": "4.0.8"
       }
@@ -212,10 +274,20 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
     "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
       "requires": {
         "@sinonjs/commons": "^1.6.0",
         "lodash.get": "^4.4.2",
@@ -239,23 +311,6 @@
         "detect-indent": "^5.0.0",
         "hosted-git-info": "^3.0.2",
         "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "hosted-git-info": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
-          "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^5.1.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "@studio/editor": {
@@ -295,15 +350,15 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
       "dev": true
     },
     "@types/parse-json": {
@@ -313,21 +368,21 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -335,33 +390,44 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true
     },
     "ansi-styles": {
@@ -372,12 +438,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "any-observable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
-      "dev": true
     },
     "anymatch": {
       "version": "3.1.1",
@@ -431,9 +491,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "brace-expansion": {
@@ -531,71 +591,72 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-truncate": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "requires": {
-        "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "slice-ansi": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
           }
         }
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
     "cliui": {
@@ -609,6 +670,18 @@
         "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -633,12 +706,6 @@
         }
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -655,9 +722,9 @@
       "dev": true
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+      "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
       "dev": true
     },
     "commondir": {
@@ -688,30 +755,16 @@
       }
     },
     "cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
-            "lines-and-columns": "^1.1.6"
-          }
-        }
+        "yaml": "^1.10.0"
       }
     },
     "cross-spawn": {
@@ -735,19 +788,13 @@
         }
       }
     },
-    "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-      "dev": true
-    },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -815,16 +862,10 @@
         "esutils": "^2.0.2"
       }
     },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-      "dev": true
-    },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "end-of-stream": {
@@ -834,6 +875,15 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "error-ex": {
@@ -846,27 +896,28 @@
       }
     },
     "es-abstract": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
-      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -931,15 +982,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.8.1"
-          }
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -947,28 +989,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-              "dev": true
-            }
           }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
-      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz",
+      "integrity": "sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -1000,9 +1028,9 @@
       },
       "dependencies": {
         "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -1011,21 +1039,21 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -1039,19 +1067,19 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -1062,21 +1090,37 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -1098,9 +1142,9 @@
       "dev": true
     },
     "execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
@@ -1110,15 +1154,14 @@
         "merge-stream": "^2.0.0",
         "npm-run-path": "^4.0.0",
         "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
         "signal-exit": "^3.0.2",
         "strip-final-newline": "^2.0.0"
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -1170,9 +1213,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-diff": {
@@ -1194,13 +1237,12 @@
       "dev": true
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -1232,13 +1274,13 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-      "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^3.0.0",
+        "make-dir": "^3.0.2",
         "pkg-dir": "^4.1.0"
       }
     },
@@ -1282,9 +1324,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "foreground-child": {
@@ -1298,9 +1340,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -1341,9 +1383,9 @@
       }
     },
     "fromentries": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
-      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.1.tgz",
+      "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
       "dev": true
     },
     "fs.realpath": {
@@ -1353,9 +1395,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -1371,6 +1413,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1383,6 +1431,12 @@
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
       "dev": true
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -1390,18 +1444,18 @@
       "dev": true
     },
     "get-stream": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-      "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1413,24 +1467,27 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "growl": {
@@ -1448,23 +1505,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1472,33 +1512,19 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "hasha": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
-      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.1.tgz",
+      "integrity": "sha512-x15jnRSHTi3VmH+oHtVb9kgU/HuKOK8mjK8iCL3dPQXh4YJlUb9YSI8ZLiiqLAIvY2wuDIlZYZppy8vB2XISkQ==",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
         "type-fest": "^0.8.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
-        }
       }
     },
     "he": {
@@ -1508,15 +1534,18 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
-      "dev": true
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+      "integrity": "sha512-i4dpK6xj9BIpVOTboXIlKG9+8HMKggcrMX7WA24xZtKwX0TPelq/rbaS5rCKeNX8sJXZJGdSxpnEGtta+wismQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "html-escaper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "human-signals": {
@@ -1526,15 +1555,15 @@
       "dev": true
     },
     "husky": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.3.tgz",
-      "integrity": "sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.0.tgz",
+      "integrity": "sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
+        "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
-        "compare-versions": "^3.5.1",
-        "cosmiconfig": "^6.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
         "find-versions": "^3.2.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
@@ -1554,9 +1583,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1585,9 +1614,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -1649,108 +1678,84 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
-      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
+        "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.5.3",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-escapes": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-          "dev": true,
-          "requires": {
-            "restore-cursor": "^3.1.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "figures": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5"
+            "ansi-regex": "^5.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2"
+            "has-flag": "^4.0.0"
           }
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "6.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
-          }
-        },
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
         }
       }
     },
@@ -1776,15 +1781,15 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-extglob": {
@@ -1794,9 +1799,9 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -1826,37 +1831,22 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
-    "is-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-      "dev": true,
-      "requires": {
-        "symbol-observable": "^1.1.0"
-      }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-reference": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
-      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
       "requires": {
-        "@types/estree": "0.0.39"
+        "@types/estree": "*"
       }
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-regexp": {
@@ -1872,12 +1862,12 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -1920,15 +1910,12 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
-      "integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
-        "@babel/parser": "^7.7.5",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
@@ -1950,14 +1937,23 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
+          }
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
           }
         },
         "path-key": {
@@ -1967,9 +1963,9 @@
           "dev": true
         },
         "rimraf": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -2019,9 +2015,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2049,9 +2045,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -2065,9 +2061,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2086,6 +2082,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2099,26 +2101,18 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "levn": {
@@ -2138,19 +2132,21 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.1.1.tgz",
-      "integrity": "sha512-wAeu/ePaBAOfwM2+cVbgPWDtn17B0Sxiv0NvNEqDAIvB8Yhvl60vafKFiK4grcYn87K1iK+a0zVoETvKbdT9/Q==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.4.0.tgz",
+      "integrity": "sha512-uaiX4U5yERUSiIEQc329vhCTDDwUcSvKdRLsNomkYLRzijk3v8V9GWm2Nz0RMVB87VcuzLvtgy6OsjoH++QHIg==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "commander": "^4.0.1",
-        "cosmiconfig": "^6.0.0",
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "commander": "^6.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.1.1",
         "dedent": "^0.7.0",
-        "execa": "^3.4.0",
-        "listr": "^0.14.3",
-        "log-symbols": "^3.0.0",
+        "enquirer": "^2.3.6",
+        "execa": "^4.0.3",
+        "listr2": "^2.6.0",
+        "log-symbols": "^4.0.0",
         "micromatch": "^4.0.2",
         "normalize-path": "^3.0.0",
         "please-upgrade-node": "^3.2.0",
@@ -2169,9 +2165,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -2200,9 +2196,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2210,135 +2206,70 @@
         }
       }
     },
-    "listr": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+    "listr2": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-2.6.2.tgz",
+      "integrity": "sha512-6x6pKEMs8DSIpA/tixiYY2m/GcbgMplMVmhQAaLFxEtNSKLeWTGjtmU57xvv6QCm2XcqzyNXL/cTSVf4IChCRA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
+        "chalk": "^4.1.0",
+        "cli-truncate": "^2.1.0",
+        "figures": "^3.2.0",
+        "indent-string": "^4.0.0",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rxjs": "^6.6.2",
+        "through": "^2.3.8"
       },
       "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-          "dev": true
-        }
-      }
-    },
-    "listr-silent-renderer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-      "dev": true
-    },
-    "listr-update-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
         },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "listr-verbose-renderer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
-      },
-      "dependencies": {
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -2353,6 +2284,18 @@
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
       }
     },
     "locate-path": {
@@ -2365,9 +2308,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -2392,47 +2335,144 @@
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "log-update": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-      "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        }
       }
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "magic-string": {
-      "version": "0.25.4",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
-      "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
@@ -2481,16 +2521,22 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
     "mkdirp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -2506,7 +2552,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -2519,6 +2565,12 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+          "dev": true
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2551,6 +2603,16 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -2561,16 +2623,19 @@
             "path-exists": "^3.0.0"
           }
         },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
+        "log-symbols": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2"
+          }
         },
         "mkdirp": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -2645,9 +2710,9 @@
       "dev": true
     },
     "nise": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -2696,6 +2761,12 @@
         "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+          "dev": true
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2725,28 +2796,6 @@
         "read-pkg": "^3.0.0",
         "shell-quote": "^1.6.1",
         "string.prototype.padend": "^3.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        }
       }
     },
     "npm-run-path": {
@@ -2766,16 +2815,10 @@
         }
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
     "nyc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
       "dev": true,
       "requires": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2786,6 +2829,7 @@
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
         "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
@@ -2793,10 +2837,9 @@
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.0",
-        "js-yaml": "^3.13.1",
+        "istanbul-reports": "^3.0.2",
         "make-dir": "^3.0.0",
-        "node-preload": "^0.2.0",
+        "node-preload": "^0.2.1",
         "p-map": "^3.0.0",
         "process-on-spawn": "^1.0.0",
         "resolve-from": "^5.0.0",
@@ -2804,26 +2847,9 @@
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^2.0.0",
         "test-exclude": "^6.0.0",
-        "uuid": "^3.3.3",
         "yargs": "^15.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -2835,46 +2861,14 @@
             "wrap-ansi": "^6.2.0"
           }
         },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
+        "p-map": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -2883,23 +2877,12 @@
           "dev": true
         },
         "rimraf": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
@@ -2911,21 +2894,10 @@
             "ansi-regex": "^5.0.0"
           }
         },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
         "yargs": {
-          "version": "15.3.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "dev": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -2938,7 +2910,7 @@
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.1"
+            "yargs-parser": "^18.1.2"
           }
         },
         "yargs-parser": {
@@ -2959,9 +2931,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -2990,87 +2962,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "dev": true
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimstart": "^1.0.0"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimend": "^1.0.0"
-          }
-        }
       }
     },
     "once": {
@@ -3083,18 +2974,18 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
     },
     "opencollective-postinstall": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
     "optionator": {
@@ -3117,16 +3008,10 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true
-    },
     "p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3142,9 +3027,9 @@
       }
     },
     "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -3178,13 +3063,15 @@
       }
     },
     "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
       "dev": true,
       "requires": {
+        "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "path-exists": {
@@ -3227,15 +3114,15 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -3326,10 +3213,32 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
-      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
       "dev": true
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
+      }
     },
     "readdirp": {
       "version": "3.2.0",
@@ -3339,12 +3248,6 @@
       "requires": {
         "picomatch": "^2.0.4"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3380,9 +3283,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -3395,30 +3298,13 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        }
       }
     },
     "rimraf": {
@@ -3431,9 +3317,9 @@
       }
     },
     "rollup": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.0.tgz",
-      "integrity": "sha512-ab2tF5pdDqm2zuI8j02ceyrJSScl9V2C24FgWQ1v1kTFTu1UrG5H0hpP++mDZlEFyZX4k0chtGEHU2i+pAzBgA==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -3464,18 +3350,15 @@
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -3539,23 +3422,23 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "sinon": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.1.tgz",
-      "integrity": "sha512-iTTyiQo5T94jrOx7X7QLBZyucUJ2WvL9J13+96HMfm2CGoJYbIPqRfl6wgNcqmzk0DI28jeGx5bUTXizkrqBmg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.1.0.tgz",
+      "integrity": "sha512-9zQShgaeylYH6qtsnNXlTvv0FGTTckuDfHBi+qhgj5PvW2r2WslHZpgc3uy3e/ZAoPkqaOASPi+juU6EdYRYxA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
+        "@sinonjs/samsam": "^5.1.0",
         "diff": "^4.0.2",
-        "nise": "^4.0.1",
+        "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -3572,9 +3455,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -3597,6 +3480,14 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -3606,9 +3497,9 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-wrap": {
@@ -3626,9 +3517,9 @@
       },
       "dependencies": {
         "rimraf": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-          "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -3646,9 +3537,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -3656,15 +3547,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -3672,9 +3563,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "sprintf-js": {
@@ -3690,237 +3581,55 @@
       "dev": true
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
     },
     "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "dev": true
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimstart": "^1.0.0"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimend": "^1.0.0"
-          }
-        }
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.5",
-            "is-regex": "^1.0.5",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.1",
-            "string.prototype.trimright": "^2.1.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "has-symbols": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
-        },
-        "is-callable": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-          "dev": true,
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "object-inspect": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-          "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-          "dev": true
-        },
-        "string.prototype.trimleft": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-          "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimstart": "^1.0.0"
-          }
-        },
-        "string.prototype.trimright": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-          "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-          "dev": true,
-          "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5",
-            "string.prototype.trimend": "^1.0.0"
-          }
-        }
       }
     },
     "stringify-object": {
@@ -3964,9 +3673,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -3977,12 +3686,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
     },
     "table": {
       "version": "5.4.6",
@@ -3996,6 +3699,18 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -4057,9 +3772,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "type-check": {
@@ -4076,6 +3791,12 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -4086,24 +3807,24 @@
       }
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -4144,6 +3865,39 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "word-wrap": {
@@ -4153,22 +3907,48 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-      "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -4195,22 +3975,14 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-              "dev": true
-            }
           }
         }
       }
     },
     "write-file-atomic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
-      "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
@@ -4226,19 +3998,16 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.6.3"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs": {
       "version": "13.3.2",
@@ -4258,6 +4027,12 @@
         "yargs-parser": "^13.1.2"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -4266,6 +4041,12 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "locate-path": {
           "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,15 +212,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
-      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
-      "requires": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^5.0.2"
-      }
-    },
     "@sinonjs/samsam": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,6 +1221,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1817,6 +1827,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
     "is-observable": {
@@ -2437,6 +2453,12 @@
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2600,6 +2622,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -3278,6 +3306,17 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",
-    "@sinonjs/formatio": "^5.0.1",
     "@sinonjs/samsam": "^5.0.2",
     "array-from": "2.1.1",
     "lodash.includes": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "npm-run-all": "^4.1.3",
     "nyc": "^15.0.0",
     "prettier": "^1.18.2",
+    "proxyquire": "^2.1.3",
     "rollup": "^1.23.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "sinon": "^9.0.0"


### PR DESCRIPTION
This PR fixes #181, it replaces `@sinonjs/formatio` with Node's `util.inspect`.

It replaces #182 with a branch that lives on this repo, and not in my fork, so others can contribute easily.

#### Purpose

See if we can drop `@sinonjs/formatio` so it can be deprecated and we don't have to do as much maintenance.

#### Solution

Use Node's `util.inspect` as the object formatter

#### How to verify

1. Observe tests passing