### PR TITLE
Add missing expectation property for resolves/rejects

### DIFF
--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -25,6 +25,7 @@ module.exports = function(referee) {
             }
             this.resolve();
         }),
+        expectation: "toRejectWith",
         assertMessage: assertMessage,
         refuteMessage: refuteMessage
     });

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -25,6 +25,7 @@ module.exports = function(referee) {
             }
             this.resolve();
         }, catchCallback),
+        expectation: "toResolveWith",
         assertMessage: assertMessage,
         refuteMessage: refuteMessage
     });


### PR DESCRIPTION
This PR adds missing expecation properties for `resolves` and `rejects` assertions.

#### Purpose

Improve support for the BDD style use of the library

#### Background

When these assertions were introduced in 1af3c778914f044e601ecfaed7dcb070d301e53c, we overlooked the expectation property.

#### Solution

Add the missing `expectation` properties.

#### How to verify

1. Observe tests passing
