### PR TITLE
Fix assert.equals referencing deprecated assert.defined

### DIFF
--- a/lib/assertions/equals.js
+++ b/lib/assertions/equals.js
@@ -16,7 +16,7 @@ module.exports = function(referee) {
         assert: function(actual, expected) {
             if (typeof expected === "undefined") {
                 return this.fail(
-                    "Expectation for equals should not be undefined. Use assert.defined or refute.defined instead."
+                    "Expectation for equals should not be undefined. Use assert.isUndefined instead."
                 );
             }
             return samsam.deepEqual(actual, expected);


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fix issue #184 by updating the assert.equals error message when using `undefined` as the expectation value.

#### How to verify - mandatory
1. Check out this branch
2. Check that the updated message text looks good (this PR does not change any logic)

#### Checklist for author

- [X] `npm run lint` passes
- [X ] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
