### PR TITLE
Properly stringify objects without prototype

### DIFF
--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -126,4 +126,7 @@ describe("assert.isUndefined", function() {
             }
         );
     });
+    it("should handle objects without prototype", function() {
+        referee.refute.isUndefined(Object.create(null));
+    });
 });

--- a/lib/interpolate-pos-arg.js
+++ b/lib/interpolate-pos-arg.js
@@ -9,7 +9,9 @@ function interpolatePosArg(message, values) {
     return reduce(
         values,
         function(msg, value, index) {
-            return interpolate(msg, index, String(value));
+            var stringifiedMessage =
+                value && value.toString ? String(value) : JSON.stringify(value);
+            return interpolate(msg, index, stringifiedMessage);
         },
         message
     );


### PR DESCRIPTION
#### Purpose
Fix issue #148 by providing an alternative stringification method for cases where the object prototype is not available.

#### Background

If an object is created without a prototype and thus lacks `toString()`, assertions on the object will crash because the error message interpolation method expects this to be present. 

#### Solution

Check if the object has a `toString()` method, and stringify using `String(value)` if present. If not, use `JSON.stringify(value)`. This was one of the solutions proposed in the ticket; the other proposed solution was using `Object.prototype.toString.call(value)`, but this method caused existing tests to break.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test` (unit test included in PR)