### PR TITLE
Use deep equal comparison for resolves and rejects and allow to be called without expectation

### DIFF
--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -20,7 +20,11 @@ module.exports = function(referee) {
         }),
         refute: createAsyncAssertion(thenCallback, function(actual, expected) {
             if (samsam.deepEqual(actual, expected)) {
-                this.reject(refuteMessage);
+                if (expected === samsam.match.any) {
+                    this.reject("${0} rejected unexpectedly");
+                } else {
+                    this.reject(refuteMessage);
+                }
                 return;
             }
             this.resolve();

--- a/lib/assertions/rejects.js
+++ b/lib/assertions/rejects.js
@@ -3,8 +3,8 @@
 var samsam = require("@sinonjs/samsam");
 var createAsyncAssertion = require("../create-async-assertion");
 
-var assertMessage = "${actual} is not identical to ${expected}";
-var refuteMessage = "${actual} is identical to ${expected}";
+var assertMessage = "${actual} is not equal to ${expected}";
+var refuteMessage = "${actual} is equal to ${expected}";
 
 module.exports = function(referee) {
     function thenCallback() {
@@ -12,14 +12,14 @@ module.exports = function(referee) {
     }
     referee.add("rejects", {
         assert: createAsyncAssertion(thenCallback, function(actual, expected) {
-            if (!samsam.identical(actual, expected)) {
+            if (!samsam.deepEqual(actual, expected)) {
                 this.reject(assertMessage);
                 return;
             }
             this.resolve();
         }),
         refute: createAsyncAssertion(thenCallback, function(actual, expected) {
-            if (samsam.identical(actual, expected)) {
+            if (samsam.deepEqual(actual, expected)) {
                 this.reject(refuteMessage);
                 return;
             }

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -37,6 +37,12 @@ describe("rejects factory", function() {
             return result;
         });
 
+        context("when called without expectation", function() {
+            it("should pass if promise is rejected", function() {
+                return this.options.assert(Promise.reject("test"));
+            });
+        });
+
         context("when promise argument rejects to value argument", function() {
             it("should resolve the returned promise", function() {
                 return this.options.assert(Promise.reject("test"), "test");
@@ -126,6 +132,18 @@ describe("rejects factory", function() {
             assert(result instanceof Promise);
 
             return result;
+        });
+
+        context("when called without expectation", function() {
+            it("should fail if promise is rejected", function() {
+                return this.options
+                    .refute(Promise.reject("test"))
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, "${0} rejected unexpectedly");
+                    });
+            });
         });
 
         context(

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -2,6 +2,7 @@
 
 var assert = require("assert");
 var sinon = require("sinon");
+var samsam = require("@sinonjs/samsam");
 
 var factory = require("./rejects");
 
@@ -14,7 +15,14 @@ describe("rejects factory", function() {
         factory(this.fakeReferee);
 
         this.options = this.fakeReferee.add.args[0][1];
+        this.options.fail = function(message) {
+            throw new Error(message);
+        };
     });
+
+    function unexpectedThen() {
+        throw new Error("Unexpected then");
+    }
 
     it("calls referee.add with 'rejects' as name", function() {
         assert(this.fakeReferee.add.calledWith("rejects"));
@@ -33,16 +41,55 @@ describe("rejects factory", function() {
             it("should resolve the returned promise", function() {
                 return this.options.assert(Promise.reject("test"), "test");
             });
+
+            it("should pass for equal object", function() {
+                return this.options.assert(Promise.reject({ foo: 1 }), {
+                    foo: 1
+                });
+            });
+
+            it("should pass for matching matcher", function() {
+                return this.options.assert(
+                    Promise.reject({ foo: 1 }),
+                    samsam.match.object
+                );
+            });
         });
 
         context(
             "when promise argument does not reject to value argument",
             function() {
                 it("should reject the returned promise", function() {
-                    return this.options
+                    var options = this.options;
+                    return options
                         .assert(Promise.reject("test"), "test2")
+                        .then(unexpectedThen)
                         .catch(function(e) {
                             assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
+                        });
+                });
+
+                it("should fail for different object", function() {
+                    var options = this.options;
+                    return options
+                        .assert(Promise.reject({ foo: 1 }), { foo: 2 })
+                        .then(unexpectedThen)
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
+                        });
+                });
+
+                it("should fail for non-matching matcher", function() {
+                    var promise = Promise.reject({ foo: 1 });
+                    var options = this.options;
+                    return options
+                        .assert(promise, samsam.match.array)
+                        .then(unexpectedThen)
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
                         });
                 });
             }
@@ -52,6 +99,7 @@ describe("rejects factory", function() {
             it("should reject the returned promise", function() {
                 return this.options.assert({}, "test").catch(function(e) {
                     assert(e instanceof Error);
+                    assert.equal(e.message, "promise.then is not a function");
                 });
             });
         });
@@ -62,6 +110,10 @@ describe("rejects factory", function() {
                     .assert(Promise.resolve(), "test")
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(
+                            e.message,
+                            "${0} did not reject, it resolved instead"
+                        );
                     });
             });
         });
@@ -82,15 +134,54 @@ describe("rejects factory", function() {
                 it("should resolve the returned promise", function() {
                     return this.options.refute(Promise.reject("test"), "test2");
                 });
+
+                it("should pass for different object", function() {
+                    return this.options.refute(Promise.reject({ foo: 1 }), {
+                        foo: 2
+                    });
+                });
+
+                it("should pass for non-matching matcher", function() {
+                    return this.options.refute(
+                        Promise.reject({ foo: 1 }),
+                        samsam.match.array
+                    );
+                });
             }
         );
 
         context("when promise argument rejects to value argument", function() {
             it("should reject the returned promise", function() {
-                return this.options
+                var options = this.options;
+                return options
                     .refute(Promise.reject("test"), "test")
+                    .then(unexpectedThen)
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
+                    });
+            });
+
+            it("should fail for equal object", function() {
+                var options = this.options;
+                return options
+                    .refute(Promise.reject({ foo: 1 }), { foo: 1 })
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
+                    });
+            });
+
+            it("should fail for matching matcher", function() {
+                var promise = Promise.reject({ foo: 1 });
+                var options = this.options;
+                return options
+                    .refute(promise, samsam.match.object)
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
                     });
             });
         });
@@ -99,6 +190,7 @@ describe("rejects factory", function() {
             it("should reject the returned promise", function() {
                 return this.options.refute({}, "test").catch(function(e) {
                     assert(e instanceof Error);
+                    assert.equal(e.message, "promise.then is not a function");
                 });
             });
         });
@@ -109,25 +201,29 @@ describe("rejects factory", function() {
                     .refute(Promise.resolve(), "test")
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(
+                            e.message,
+                            "${0} did not reject, it resolved instead"
+                        );
                     });
             });
         });
     });
 
     describe(".assertMessage", function() {
-        it("is '${actual} is not identical to ${expected}'", function() {
+        it("is '${actual} is not equal to ${expected}'", function() {
             assert.equal(
                 this.options.assertMessage,
-                "${actual} is not identical to ${expected}"
+                "${actual} is not equal to ${expected}"
             );
         });
     });
 
     describe(".refuteMessage", function() {
-        it("is '${actual} is identical to ${expected}'", function() {
+        it("is '${actual} is equal to ${expected}'", function() {
             assert.equal(
                 this.options.refuteMessage,
-                "${actual} is identical to ${expected}"
+                "${actual} is equal to ${expected}"
             );
         });
     });

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -20,7 +20,11 @@ module.exports = function(referee) {
         }, catchCallback),
         refute: createAsyncAssertion(function(actual, expected) {
             if (samsam.deepEqual(actual, expected)) {
-                this.reject(refuteMessage);
+                if (expected === samsam.match.any) {
+                    this.reject("${0} resolved unexpectedly");
+                } else {
+                    this.reject(refuteMessage);
+                }
                 return;
             }
             this.resolve();

--- a/lib/assertions/resolves.js
+++ b/lib/assertions/resolves.js
@@ -3,8 +3,8 @@
 var samsam = require("@sinonjs/samsam");
 var createAsyncAssertion = require("../create-async-assertion");
 
-var assertMessage = "${actual} is not identical to ${expected}";
-var refuteMessage = "${actual} is identical to ${expected}";
+var assertMessage = "${actual} is not equal to ${expected}";
+var refuteMessage = "${actual} is equal to ${expected}";
 
 module.exports = function(referee) {
     function catchCallback() {
@@ -12,14 +12,14 @@ module.exports = function(referee) {
     }
     referee.add("resolves", {
         assert: createAsyncAssertion(function(actual, expected) {
-            if (!samsam.identical(actual, expected)) {
+            if (!samsam.deepEqual(actual, expected)) {
                 this.reject(assertMessage);
                 return;
             }
             this.resolve();
         }, catchCallback),
         refute: createAsyncAssertion(function(actual, expected) {
-            if (samsam.identical(actual, expected)) {
+            if (samsam.deepEqual(actual, expected)) {
                 this.reject(refuteMessage);
                 return;
             }

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -40,6 +40,12 @@ describe("resolves factory", function() {
             return result;
         });
 
+        context("when called without expectation", function() {
+            it("should pass if promise is resolved", function() {
+                return this.options.assert(Promise.resolve("test"));
+            });
+        });
+
         context("when promise argument resolves to value argument", function() {
             it("should resolve the returned promise", function() {
                 return this.options.assert(Promise.resolve("test"), "test");
@@ -129,6 +135,18 @@ describe("resolves factory", function() {
             assert(result instanceof Promise);
 
             return result;
+        });
+
+        context("when called without expectation", function() {
+            it("should fail if promise is resolved", function() {
+                return this.options
+                    .refute(Promise.resolve("test"))
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, "${0} resolved unexpectedly");
+                    });
+            });
         });
 
         context(

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -2,6 +2,7 @@
 
 var assert = require("assert");
 var sinon = require("sinon");
+var samsam = require("@sinonjs/samsam");
 
 var factory = require("./resolves");
 
@@ -14,7 +15,14 @@ describe("resolves factory", function() {
         factory(this.fakeReferee);
 
         this.options = this.fakeReferee.add.args[0][1];
+        this.options.fail = function(message) {
+            throw new Error(message);
+        };
     });
+
+    function unexpectedThen() {
+        throw new Error("Unexpected then");
+    }
 
     it("calls referee.add with 'resolves' as name", function() {
         assert(this.fakeReferee.add.calledWith("resolves"));
@@ -36,16 +44,55 @@ describe("resolves factory", function() {
             it("should resolve the returned promise", function() {
                 return this.options.assert(Promise.resolve("test"), "test");
             });
+
+            it("should pass for equal object", function() {
+                return this.options.assert(Promise.resolve({ foo: 1 }), {
+                    foo: 1
+                });
+            });
+
+            it("should pass for matching matcher", function() {
+                return this.options.assert(
+                    Promise.resolve({ foo: 1 }),
+                    samsam.match.object
+                );
+            });
         });
 
         context(
             "when promise argument does not resolves to value argument",
             function() {
                 it("should reject the returned promise", function() {
-                    return this.options
+                    var options = this.options;
+                    return options
                         .assert(Promise.resolve("test"), "test2")
+                        .then(unexpectedThen)
                         .catch(function(e) {
                             assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
+                        });
+                });
+
+                it("should fail for different object", function() {
+                    var options = this.options;
+                    return options
+                        .assert(Promise.resolve({ foo: 1 }), { foo: 2 })
+                        .then(unexpectedThen)
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
+                        });
+                });
+
+                it("should fail for non-matching matcher", function() {
+                    var promise = Promise.resolve({ foo: 1 });
+                    var options = this.options;
+                    return options
+                        .assert(promise, samsam.match.array)
+                        .then(unexpectedThen)
+                        .catch(function(e) {
+                            assert(e instanceof Error);
+                            assert.equal(e.message, options.assertMessage);
                         });
                 });
             }
@@ -55,6 +102,7 @@ describe("resolves factory", function() {
             it("should reject the returned promise", function() {
                 return this.options.assert({}, "test").catch(function(e) {
                     assert(e instanceof Error);
+                    assert.equal(e.message, "promise.then is not a function");
                 });
             });
         });
@@ -65,6 +113,10 @@ describe("resolves factory", function() {
                     .assert(Promise.reject(), "test")
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(
+                            e.message,
+                            "${0} did not resolve, it rejected instead"
+                        );
                     });
             });
         });
@@ -88,15 +140,54 @@ describe("resolves factory", function() {
                         "test2"
                     );
                 });
+
+                it("should pass for different object", function() {
+                    return this.options.refute(Promise.resolve({ foo: 1 }), {
+                        foo: 2
+                    });
+                });
+
+                it("should pass for non-matching matcher", function() {
+                    return this.options.refute(
+                        Promise.resolve({ foo: 1 }),
+                        samsam.match.array
+                    );
+                });
             }
         );
 
         context("when promise argument resolves to value argument", function() {
             it("rejects the returned promise", function() {
-                return this.options
+                var options = this.options;
+                return options
                     .refute(Promise.resolve("test"), "test")
+                    .then(unexpectedThen)
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
+                    });
+            });
+
+            it("should fail for equal object", function() {
+                var options = this.options;
+                return options
+                    .refute(Promise.resolve({ foo: 1 }), { foo: 1 })
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
+                    });
+            });
+
+            it("should fail for matching matcher", function() {
+                var promise = Promise.resolve({ foo: 1 });
+                var options = this.options;
+                return options
+                    .refute(promise, samsam.match.object)
+                    .then(unexpectedThen)
+                    .catch(function(e) {
+                        assert(e instanceof Error);
+                        assert.equal(e.message, options.refuteMessage);
                     });
             });
         });
@@ -105,6 +196,7 @@ describe("resolves factory", function() {
             it("should reject the returned promise", function() {
                 return this.options.refute({}, "test").catch(function(e) {
                     assert(e instanceof Error);
+                    assert.equal(e.message, "promise.then is not a function");
                 });
             });
         });
@@ -115,25 +207,29 @@ describe("resolves factory", function() {
                     .refute(Promise.reject(), "test")
                     .catch(function(e) {
                         assert(e instanceof Error);
+                        assert.equal(
+                            e.message,
+                            "${0} did not resolve, it rejected instead"
+                        );
                     });
             });
         });
     });
 
     describe(".assertMessage", function() {
-        it("is '${actual} is not identical to ${expected}'", function() {
+        it("is '${actual} is not equal to ${expected}'", function() {
             assert.equal(
                 this.options.assertMessage,
-                "${actual} is not identical to ${expected}"
+                "${actual} is not equal to ${expected}"
             );
         });
     });
 
     describe(".refuteMessage", function() {
-        it("is '${actual} is identical to ${expected}'", function() {
+        it("is '${actual} is equal to ${expected}'", function() {
             assert.equal(
                 this.options.refuteMessage,
-                "${actual} is identical to ${expected}"
+                "${actual} is equal to ${expected}"
             );
         });
     });

--- a/lib/create-async-assertion.js
+++ b/lib/create-async-assertion.js
@@ -1,13 +1,15 @@
 "use strict";
 
+var samsam = require("@sinonjs/samsam");
+
 function createAsyncAssertion(thenFunc, catchFunc) {
     function asyncAssertion(promise, expected) {
         var self = this;
-        this.expected = expected;
+        this.expected = arguments.length === 1 ? samsam.match.any : expected;
         function applyCallback(callback, context) {
             return function(actual) {
                 self.actual = actual;
-                callback.apply(context, [actual, expected]);
+                callback.apply(context, [actual, self.expected]);
             };
         }
         var assertionPromise = new Promise(function(resolve, reject) {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

- Add support for deep equality checks in `resolves` and `rejects` which also comes with support for matchers.
- Allow `resolves` and `rejects` to be called without an expectation (same as expectation being `samsam.match.any`).

#### Background (Problem in detail)  - optional

These use cases are currently not supported or fail / succeed for the wrong reason:

```js
assert.resolves(promise, { some: 'object' })
assert.resolves(promise, match.string)
refute.resolves(promise, { some: 'object' })
refute.resolves(promise, match.string)

assert.rejects(promise, { some: 'object' })
assert.rejects(promise, match.string)
refute.rejects(promise, { some: 'object' })
refute.rejects(promise, match.string)
```

Furthermore, I'd like to verify that a given promise is either resolved or rejected, without caring for the value:

```js
assert.resolves(promise)
refute.resolves(promise)

assert.rejects(promise)
refute.rejects(promise)
```

#### Solution  - optional

- Use `samsam.deepEqual` to compare the `actual` and `expected` values.
- Default `expected` to `samsam.match.any` if not provided.
- Fail with a more intuitive message in `refute.resolves(promise)` and `refute.rejects(promise)`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
