### PR TITLE
Remove dependency on bane

### DIFF
--- a/lib/assert-equals-host-objects.test.js
+++ b/lib/assert-equals-host-objects.test.js
@@ -18,7 +18,7 @@ describe("assert.equals host objects", function() {
 
     afterEach(function() {
         sinon.restore();
-        referee.off();
+        referee.removeAllListeners();
         referee.count = 0;
         delete referee.throwOnFailure;
     });

--- a/lib/assert.test.js
+++ b/lib/assert.test.js
@@ -6,7 +6,7 @@ var referee = require("../lib/referee");
 describe("assert", function() {
     afterEach(function() {
         sinon.restore();
-        referee.off();
+        referee.removeAllListeners();
         delete referee.throwOnFailure;
     });
 

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -15,7 +15,7 @@ describe("custom assertions", function() {
 
     afterEach(function() {
         sinon.restore();
-        referee.off();
+        referee.removeAllListeners();
         delete referee.throwOnFailure;
 
         delete referee.assert.custom;

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -19,7 +19,7 @@ describe("expect", function() {
 
     afterEach(function() {
         sinon.restore();
-        referee.off();
+        referee.removeAllListeners();
         delete referee.throwOnFailure;
     });
 

--- a/lib/referee.js
+++ b/lib/referee.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var bane = require("bane");
+var EventEmitter = require("events");
 
-var referee = bane.createEventEmitter();
+var referee = new EventEmitter();
 
 // construct the public API
 referee.add = require("./create-add")(referee);

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -2,6 +2,7 @@
 
 var referee = require("./referee");
 var assert = require("assert");
+var EventEmitter = require("events");
 
 describe("API", function() {
     describe(".add", function() {
@@ -77,29 +78,25 @@ describe("API", function() {
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
+            "_events",
+            "_eventsCount",
+            "_maxListeners",
             "add",
             "assert",
-            "bind",
             "captureException",
-            "emit",
             "equals",
-            "errback",
-            "errbacks",
             "expect",
             "fail",
-            "listeners",
             "match",
-            "off",
-            "on",
-            "once",
             "pass",
             "refute",
             "setFormatter",
-            "supervisors",
             "verifier"
         ]);
         var actualProperties = JSON.stringify(Object.keys(referee).sort());
 
         assert.equal(actualProperties, expectedProperties);
+
+        assert.ok(referee instanceof EventEmitter);
     });
 });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -78,9 +78,6 @@ describe("API", function() {
     // this prevents accidental expansions of the public API
     it("should only have expected properties", function() {
         var expectedProperties = JSON.stringify([
-            "_events",
-            "_eventsCount",
-            "_maxListeners",
             "add",
             "assert",
             "captureException",
@@ -93,7 +90,14 @@ describe("API", function() {
             "setFormatter",
             "verifier"
         ]);
-        var actualProperties = JSON.stringify(Object.keys(referee).sort());
+
+        var actualProperties = JSON.stringify(
+            Object.keys(referee)
+                .filter(function(name) {
+                    return !name.startsWith("_");
+                })
+                .sort()
+        );
 
         assert.equal(actualProperties, expectedProperties);
 

--- a/lib/refute.test.js
+++ b/lib/refute.test.js
@@ -5,7 +5,7 @@ var referee = require("../lib/referee");
 
 describe("refute", function() {
     afterEach(function() {
-        referee.off();
+        referee.removeAllListeners();
         delete referee.throwOnFailure;
     });
 

--- a/lib/test-helper/index.js
+++ b/lib/test-helper/index.js
@@ -22,7 +22,7 @@ var testHelper = {
         sinon.restore();
         delete testHelper.okListener;
         delete testHelper.failListener;
-        referee.off();
+        referee.removeAllListeners();
         delete referee.throwOnFailure;
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -439,11 +439,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bane": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bane/-/bane-1.1.2.tgz",
-      "integrity": "sha1-vGQkjMgjFgx98/I4uH/mLEThB7k="
-    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@sinonjs/formatio": "^5.0.1",
     "@sinonjs/samsam": "^5.0.2",
     "array-from": "2.1.1",
-    "bane": "^1.x",
     "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",
     "object-assign": "^4.1.1"


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Replaces an unmaintained custom event emitter with Node's built in one.


#### Background (Problem in detail)

[bane](https://www.npmjs.com/package/bane) is an event emitter, which has had its last release 5 years ago. The API is roughly the same as Node's built-in event emitter, although in Node there's some things missing, e.g. the `off()` without any parameters is only available as `removeAllListeners`.

I'm not sure if this is meant to be used in the browser (although the download count is small enough to maybe not be too concerned about it)? I suppose in 2020, using it in the browser means using a bundler anyways. The available `npm run build` script seems to no longer work on `master`, so I didn't go further than that, but I do believe rollup is able to import node's internals in some form? (via plugin?)

#### Solution

This replaces `bane.createEventEmitter();` with `new EventEmitter()`. This is technically a breaking change, as some APIs will no longer be available on referee, although an argument could be made that it is not, as the documentation is very vague - it only ever mentions the `on()` method, which is still available and I believe works pretty much the same (or at least the tests did not complain).

I'm happy to make any other necessary changes or consider an alternative implementation.

#### How to verify
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
