### PR TITLE
String escapes

### DIFF
--- a/lib/assertions/equals.js
+++ b/lib/assertions/equals.js
@@ -2,13 +2,6 @@
 
 var samsam = require("@sinonjs/samsam");
 
-function escapeNewlines(value) {
-    if (typeof value === "string") {
-        return value.replace(/\n/g, "\\n");
-    }
-    return value;
-}
-
 module.exports = function(referee) {
     referee.add("equals", {
         // Uses arguments[2] because the function's .length is used to determine
@@ -22,14 +15,12 @@ module.exports = function(referee) {
             return samsam.deepEqual(actual, expected);
         },
         assertMessage:
-            "${customMessage}${escapedActual} expected to be equal to ${escapedExpected}",
+            "${customMessage}${actual} expected to be equal to ${expected}",
         refuteMessage:
-            "${customMessage}${escapedActual} expected not to be equal to ${escapedExpected}",
+            "${customMessage}${actual} expected not to be equal to ${expected}",
         expectation: "toEqual",
         values: function(actual, expected, message) {
             return {
-                escapedActual: escapeNewlines(actual),
-                escapedExpected: escapeNewlines(expected),
                 actual: actual,
                 expected: expected,
                 customMessage: message

--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -166,14 +166,14 @@ testHelper.assertionTests("assert", "equals", function(pass, fail, msg, error) {
 
     msg(
         "fail for multi-line strings",
-        "[assert.equals] 'Yo!\\\\nMultiline' expected to be equal to 'Yo!\\\\nHey'",
+        "[assert.equals] 'Yo!\\nMultiline' expected to be equal to 'Yo!\\nHey'",
         "Yo!\nMultiline",
         "Yo!\nHey"
     );
 
     msg(
         "fail for multi-line strings with more than one newline",
-        "[assert.equals] 'Yo!\\\\nMulti-\\\\nline' expected to be equal to 'Yo!\\\\nHey'",
+        "[assert.equals] 'Yo!\\nMulti-\\nline' expected to be equal to 'Yo!\\nHey'",
         "Yo!\nMulti-\nline",
         "Yo!\nHey"
     );

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -151,6 +151,25 @@ describe("custom assertions", function() {
         }
     });
 
+    it("should not escape ! placeholders with string values", function() {
+        referee.add("custom", {
+            assert: function(actual) {
+                this.actual = actual;
+                this.alreadyFormatted = "test";
+                return false;
+            },
+            assertMessage: "unquoted ${!alreadyFormatted}",
+            refuteMessage: "ignored"
+        });
+
+        try {
+            referee.assert.custom(2, 3);
+            throw new Error("Didn't throw");
+        } catch (e) {
+            referee.assert.equals("[assert.custom] unquoted test", e.message);
+        }
+    });
+
     it("should interpolate ... placeholders with array value", function() {
         referee.add("custom", {
             assert: function(actual) {

--- a/lib/interpolate-properties.js
+++ b/lib/interpolate-properties.js
@@ -12,7 +12,7 @@ function prepareMessage(message) {
 }
 
 function interpolateProperties(referee, message, properties) {
-    return message.replace(/\${(\.\.\.)?([a-z]+)}/gi, function(
+    return message.replace(/\${(\.\.\.|!)?([a-z]+)}/gi, function(
         match,
         prefix,
         name
@@ -21,7 +21,10 @@ function interpolateProperties(referee, message, properties) {
             return match;
         }
         var value = properties[name];
-        if (prefix && Array.isArray(value)) {
+        if (prefix === "!") {
+            return value;
+        }
+        if (prefix === "..." && Array.isArray(value)) {
             return value.map(format).join(", ");
         }
         if (name === "customMessage") {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

- Fixes double escaped newlines in `assert.equals`.
- Allows to skip escaping interpolated values by prefixing the property name with `!`, e.g. `some already ${formatted} value`.

<!--
#### Background (Problem in detail)  - optional
-->

When integrating the new formatting in referee with referee-sinon, most fake related assertion where serialized weirdly, mostly because referee-sinon already formats the values and referee's interpolation strategy would format and escape the whole string again.

<!--
#### Solution  - optional
-->

With the new `!` notation for interpolated strings, custom assertions can opt out of referee's formatting.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
