### PR TITLE
Upgrade @sinonjs/eslint-config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead
+not IE 11
+not op_mini all
+maintained node versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - *attach-step
       - run:
           name: lint
-          command: npm run lint
+          command: npm run lint -- --quiet
 
   node-12:
     docker:

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,9 +1,5 @@
 extends:
-    - 'eslint-config-sinon'
-
-env:
-  browser: true
-  node: true
+  - "@sinonjs/eslint-config"
 
 globals:
   Float32Array: false
@@ -22,43 +18,10 @@ globals:
   WeakMap: false
   WeakSet: false
 
-plugins:
-  - ie11
-
 rules:
-  strict: [error, 'global']
-
-  ie11/no-collection-args: error
-  ie11/no-for-in-const: error
-  ie11/no-loop-func: warn
-  ie11/no-weak-collections: error
-
   quotes: off
   max-len: off
   # the sinon config is currently using prettier plugin
   # once that has been updated, this line can be removed
   # See https://github.com/sinonjs/eslint-config-sinon/blob/956db70f2e0566d0e7f8f1f093da4704cf16afb2/index.js#L288-L290
   prettier/prettier: off
-
-overrides:
-    - files: ['*.test.*', 'lib/test-helper/*.js']
-      plugins:
-          - mocha
-      env:
-          mocha: true
-      rules:
-          max-nested-callbacks: [error, 6]
-          no-empty-function: off
-          strict: [error, 'global']
-
-          mocha/handle-done-callback: error
-          mocha/no-exclusive-tests: error
-          mocha/no-global-tests: error
-          mocha/no-hooks-for-single-case: off
-          mocha/no-identical-title: error
-          mocha/no-mocha-arrows: error
-          mocha/no-nested-tests: error
-          mocha/no-return-and-callback: error
-          mocha/no-sibling-hooks: error
-          mocha/no-skipped-tests: error
-          mocha/no-top-level-hooks: error

--- a/lib/add.test.js
+++ b/lib/add.test.js
@@ -43,6 +43,7 @@ describe("add", function () {
       var expected =
         "'assert' option must be a Function, taking at least one argument";
       var options = {
+        // eslint-disable-next-line no-empty-function
         assert: function () {},
       };
       var error;
@@ -66,6 +67,7 @@ describe("add", function () {
         assert: function (actual) {
           return actual;
         },
+        // eslint-disable-next-line no-empty-function
         refute: function () {},
       };
       var error;

--- a/lib/assert-arg-num.js
+++ b/lib/assert-arg-num.js
@@ -7,7 +7,7 @@ function assertArgNum(fail, name, args, num) {
     return true;
   }
 
-  fail("[" + name + "] Expected to receive at least " + num + " argument(s)");
+  fail(`[${name}] Expected to receive at least ${num} argument(s)`);
 
   return false;
 }

--- a/lib/assert-arg-num.test.js
+++ b/lib/assert-arg-num.test.js
@@ -51,12 +51,7 @@ describe("assertArgNum", function () {
 
       assertArgNum(fail, name, args, expected);
 
-      var expectedMessage =
-        "[" +
-        name +
-        "] Expected to receive at least " +
-        expected +
-        " argument(s)";
+      var expectedMessage = `[${name}] Expected to receive at least ${expected} argument(s)`;
 
       assert.equal(fail.calledOnce, true);
       assert.equal(fail.getCall(0).args[0], expectedMessage);

--- a/lib/assertions/class-name.test.js
+++ b/lib/assertions/class-name.test.js
@@ -225,9 +225,7 @@ describe("refute.className", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.className] " +
-            message +
-            ": Expected object's className not to include 'item'"
+          `[refute.className] ${message}: Expected object's className not to include 'item'`
         );
         assert.equal(error.name, "AssertionError");
         return true;

--- a/lib/assertions/contains.test.js
+++ b/lib/assertions/contains.test.js
@@ -37,7 +37,7 @@ describe("assert.contains", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.contains] " + message + ": Expected [ 0, 1, 2 ] to contain 3"
+          `[assert.contains] ${message}: Expected [ 0, 1, 2 ] to contain 3`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.contains");
@@ -104,9 +104,7 @@ describe("refute.contains", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.contains] " +
-            message +
-            ": Expected [ 0, 1, 2 ] not to contain 1"
+          `[refute.contains] ${message}: Expected [ 0, 1, 2 ] not to contain 1`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.contains");

--- a/lib/assertions/equals.test.js
+++ b/lib/assertions/equals.test.js
@@ -11,6 +11,7 @@ testHelper.assertionTests("assert", "equals", function (
   msg,
   error
 ) {
+  // eslint-disable-next-line no-empty-function
   var func = function () {};
   var arr = [];
   var date = new Date();
@@ -26,7 +27,9 @@ testHelper.assertionTests("assert", "equals", function (
   pass("when comparing function to itself", func, func);
   fail(
     "when comparing functions",
+    // eslint-disable-next-line no-empty-function
     function () {},
+    // eslint-disable-next-line no-empty-function
     function () {}
   );
   pass("when comparing array to itself", arr, arr);
@@ -92,6 +95,7 @@ testHelper.assertionTests("assert", "equals", function (
     },
 
     child: {
+      // eslint-disable-next-line no-empty-function
       speaking: function () {},
     },
   };
@@ -226,6 +230,7 @@ testHelper.assertionTests("refute", "equals", function (
   fail("when comparing null", null, null);
   fail("when comparing undefined", undefined, undefined);
 
+  // eslint-disable-next-line no-empty-function
   var func = function () {};
   var arr = [];
   var date = new Date();
@@ -235,7 +240,9 @@ testHelper.assertionTests("refute", "equals", function (
   fail("when comparing function to itself", func, func);
   pass(
     "when comparing functions",
+    // eslint-disable-next-line no-empty-function
     function () {},
+    // eslint-disable-next-line no-empty-function
     function () {}
   );
   fail("when comparing array to itself", arr, arr);
@@ -282,6 +289,7 @@ testHelper.assertionTests("refute", "equals", function (
     },
 
     child: {
+      // eslint-disable-next-line no-empty-function
       speaking: function () {},
     },
   };

--- a/lib/assertions/exception.test.js
+++ b/lib/assertions/exception.test.js
@@ -6,11 +6,13 @@ testHelper.assertionTests("assert", "exception", function (pass, fail, msg) {
   pass("when callback throws", function () {
     throw new Error();
   });
+  // eslint-disable-next-line no-empty-function
   fail("when callback does not throw", function () {});
 
   msg(
     "fail with message",
     "[assert.exception] Expected exception",
+    // eslint-disable-next-line no-empty-function
     function () {}
   );
 
@@ -48,6 +50,7 @@ testHelper.assertionTests("assert", "exception", function (pass, fail, msg) {
 
   fail(
     "when callback does not throw and specific type is expected",
+    // eslint-disable-next-line no-empty-function
     function () {},
     { name: "TypeError" }
   );
@@ -55,6 +58,7 @@ testHelper.assertionTests("assert", "exception", function (pass, fail, msg) {
   msg(
     "fail with message when not throwing",
     "[assert.exception] Expected { name: 'TypeError' } but no exception was thrown",
+    // eslint-disable-next-line no-empty-function
     function () {},
     { name: "TypeError" }
   );
@@ -62,6 +66,7 @@ testHelper.assertionTests("assert", "exception", function (pass, fail, msg) {
   msg(
     "fail with custom message",
     "[assert.exception] Hmm: Expected exception",
+    // eslint-disable-next-line no-empty-function
     function () {},
     "Hmm"
   );
@@ -69,6 +74,7 @@ testHelper.assertionTests("assert", "exception", function (pass, fail, msg) {
   msg(
     "fail with matcher and custom message",
     "[assert.exception] Hmm: Expected { name: 'TypeError' } but no exception was thrown",
+    // eslint-disable-next-line no-empty-function
     function () {},
     { name: "TypeError" },
     "Hmm"
@@ -154,7 +160,9 @@ testHelper.assertionTests("refute", "exception", function (pass, fail, msg) {
     throw new Error("Yo, Malcolm");
   });
 
+  // eslint-disable-next-line no-empty-function
   pass("when callback does not throw", function () {});
+  // eslint-disable-next-line no-empty-function
   pass("with message when callback does not throw", function () {}, "Oh noes");
 
   msg(

--- a/lib/assertions/greater.test.js
+++ b/lib/assertions/greater.test.js
@@ -55,7 +55,7 @@ describe("assert.greater", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.greater] " + message + ": Expected 1 to be greater than 2"
+          `[assert.greater] ${message}: Expected 1 to be greater than 2`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.greater");
@@ -95,9 +95,7 @@ describe("refute.greater", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.greater] " +
-            message +
-            ": Expected 2 to be less than or equal to 1"
+          `[refute.greater] ${message}: Expected 2 to be less than or equal to 1`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.greater");

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -4,9 +4,11 @@ var assert = require("assert");
 var inspect = require("util").inspect;
 var referee = require("../referee");
 
+// eslint-disable-next-line no-empty-function
 function MyThing() {}
 var myThing = new MyThing();
 var otherThing = {};
+// eslint-disable-next-line no-empty-function
 function F() {}
 F.prototype = myThing;
 var specializedThing = new F();

--- a/lib/assertions/has-prototype.test.js
+++ b/lib/assertions/has-prototype.test.js
@@ -25,9 +25,7 @@ describe("assert.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.hasPrototype] Expected {} to have " +
-            myThingString +
-            " on its prototype chain"
+          `[assert.hasPrototype] Expected {} to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.hasPrototype");
@@ -45,9 +43,7 @@ describe("assert.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.hasPrototype] Expected 3 to have " +
-            myThingString +
-            " on its prototype chain"
+          `[assert.hasPrototype] Expected 3 to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.hasPrototype");
@@ -109,11 +105,7 @@ describe("assert.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.hasPrototype] " +
-            message +
-            ": Expected {} to have " +
-            myThingString +
-            " on its prototype chain"
+          `[assert.hasPrototype] ${message}: Expected {} to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.hasPrototype");
@@ -167,9 +159,7 @@ describe("refute.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.hasPrototype] Expected MyThing {} not to have " +
-            myThingString +
-            " on its prototype chain"
+          `[refute.hasPrototype] Expected MyThing {} not to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.hasPrototype");
@@ -187,9 +177,7 @@ describe("refute.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.hasPrototype] Expected MyThing {} not to have " +
-            myThingString +
-            " on its prototype chain"
+          `[refute.hasPrototype] Expected MyThing {} not to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.hasPrototype");
@@ -221,11 +209,7 @@ describe("refute.hasPrototype", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.hasPrototype] " +
-            message +
-            ": Expected MyThing {} not to have " +
-            myThingString +
-            " on its prototype chain"
+          `[refute.hasPrototype] ${message}: Expected MyThing {} not to have ${myThingString} on its prototype chain`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.hasPrototype");

--- a/lib/assertions/is-array.test.js
+++ b/lib/assertions/is-array.test.js
@@ -79,7 +79,7 @@ describe("assert.isArray", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isArray] " + message + ": Expected {} to be array"
+          `[assert.isArray] ${message}: Expected {} to be array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isArray");
@@ -130,7 +130,7 @@ describe("refute.isArray", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isArray] " + message + ": Expected [] not to be array"
+          `[refute.isArray] ${message}: Expected [] not to be array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isArray");

--- a/lib/assertions/is-boolean.test.js
+++ b/lib/assertions/is-boolean.test.js
@@ -60,9 +60,7 @@ describe("assert.isBoolean", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isBoolean] " +
-            message +
-            ": Expected 'hello' ('string') to be boolean"
+          `[assert.isBoolean] ${message}: Expected 'hello' ('string') to be boolean`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isBoolean");
@@ -109,7 +107,7 @@ describe("refute.isBoolean", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isBoolean] " + message + ": Expected true not to be boolean"
+          `[refute.isBoolean] ${message}: Expected true not to be boolean`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isBoolean");

--- a/lib/assertions/is-data-view.test.js
+++ b/lib/assertions/is-data-view.test.js
@@ -100,7 +100,7 @@ describe("assert.isDataView", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isDataView] " + message + ": Expected [] to be a DataView"
+          `[assert.isDataView] ${message}: Expected [] to be a DataView`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isDataView");
@@ -162,16 +162,14 @@ describe("refute.isDataView", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isDataView] " +
-            message +
-            ": Expected DataView {\n" +
-            "  byteLength: 8,\n" +
-            "  byteOffset: 0,\n" +
-            "  buffer: ArrayBuffer {\n" +
-            "    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n" +
-            "    byteLength: 8\n" +
-            "  }\n" +
-            "} not to be a DataView"
+          `[refute.isDataView] ${message}: Expected DataView {\n` +
+            `  byteLength: 8,\n` +
+            `  byteOffset: 0,\n` +
+            `  buffer: ArrayBuffer {\n` +
+            `    [Uint8Contents]: <00 00 00 00 00 00 00 00>,\n` +
+            `    byteLength: 8\n` +
+            `  }\n` +
+            `} not to be a DataView`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isDataView");

--- a/lib/assertions/is-date.test.js
+++ b/lib/assertions/is-date.test.js
@@ -104,7 +104,7 @@ describe("assert.isDate", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isDate] " + message + ": Expected {} to be a Date"
+          `[assert.isDate] ${message}: Expected {} to be a Date`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isDate");
@@ -161,13 +161,10 @@ describe("refute.isDate", function () {
     // In node 6+8 date.toString() uses "(UTC)" as suffix in UTC timezone
     // In node 10 date.toString() uses "(Coordinated Universal Time)"
     var suffix = date.toString().match(/\(.*\)$/)[0];
-    var expectedMessage =
-      "[refute.isDate] " +
-      message +
-      ": Expected 1899-12-31T00:00:00.000Z not to be a Date".replace(
-        "{suffix}",
-        suffix
-      );
+    var expectedMessage = `[refute.isDate] ${message}${": Expected 1899-12-31T00:00:00.000Z not to be a Date".replace(
+      "{suffix}",
+      suffix
+    )}`;
 
     assert.throws(
       function () {

--- a/lib/assertions/is-error.test.js
+++ b/lib/assertions/is-error.test.js
@@ -115,9 +115,7 @@ describe("assert.isError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isError] " +
-            message +
-            ": Expected 'not an error instance' to be an Error"
+          `[assert.isError] ${message}: Expected 'not an error instance' to be an Error`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isError");
@@ -281,7 +279,7 @@ describe("refute.isError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isError] " + message + ": Expected Error not to be an Error"
+          `[refute.isError] ${message}: Expected Error not to be an Error`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isError");

--- a/lib/assertions/is-eval-error.test.js
+++ b/lib/assertions/is-eval-error.test.js
@@ -200,9 +200,7 @@ describe("assert.isEvalError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isEvalError] " +
-            message +
-            ": Expected Error to be an EvalError"
+          `[assert.isEvalError] ${message}: Expected Error to be an EvalError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isEvalError");
@@ -282,9 +280,7 @@ describe("refute.isEvalError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isEvalError] " +
-            message +
-            ": Expected EvalError not to be an EvalError"
+          `[refute.isEvalError] ${message}: Expected EvalError not to be an EvalError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isEvalError");

--- a/lib/assertions/is-false.test.js
+++ b/lib/assertions/is-false.test.js
@@ -121,7 +121,7 @@ describe("assert.isFalse", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFalse] " + message + ": Expected true to be false"
+          `[assert.isFalse] ${message}: Expected true to be false`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFalse");
@@ -185,7 +185,7 @@ describe("refute.isFalse", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFalse] " + message + ": Expected false to not be false"
+          `[refute.isFalse] ${message}: Expected false to not be false`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFalse");

--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -92,9 +92,7 @@ describe("assert.isFloat32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFloat32Array] " +
-            message +
-            ": Expected Float64Array(2) [ 0, 0 ] to be a Float32Array"
+          `[assert.isFloat32Array] ${message}: Expected Float64Array(2) [ 0, 0 ] to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat32Array");
@@ -150,9 +148,7 @@ describe("refute.isFloat32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFloat32Array] " +
-            message +
-            ": Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array"
+          `[refute.isFloat32Array] ${message}: Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat32Array");

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -92,9 +92,7 @@ describe("assert.isFloat64Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFloat64Array] " +
-            message +
-            ": Expected Float32Array(2) [ 0, 0 ] to be a Float64Array"
+          `[assert.isFloat64Array] ${message}: Expected Float32Array(2) [ 0, 0 ] to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat64Array");
@@ -150,9 +148,7 @@ describe("refute.isFloat64Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFloat64Array] " +
-            message +
-            ": Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array"
+          `[refute.isFloat64Array] ${message}: Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat64Array");

--- a/lib/assertions/is-function.test.js
+++ b/lib/assertions/is-function.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isFunction", function () {

--- a/lib/assertions/is-function.test.js
+++ b/lib/assertions/is-function.test.js
@@ -39,9 +39,7 @@ describe("assert.isFunction", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFunction] " +
-            message +
-            ": '[object Object]' ('object') expected to be function"
+          `[assert.isFunction] ${message}: '[object Object]' ('object') expected to be function`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFunction");
@@ -84,9 +82,7 @@ describe("refute.isFunction", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFunction] " +
-            message +
-            ": 'function noop() {}' expected not to be function"
+          `[refute.isFunction] ${message}: 'function noop() {}' expected not to be function`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFunction");

--- a/lib/assertions/is-infinity.test.js
+++ b/lib/assertions/is-infinity.test.js
@@ -110,9 +110,7 @@ describe("assert.isInfinity", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInfinity] " +
-            message +
-            ": Expected -Infinity to be Infinity"
+          `[assert.isInfinity] ${message}: Expected -Infinity to be Infinity`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInfinity");
@@ -172,9 +170,7 @@ describe("refute.isInfinity", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInfinity] " +
-            message +
-            ": Expected Infinity not to be Infinity"
+          `[refute.isInfinity] ${message}: Expected Infinity not to be Infinity`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInfinity");

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -110,9 +110,7 @@ describe("assert.isInt16Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt16Array] " +
-            message +
-            ": Expected [Arguments] {} to be an Int16Array"
+          `[assert.isInt16Array] ${message}: Expected [Arguments] {} to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt16Array");
@@ -172,9 +170,7 @@ describe("refute.isInt16Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt16Array] " +
-            message +
-            ": Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array"
+          `[refute.isInt16Array] ${message}: Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt16Array");

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -110,9 +110,7 @@ describe("assert.isInt32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt32Array] " +
-            message +
-            ": Expected [Arguments] {} to be an Int32Array"
+          `[assert.isInt32Array] ${message}: Expected [Arguments] {} to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt32Array");
@@ -172,9 +170,7 @@ describe("refute.isInt32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt32Array] " +
-            message +
-            ": Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array"
+          `[refute.isInt32Array] ${message}: Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt32Array");

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -110,9 +110,7 @@ describe("assert.isInt8Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt8Array] " +
-            message +
-            ": Expected [Arguments] {} to be an Int8Array"
+          `[assert.isInt8Array] ${message}: Expected [Arguments] {} to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt8Array");
@@ -172,9 +170,7 @@ describe("refute.isInt8Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt8Array] " +
-            message +
-            ": Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array"
+          `[refute.isInt8Array] ${message}: Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt8Array");

--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -92,9 +92,7 @@ describe("assert.isIntlCollator", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isIntlCollator] " +
-            message +
-            ": Expected 'apple pie' to be an Intl.Collator"
+          `[assert.isIntlCollator] ${message}: Expected 'apple pie' to be an Intl.Collator`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isIntlCollator");
@@ -149,9 +147,7 @@ describe("refute.isIntlCollator", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlCollator] " +
-            message +
-            ": Expected Collator [Object] {} not to be an Intl.Collator"
+          `[refute.isIntlCollator] ${message}: Expected Collator [Object] {} not to be an Intl.Collator`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlCollator");

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -92,9 +92,7 @@ describe("assert.isIntlDateTimeFormat", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isIntlDateTimeFormat] " +
-            message +
-            ": Expected 'apple pie' to be an Intl.DateTimeFormat"
+          `[assert.isIntlDateTimeFormat] ${message}: Expected 'apple pie' to be an Intl.DateTimeFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isIntlDateTimeFormat");
@@ -149,9 +147,7 @@ describe("refute.isIntlDateTimeFormat", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlDateTimeFormat] " +
-            message +
-            ": Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
+          `[refute.isIntlDateTimeFormat] ${message}: Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlDateTimeFormat");

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -92,9 +92,7 @@ describe("assert.isIntlNumberFormat", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isIntlNumberFormat] " +
-            message +
-            ": Expected 'apple pie' to be an Intl.NumberFormat"
+          `[assert.isIntlNumberFormat] ${message}: Expected 'apple pie' to be an Intl.NumberFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isIntlNumberFormat");
@@ -149,9 +147,7 @@ describe("refute.isIntlNumberFormat", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlNumberFormat] " +
-            message +
-            ": Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
+          `[refute.isIntlNumberFormat] ${message}: Expected NumberFormat [Object] {} not to be an Intl.NumberFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlNumberFormat");

--- a/lib/assertions/is-map.test.js
+++ b/lib/assertions/is-map.test.js
@@ -42,7 +42,6 @@ describe("isMap factory", function () {
           Map,
           WeakMap,
           Set,
-          // eslint-disable-next-line ie11/no-weak-collections
           new WeakMap(),
           [],
           {},

--- a/lib/assertions/is-nan.test.js
+++ b/lib/assertions/is-nan.test.js
@@ -4,6 +4,7 @@ var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isNaN", function () {

--- a/lib/assertions/is-nan.test.js
+++ b/lib/assertions/is-nan.test.js
@@ -206,7 +206,7 @@ describe("assert.isNaN", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isNaN] " + message + ": Expected null to be NaN"
+          `[assert.isNaN] ${message}: Expected null to be NaN`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isNaN");
@@ -287,7 +287,7 @@ describe("refute.isNaN", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isNaN] " + message + ": Expected not to be NaN"
+          `[refute.isNaN] ${message}: Expected not to be NaN`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isNaN");

--- a/lib/assertions/is-negative-infinity.test.js
+++ b/lib/assertions/is-negative-infinity.test.js
@@ -110,9 +110,7 @@ describe("assert.isNegativeInfinity", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isNegativeInfinity] " +
-            message +
-            ": Expected Infinity to be -Infinity"
+          `[assert.isNegativeInfinity] ${message}: Expected Infinity to be -Infinity`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isNegativeInfinity");
@@ -172,9 +170,7 @@ describe("refute.isNegativeInfinity", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isNegativeInfinity] " +
-            message +
-            ": Expected -Infinity not to be -Infinity"
+          `[refute.isNegativeInfinity] ${message}: Expected -Infinity not to be -Infinity`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isNegativeInfinity");

--- a/lib/assertions/is-null.test.js
+++ b/lib/assertions/is-null.test.js
@@ -155,7 +155,7 @@ describe("assert.isNull", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isNull] " + message + ": Expected undefined to be null"
+          `[assert.isNull] ${message}: Expected undefined to be null`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isNull");
@@ -224,7 +224,7 @@ describe("refute.isNull", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isNull] " + message + ": Expected not to be null"
+          `[refute.isNull] ${message}: Expected not to be null`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isNull");

--- a/lib/assertions/is-null.test.js
+++ b/lib/assertions/is-null.test.js
@@ -4,6 +4,7 @@ var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isNull", function () {

--- a/lib/assertions/is-number.test.js
+++ b/lib/assertions/is-number.test.js
@@ -129,9 +129,7 @@ describe("assert.isNumber", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isNumber] " +
-            message +
-            ": Expected NaN ('number') to be a non-NaN number"
+          `[assert.isNumber] ${message}: Expected NaN ('number') to be a non-NaN number`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isNumber");
@@ -263,9 +261,7 @@ describe("refute.isNumber", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isNumber] " +
-            message +
-            ": Expected 42 to be NaN or a non-number value"
+          `[refute.isNumber] ${message}: Expected 42 to be NaN or a non-number value`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isNumber");

--- a/lib/assertions/is-number.test.js
+++ b/lib/assertions/is-number.test.js
@@ -4,6 +4,7 @@ var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isNumber", function () {

--- a/lib/assertions/is-object.test.js
+++ b/lib/assertions/is-object.test.js
@@ -58,9 +58,7 @@ describe("assert.isObject", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isObject] " +
-            message +
-            ": [Function: noop] ('function') expected to be object and not null"
+          `[assert.isObject] ${message}: [Function: noop] ('function') expected to be object and not null`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isObject");
@@ -106,9 +104,7 @@ describe("refute.isObject", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isObject] " +
-            message +
-            ": {} expected to be null or not an object"
+          `[refute.isObject] ${message}: {} expected to be null or not an object`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isObject");

--- a/lib/assertions/is-object.test.js
+++ b/lib/assertions/is-object.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isObject", function () {

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -112,9 +112,7 @@ describe("assert.isPromise", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isPromise] " +
-            message +
-            ": Expected 'apple pie' to be a Promise"
+          `[assert.isPromise] ${message}: Expected 'apple pie' to be a Promise`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isPromise");
@@ -174,9 +172,7 @@ describe("refute.isPromise", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isPromise] " +
-            message +
-            ": Expected Promise { 'apple pie' } not to be a Promise"
+          `[refute.isPromise] ${message}: Expected Promise { 'apple pie' } not to be a Promise`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isPromise");

--- a/lib/assertions/is-promise.test.js
+++ b/lib/assertions/is-promise.test.js
@@ -4,6 +4,7 @@ var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
+// eslint-disable-next-line no-empty-function
 function noop() {}
 
 describe("assert.isPromise", function () {

--- a/lib/assertions/is-range-error.test.js
+++ b/lib/assertions/is-range-error.test.js
@@ -200,9 +200,7 @@ describe("assert.isRangeError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isRangeError] " +
-            message +
-            ": Expected Error to be a RangeError"
+          `[assert.isRangeError] ${message}: Expected Error to be a RangeError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isRangeError");
@@ -282,9 +280,7 @@ describe("refute.isRangeError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isRangeError] " +
-            message +
-            ": Expected RangeError not to be a RangeError"
+          `[refute.isRangeError] ${message}: Expected RangeError not to be a RangeError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isRangeError");

--- a/lib/assertions/is-reference-error.test.js
+++ b/lib/assertions/is-reference-error.test.js
@@ -200,9 +200,7 @@ describe("assert.isReferenceError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isReferenceError] " +
-            message +
-            ": Expected Error to be a ReferenceError"
+          `[assert.isReferenceError] ${message}: Expected Error to be a ReferenceError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isReferenceError");
@@ -282,9 +280,7 @@ describe("refute.isReferenceError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isReferenceError] " +
-            message +
-            ": Expected ReferenceError not to be a ReferenceError"
+          `[refute.isReferenceError] ${message}: Expected ReferenceError not to be a ReferenceError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isReferenceError");

--- a/lib/assertions/is-set.test.js
+++ b/lib/assertions/is-set.test.js
@@ -86,7 +86,7 @@ describe("assert.isSet", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isSet] " + message + ": Expected [Arguments] {} to be a Set"
+          `[assert.isSet] ${message}: Expected [Arguments] {} to be a Set`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isSet");

--- a/lib/assertions/is-symbol.test.js
+++ b/lib/assertions/is-symbol.test.js
@@ -92,9 +92,7 @@ describe("assert.isSymbol", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isSymbol] " +
-            message +
-            ": Expected 'apple pie' to be a Symbol"
+          `[assert.isSymbol] ${message}: Expected 'apple pie' to be a Symbol`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isSymbol");
@@ -134,9 +132,7 @@ describe("refute.isSymbol", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isSymbol] " +
-            message +
-            ": Expected Symbol(apple pie) not to be a Symbol"
+          `[refute.isSymbol] ${message}: Expected Symbol(apple pie) not to be a Symbol`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isSymbol");

--- a/lib/assertions/is-syntax-error.test.js
+++ b/lib/assertions/is-syntax-error.test.js
@@ -200,9 +200,7 @@ describe("assert.isSyntaxError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isSyntaxError] " +
-            message +
-            ": Expected Error to be a SyntaxError"
+          `[assert.isSyntaxError] ${message}: Expected Error to be a SyntaxError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isSyntaxError");
@@ -282,9 +280,7 @@ describe("refute.isSyntaxError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isSyntaxError] " +
-            message +
-            ": Expected SyntaxError not to be a SyntaxError"
+          `[refute.isSyntaxError] ${message}: Expected SyntaxError not to be a SyntaxError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isSyntaxError");

--- a/lib/assertions/is-type-error.test.js
+++ b/lib/assertions/is-type-error.test.js
@@ -200,9 +200,7 @@ describe("assert.isTypeError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isTypeError] " +
-            message +
-            ": Expected Error to be a TypeError"
+          `[assert.isTypeError] ${message}: Expected Error to be a TypeError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isTypeError");
@@ -282,9 +280,7 @@ describe("refute.isTypeError", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isTypeError] " +
-            message +
-            ": Expected TypeError not to be a TypeError"
+          `[refute.isTypeError] ${message}: Expected TypeError not to be a TypeError`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isTypeError");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -109,9 +109,7 @@ describe("assert.isUint16Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint16Array] " +
-            message +
-            ": Expected [] to be a Uint16Array"
+          `[assert.isUint16Array] ${message}: Expected [] to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint16Array");
@@ -150,9 +148,7 @@ describe("refute.isUint16Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint16Array] " +
-            message +
-            ": Expected Uint16Array(0) [] not to be a Uint16Array"
+          `[refute.isUint16Array] ${message}: Expected Uint16Array(0) [] not to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint16Array");

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -109,9 +109,7 @@ describe("assert.isUint32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint32Array] " +
-            message +
-            ": Expected [] to be a Uint32Array"
+          `[assert.isUint32Array] ${message}: Expected [] to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint32Array");
@@ -150,9 +148,7 @@ describe("refute.isUint32Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint32Array] " +
-            message +
-            ": Expected Uint32Array(0) [] not to be a Uint32Array"
+          `[refute.isUint32Array] ${message}: Expected Uint32Array(0) [] not to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint32Array");

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -109,9 +109,7 @@ describe("assert.isUint8Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint8Array] " +
-            message +
-            ": Expected [] to be a Uint8Array"
+          `[assert.isUint8Array] ${message}: Expected [] to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint8Array");
@@ -150,9 +148,7 @@ describe("refute.isUint8Array", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint8Array] " +
-            message +
-            ": Expected Uint8Array(0) [] not to be a Uint8Array"
+          `[refute.isUint8Array] ${message}: Expected Uint8Array(0) [] not to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint8Array");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -52,9 +52,7 @@ describe("assert.isUndefined", function () {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUndefined] Expected " +
-            anonymousFunction +
-            " ('function') to be undefined"
+          `[assert.isUndefined] Expected ${anonymousFunction} ('function') to be undefined`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUndefined");

--- a/lib/assertions/is-undefined.test.js
+++ b/lib/assertions/is-undefined.test.js
@@ -45,6 +45,7 @@ describe("assert.isUndefined", function () {
   it("should fail for function", function () {
     assert.throws(
       function () {
+        // eslint-disable-next-line no-empty-function
         referee.assert.isUndefined(function () {});
       },
       function (error) {

--- a/lib/assertions/is-weak-map.js
+++ b/lib/assertions/is-weak-map.js
@@ -5,7 +5,6 @@ var actualMessageValues = require("../actual-message-values");
 module.exports = function (referee) {
   referee.add("isWeakMap", {
     assert: function (actual) {
-      // eslint-disable-next-line ie11/no-weak-collections
       return actual instanceof WeakMap;
     },
     assertMessage: "${customMessage}Expected ${actual} to be a WeakMap",

--- a/lib/assertions/is-weak-map.test.js
+++ b/lib/assertions/is-weak-map.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable ie11/no-weak-collections */
 "use strict";
 
 var assert = require("assert");

--- a/lib/assertions/is-weak-set.js
+++ b/lib/assertions/is-weak-set.js
@@ -5,7 +5,6 @@ var actualMessageValues = require("../actual-message-values");
 module.exports = function (referee) {
   referee.add("isWeakSet", {
     assert: function (actual) {
-      // eslint-disable-next-line ie11/no-weak-collections
       return actual instanceof WeakSet;
     },
     assertMessage: "${customMessage}Expected ${actual} to be a WeakSet",

--- a/lib/assertions/is-weak-set.test.js
+++ b/lib/assertions/is-weak-set.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable ie11/no-weak-collections */
 "use strict";
 
 var assert = require("assert");

--- a/lib/assertions/keys.test.js
+++ b/lib/assertions/keys.test.js
@@ -15,7 +15,9 @@ describe("keys factory", function () {
       }
     }
   }
+  // eslint-disable-next-line no-empty-function
   Klass.prototype.methodA = function () {};
+  // eslint-disable-next-line no-empty-function
   Klass.prototype.methodB = function () {};
 
   beforeEach(function () {

--- a/lib/assertions/keys.test.js
+++ b/lib/assertions/keys.test.js
@@ -15,9 +15,9 @@ describe("keys factory", function () {
       }
     }
   }
-  // eslint-disable-next-line no-empty-function
+  // eslint-disable-next-line no-empty-function, mocha/no-setup-in-describe
   Klass.prototype.methodA = function () {};
-  // eslint-disable-next-line no-empty-function
+  // eslint-disable-next-line no-empty-function, mocha/no-setup-in-describe
   Klass.prototype.methodB = function () {};
 
   beforeEach(function () {

--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-promise-reject-errors  -- temporary, long term this should use Error */
 "use strict";
 
 var assert = require("assert");

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-promise-reject-errors -- temporary, long term this should use Error */
 "use strict";
 
 var assert = require("assert");

--- a/lib/create-add.js
+++ b/lib/create-add.js
@@ -8,8 +8,7 @@ var validFunctionName = /^[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*$/;
 function verifyArguments(name, options) {
   if (typeof name !== "string" || !validFunctionName.test(name)) {
     throw new TypeError(
-      "'name' argument must be a non-empty string matching " +
-        validFunctionName.toString()
+      `'name' argument must be a non-empty string matching ${validFunctionName.toString()}`
     );
   }
 

--- a/lib/create-assert.js
+++ b/lib/create-assert.js
@@ -8,7 +8,7 @@ function createAssert(referee) {
 
     if (!actual) {
       referee.fail(
-        message || "[assert] Expected " + String(actual) + " to be truthy"
+        message || `[assert] Expected ${String(actual)} to be truthy`
       );
       return;
     }

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -3,6 +3,7 @@
 var referee = require("./referee");
 var sinon = require("sinon");
 var createAsyncAssertion = require("./create-async-assertion");
+// eslint-disable-next-line no-empty-function
 var noop = function () {};
 
 describe("createAsyncAssertion", function () {

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -33,12 +33,14 @@ describe("createAsyncAssertion", function () {
   });
 
   describe("applyCallback", function () {
+    /* eslint-disable mocha/no-setup-in-describe */
     var resolve = function () {
       this.resolve();
     };
     var thenCallback = sinon.spy(resolve);
     var catchCallback = sinon.spy(resolve);
     var func = createAsyncAssertion(thenCallback, catchCallback);
+    /* eslint-enable mocha/no-setup-in-describe */
 
     beforeEach(function () {
       thenCallback.resetHistory();

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -56,6 +56,7 @@ describe("createAsyncAssertion", function () {
     });
 
     it("should apply and call the given `catchCallback`", function () {
+      // eslint-disable-next-line prefer-promise-reject-errors -- temporary, long term this should use Error
       var promise = func.call({}, Promise.reject("test"), "test");
       return promise.then(function () {
         referee.assert.isTrue(catchCallback.calledOnceWith("test", "test"));

--- a/lib/create-refute.js
+++ b/lib/create-refute.js
@@ -8,7 +8,7 @@ function createRefute(referee) {
 
     if (actual) {
       referee.fail(
-        message || "[refute] Expected " + String(actual) + " to be falsy"
+        message || `[refute] Expected ${String(actual)} to be falsy`
       );
       return;
     }

--- a/lib/create-verifier.js
+++ b/lib/create-verifier.js
@@ -24,7 +24,7 @@ function createVerifier(referee) {
 
       if (expected && count !== expected) {
         throw new Error(
-          "Expected assertion count to be " + expected + " but was " + count
+          `Expected assertion count to be ${expected} but was ${count}`
         );
       }
 

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -26,8 +26,8 @@ describe("custom assertions", function () {
   it("should expose properties on this as message values", function () {
     referee.add("custom", {
       assert: function (actual, expected) {
-        this.actual = actual + "?";
-        this.expected = expected + "!";
+        this.actual = `${actual}?`;
+        this.expected = `${expected}!`;
         return false;
       },
       assertMessage: "${actual} ${expected}",
@@ -48,8 +48,8 @@ describe("custom assertions", function () {
 
     referee.add("custom", {
       assert: function (actual, expected) {
-        this.actual = actual + "?";
-        this.expected = expected + "!";
+        this.actual = `${actual}?`;
+        this.expected = `${expected}!`;
         return false;
       },
       assertMessage: "${actual} ${expected}",
@@ -119,7 +119,7 @@ describe("custom assertions", function () {
   it("should interpolate same property multiple times", function () {
     referee.add("custom", {
       assert: function (actual) {
-        this.actual = actual + "?";
+        this.actual = `${actual}?`;
         return false;
       },
       assertMessage: "${actual} ${actual}",
@@ -137,7 +137,7 @@ describe("custom assertions", function () {
   it("should interpolate numeric placeholders multiple times", function () {
     referee.add("custom", {
       assert: function (actual) {
-        this.actual = actual + "?";
+        this.actual = `${actual}?`;
         return false;
       },
       assertMessage: "${0} ${0}",

--- a/lib/custom-assertions.test.js
+++ b/lib/custom-assertions.test.js
@@ -227,6 +227,7 @@ describe("custom assertions", function () {
 
   it("should not throw if Promise is not defined", function () {
     // Let sinon restore global.Promise:
+    // eslint-disable-next-line no-empty-function
     sinon.replace(global, "Promise", function () {});
     delete global.Promise;
 

--- a/lib/define-assertion.js
+++ b/lib/define-assertion.js
@@ -8,7 +8,7 @@ var interpolateProperties = require("./interpolate-properties");
 
 function createAssertion(referee, type, name, func, minArgs, messageValues) {
   var assertion = function () {
-    var fullName = type + "." + name;
+    var fullName = `${type}.${name}`;
     var failed = false;
 
     assertArgNum(referee.fail, fullName, arguments, minArgs);
@@ -28,7 +28,7 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
         message = interpolatePosArg(message, args);
         message = interpolateProperties(referee, message, this);
         message = interpolateProperties(referee, message, namedValues);
-        var operator = type + "." + name;
+        var operator = `${type}.${name}`;
         var errorProperties = {
           operator: operator,
         };
@@ -41,7 +41,7 @@ function createAssertion(referee, type, name, func, minArgs, messageValues) {
             errorProperties.expected = namedValues.expected;
           }
         }
-        referee.fail("[" + operator + "] " + message, errorProperties);
+        referee.fail(`[${operator}] ${message}`, errorProperties);
         return false;
       },
     };

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -36,8 +36,8 @@ expect.wrapAssertion = function wrapAssertion(assertion, expectation, referee) {
       return callFunc.apply(referee.expect, args);
     } catch (e) {
       e.message = e.message.replace(
-        "[" + type + "." + assertion + "]",
-        "[expect." + (this.assertMode ? "" : "not.") + expectation + "]"
+        `[${type}.${assertion}]`,
+        `[expect.${this.assertMode ? "" : "not."}${expectation}]`
       );
       throw e;
     }

--- a/lib/expect.test.js
+++ b/lib/expect.test.js
@@ -93,6 +93,7 @@ describe("expect", function () {
     expect(obj).not.toEqual({});
     expect(obj).toBeObject();
     expect(false).not.toBeObject();
+    // eslint-disable-next-line no-empty-function
     expect(function () {}).toBeFunction();
     expect({}).not.toBeFunction();
     expect(new RegExp("[a-z]")).toBeRegExp();
@@ -108,6 +109,7 @@ describe("expect", function () {
     expect(function () {
       throw new TypeError("Oops");
     }).toThrow("TypeError");
+    // eslint-disable-next-line no-empty-function
     expect(function () {}).not.toThrow();
     expect({ tagName: "li" }).toHaveTagName("li");
     expect({ tagName: "ol" }).not.toHaveTagName("li");

--- a/lib/match.test.js
+++ b/lib/match.test.js
@@ -35,9 +35,7 @@ describe("match", function () {
           assert.equal(error.code, "ERR_ASSERTION");
           assert.equal(
             error.message,
-            "[assert.equals] { some: 'string', foo: 1, bar: true } expected to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: " +
-              anonymousFunction +
-              ", message: 'typeOf(\"string\")' }\n}"
+            `[assert.equals] { some: 'string', foo: 1, bar: true } expected to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: ${anonymousFunction}, message: 'typeOf("string")' }\n}`
           );
           assert.equal(error.name, "AssertionError");
           assert.equal(error.operator, "assert.equals");
@@ -72,9 +70,7 @@ describe("match", function () {
           assert.equal(error.code, "ERR_ASSERTION");
           assert.equal(
             error.message,
-            "[refute.equals] { some: 'string', foo: 1, bar: 'test' } expected not to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: " +
-              anonymousFunction +
-              ", message: 'typeOf(\"string\")' }\n}"
+            `[refute.equals] { some: 'string', foo: 1, bar: 'test' } expected not to be equal to {\n  some: 'string',\n  foo: 1,\n  bar: { test: ${anonymousFunction}, message: 'typeOf("string")' }\n}`
           );
           assert.equal(error.name, "AssertionError");
           assert.equal(error.operator, "refute.equals");

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -112,7 +112,7 @@ describe("API", function () {
       "same",
       "tagName",
     ].forEach(function (assertion) {
-      it("has '" + assertion + "' assertion", function () {
+      it(`has '${assertion}' assertion`, function () {
         assert.equal(typeof referee.assert[assertion], "function");
         assert.equal(typeof referee.refute[assertion], "function");
       });

--- a/lib/referee.test.js
+++ b/lib/referee.test.js
@@ -94,6 +94,7 @@ describe("API", function () {
   });
 
   describe("assertions", function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
     [
       "isMap",
       "isUint8ClampedArray",

--- a/lib/test-helper/anonymous-function-string.js
+++ b/lib/test-helper/anonymous-function-string.js
@@ -2,4 +2,7 @@
 
 var inspect = require("util").inspect;
 
-module.exports = inspect(function () {});
+module.exports = inspect(
+  // eslint-disable-next-line no-empty-function
+  function () {}
+);

--- a/lib/test-helper/get-array-like.js
+++ b/lib/test-helper/get-array-like.js
@@ -7,6 +7,7 @@ module.exports = function getArrayLike() {
     1: "Two",
     2: "Three",
     3: "Four",
+    // eslint-disable-next-line no-empty-function
     splice: function () {},
   };
 };

--- a/lib/test-helper/index.js
+++ b/lib/test-helper/index.js
@@ -41,13 +41,13 @@ function assertFailureEvent(callback) {
   try {
     callback();
   } catch (e) {
-    assert.fail("Assertion threw when it should not: " + e.message);
+    assert.fail(`Assertion threw when it should not: ${e.message}`);
   }
 
   assert.equal(
     this.failListener.callCount,
     fails + 1,
-    "Fail listener was not called once: " + this.failListener.callCount - fails
+    `Fail listener was not called once: ${this.failListener.callCount}` - fails
   );
   assert.equal(
     this.okListener.callCount,
@@ -65,7 +65,7 @@ function passingAssertionTest(type, assertion, args) {
 
       return value;
     });
-    var callStr = type + "." + assertion + "(" + argsAsStrings.join(", ") + ")";
+    var callStr = `${type}.${assertion}(${argsAsStrings.join(", ")})`;
 
     try {
       referee[type][assertion].apply(referee, args);
@@ -75,9 +75,9 @@ function passingAssertionTest(type, assertion, args) {
     assert.equal(
       testHelper.okListener.callCount,
       1,
-      "Expected referee to emit the pass event once for " + callStr
+      `Expected referee to emit the pass event once for ${callStr}`
     );
-    sinon.assert.calledWith(testHelper.okListener, type + "." + assertion);
+    sinon.assert.calledWith(testHelper.okListener, `${type}.${assertion}`);
     sinon.assert.notCalled(referee.fail);
     sinon.assert.notCalled(testHelper.failListener);
   };
@@ -85,24 +85,20 @@ function passingAssertionTest(type, assertion, args) {
 
 function failingAssertionTest(type, assertion, args) {
   return function () {
-    var callStr = type + "." + assertion + "(" + args.join(", ") + ")";
+    var callStr = `${type}.${assertion}(${args.join(", ")})`;
 
     try {
       referee[type][assertion].apply(referee, args);
 
       // eslint-disable-next-line no-console
-      console.log("Unexpectedly passed: " + callStr);
+      console.log(`Unexpectedly passed: ${callStr}`);
       // eslint-disable-next-line no-empty
     } catch (e) {}
 
     assert.equal(
       referee.fail.callCount,
       1,
-      "Expected referee.fail to be called once for " +
-        callStr +
-        ", was called " +
-        referee.fail.callCount +
-        " times"
+      `Expected referee.fail to be called once for ${callStr}, was called ${referee.fail.callCount} times`
     );
 
     sinon.assert.notCalled(testHelper.okListener);
@@ -120,13 +116,13 @@ function assertionMessageTest(type, assertion, message, args) {
 
     try {
       referee[type][assertion].apply(referee, args);
-      throw new Error(type + "." + assertion + " expected to fail");
+      throw new Error(`${type}.${assertion} expected to fail`);
     } catch (e) {
-      assert.equal(e.name, "AssertionError", e.name + ": " + e.message);
+      assert.equal(e.name, "AssertionError", `${e.name}: ${e.message}`);
       assert.equal(
         e.message,
         message,
-        "Message was " + e.message + ", expected " + message
+        `Message was ${e.message}, expected ${message}`
       );
       msg = e.message;
     }
@@ -142,25 +138,20 @@ function failingErrorPropertiesTest(type, assertion, properties, args) {
   return function () {
     try {
       referee[type][assertion].apply(referee, args);
-      throw new Error(type + "." + assertion + " expected to fail");
+      throw new Error(`${type}.${assertion} expected to fail`);
     } catch (e) {
-      assert.equal(e.name, "AssertionError", e.name + ": " + e.message);
+      assert.equal(e.name, "AssertionError", `${e.name}: ${e.message}`);
       Object.keys(properties).forEach(function (key) {
         assert.deepEqual(
           e[key],
           properties[key],
-          "AssertionError." + key + " " + e[key] + " == " + properties[key]
+          `AssertionError.${key} ${e[key]} == ${properties[key]}`
         );
       });
       Object.keys(e).forEach(function (key) {
         if (!properties.hasOwnProperty(key) && key !== "name") {
           throw new Error(
-            type +
-              "." +
-              assertion +
-              " defined unexpected property '" +
-              key +
-              "'' on error"
+            `${type}.${assertion} defined unexpected property '${key}'' on error`
           );
         }
       });
@@ -175,17 +166,17 @@ function assertionTests(type, assertion, callback) {
   };
 
   function pass(name) {
-    var label = "should pass " + name;
+    var label = `should pass ${name}`;
     it(label, passingAssertionTest(type, assertion, slice(arguments, 1), name));
   }
 
   function fail(name) {
-    var label = "should fail " + name;
+    var label = `should fail ${name}`;
     it(label, failingAssertionTest(type, assertion, slice(arguments, 1)));
   }
 
   function msg(name, message) {
-    var label = "should fail " + name;
+    var label = `should fail ${name}`;
     var test = assertionMessageTest(
       type,
       assertion,
@@ -197,7 +188,7 @@ function assertionTests(type, assertion, callback) {
   }
 
   function error(name, properties) {
-    var label = "should fail " + name + " with correct error properties";
+    var label = `should fail ${name} with correct error properties`;
     var test = failingErrorPropertiesTest(
       type,
       assertion,
@@ -207,7 +198,7 @@ function assertionTests(type, assertion, callback) {
     it(label, test);
   }
 
-  describe(type + "." + assertion, function () {
+  describe(`${type}.${assertion}`, function () {
     beforeEach(testHelper.setUp);
     afterEach(testHelper.tearDown);
 

--- a/lib/test-helper/index.js
+++ b/lib/test-helper/index.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+/* eslint-disable jsdoc/require-jsdoc */
 "use strict";
 
 var commons = require("@sinonjs/commons");

--- a/lib/verifier.test.js
+++ b/lib/verifier.test.js
@@ -131,11 +131,7 @@ describe("verifier", function () {
       it("should throw an error", function () {
         var limit = 10;
         var expectedCount = 2;
-        var expectedMessage =
-          "Expected assertion count to be " +
-          expectedCount +
-          " but was " +
-          limit;
+        var expectedMessage = `Expected assertion count to be ${expectedCount} but was ${limit}`;
         var error;
 
         for (var i = 0; i < limit; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,6 +230,23 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -257,12 +274,33 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@mdn/browser-compat-data": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-2.0.7.tgz",
+      "integrity": "sha512-GeeM827DlzFFidn1eKkMBiqXFD2oLsnZbaiGhByPl0vcapsRzUL+t9hDoov1swc9rB2jw64R+ihtzC8qOE9wXw==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
       "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "requires": {
         "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/eslint-config": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/eslint-config/-/eslint-config-4.0.0.tgz",
+      "integrity": "sha512-Pn5RYbBd21kDcbxRdS70WElNG/h6t9J+mHCl25/m0l3B2r0TPw58cJ19rkAu8MN6TKJP/5QHuTIKhvFGWV8V5Q==",
+      "dev": true,
+      "requires": {
+        "eslint": "^7.20.0",
+        "eslint-plugin-compat": "^3.9.0",
+        "eslint-plugin-jsdoc": "^32.2.0",
+        "eslint-plugin-mocha": "^8.0.0"
       }
     },
     "@sinonjs/fake-timers": {
@@ -356,9 +394,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-jsx": {
@@ -378,9 +416,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -471,10 +509,16 @@
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
+    "ast-metadata-inferer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
+      "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==",
+      "dev": true
+    },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "available-typed-arrays": {
@@ -522,6 +566,19 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserslist": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001181",
+        "colorette": "^1.2.1",
+        "electron-to-chromium": "^1.3.649",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.70"
+      }
+    },
     "caching-transform": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
@@ -546,6 +603,12 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "caniuse-lite": {
+      "version": "1.0.30001199",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
+      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -556,12 +619,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
     },
     "chokidar": {
       "version": "3.3.0",
@@ -654,12 +711,6 @@
         }
       }
     },
-    "cli-width": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -722,10 +773,22 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
     "commander": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
       "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+      "integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
       "dev": true
     },
     "commondir": {
@@ -754,6 +817,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "core-js": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -871,6 +940,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.687",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+      "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -973,6 +1048,12 @@
       "integrity": "sha512-JBN3gYqc6j/fX2s2zjwGoVbHGODFOIpzbRCSI9OM3rkvYuALqB91EUjoBW6uuwmiURPgH5IksJNN6ndTY778sw==",
       "dev": true
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -980,113 +1061,236 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
-      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.3",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^5.0.1",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.3",
+        "optionator": "^0.9.1",
         "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^6.1.2",
-        "strip-ansi": "^5.2.0",
-        "strip-json-comments": "^3.0.1",
-        "table": "^5.2.3",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
     },
-    "eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+    "eslint-plugin-compat": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.9.0.tgz",
+      "integrity": "sha512-lt3l5PHFHVEYSZ5zijcoYvtQJPsBifRiH5N0Et57KwVu7l/yxmHhSG6VJiLMa/lXrg93Qu8049RNQOMn0+yJBg==",
       "dev": true,
       "requires": {
-        "get-stdin": "^6.0.0"
+        "@mdn/browser-compat-data": "^2.0.7",
+        "ast-metadata-inferer": "^0.4.0",
+        "browserslist": "^4.12.2",
+        "caniuse-lite": "^1.0.30001166",
+        "core-js": "^3.6.5",
+        "find-up": "^4.1.0",
+        "lodash.memoize": "4.1.2",
+        "semver": "7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
-    "eslint-config-sinon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-sinon/-/eslint-config-sinon-3.0.1.tgz",
-      "integrity": "sha512-hHEHWZjqxhqKN5N3r6542YHU5OLtSOJDWYeAfbMLzqn/QWMNROjMaZzm5GlmOfgFFxviQ5wsOz3lxKTrfR8KwQ==",
-      "dev": true
-    },
-    "eslint-plugin-ie11": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
-      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+    "eslint-plugin-jsdoc": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.2.0.tgz",
+      "integrity": "sha512-ikeVeF3JVmzjcmGd04OZK0rXjgiw46TWtNX+OhyF2jQlw3w1CAU1vyAyLv8PZcIjp7WxP4N20Vg1CI9bp/52dw==",
       "dev": true,
       "requires": {
-        "requireindex": "~1.1.0"
+        "comment-parser": "1.1.2",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.4",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-mocha": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
-      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^2.0.0",
-        "ramda": "^0.27.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
-      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "eslint-utils": "^2.1.0",
+        "ramda": "^0.27.1"
       }
     },
     "eslint-scope": {
@@ -1100,29 +1304,45 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.1",
-        "acorn-jsx": "^5.2.0",
-        "eslint-visitor-keys": "^1.1.0"
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -1132,9 +1352,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -1261,27 +1481,16 @@
         }
       }
     },
-    "external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
-      "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      }
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1306,12 +1515,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
-      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
-        "flat-cache": "^2.0.1"
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-keys": {
@@ -1373,20 +1582,19 @@
       }
     },
     "flat-cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
-      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
       "requires": {
-        "flatted": "^2.0.0",
-        "rimraf": "2.6.3",
-        "write": "1.0.3"
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
       }
     },
     "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
     "foreach": {
@@ -1499,12 +1707,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -1686,15 +1888,6 @@
         }
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1737,88 +1930,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "inquirer": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
-      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^3.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.19",
-        "mute-stream": "0.0.8",
-        "run-async": "^2.4.0",
-        "rxjs": "^6.6.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -2139,6 +2250,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -2185,13 +2302,13 @@
       "dev": true
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "lines-and-columns": {
@@ -2402,6 +2519,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -2751,12 +2874,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2813,6 +2930,12 @@
       "requires": {
         "process-on-spawn": "^1.0.0"
       }
+    },
+    "node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3051,24 +3174,18 @@
       "dev": true
     },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -3212,9 +3329,9 @@
       }
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "prettier": {
@@ -3222,15 +3339,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "process-on-spawn": {
       "version": "1.0.0",
@@ -3312,9 +3420,15 @@
       }
     },
     "regexpp": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
       "dev": true
     },
     "release-zalgo": {
@@ -3332,16 +3446,16 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "requireindex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "resolve": {
@@ -3370,19 +3484,13 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
     },
     "rxjs": {
       "version": "6.6.3",
@@ -3397,12 +3505,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
     },
     "semver": {
       "version": "6.3.0",
@@ -3500,20 +3602,38 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
       }
@@ -3708,39 +3828,34 @@
       }
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^7.0.2",
+        "lodash": "^4.17.20",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
       },
       "dependencies": {
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "ajv": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+          "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
         }
       }
     },
@@ -3766,15 +3881,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.2"
-      }
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -3803,12 +3909,12 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-detect": {
@@ -3832,9 +3938,9 @@
       }
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -3860,9 +3966,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -4009,26 +4115,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "write": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
-      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
-      "dev": true,
-      "requires": {
-        "mkdirp": "^0.5.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
-      }
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -58,14 +58,9 @@
     "!lib/**/*.test.js"
   ],
   "devDependencies": {
+    "@sinonjs/eslint-config": "^4.0.0",
     "@studio/changes": "^2.0.0",
     "esbuild": "^0.8.6",
-    "eslint": "^6.5.1",
-    "eslint-config-prettier": "^6.15.0",
-    "eslint-config-sinon": "^3.0.1",
-    "eslint-plugin-ie11": "^1.0.0",
-    "eslint-plugin-mocha": "^6.1.1",
-    "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.2.1",
     "lint-staged": "^10.0.7",
     "mkdirp": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --check",
-    "*.js": "eslint"
+    "*.js": "eslint --quiet"
   },
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",


### PR DESCRIPTION
This PR upgrades ~`eslint-config-sinon`~ `@sinonjs/eslint-config` and fixes all uncovered lint violations.

#### Purpose

Adopt the latest `@sinonjs/eslint-config` in order to allow modern JavaScript syntax and ease the maintenance burden of keeping all the development tools up to date.

#### Background

https://hackmd.io/@mroderick/sinon-rfc-drop-legacy-browsers

#### Solution

* Add latest version of `@sinonjs/eslint-config` as `devDependency`
* Fix all lint violations
* Configure pre-commit hook and CI to ignore lint warnings. This allows contributions before we add all the missing JSDoc comments. We can still see all warnings by running `npm run lint`
* Uninstall no longer needed linting dependencies

#### TO DO

- [ ] Install `@sinonjs/eslint-config`
- [ ] Remove `eslint`
- [ ] Remove `eslint-config-prettier`
- [ ] Remove `eslint-plugin-ie11`
- [ ] Remove `eslint-plugin-mocha`
- [ ] Remove `eslint-plugin-prettier`

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. DRAFT - until https://github.com/sinonjs/eslint-config-sinon/pull/7 is merged and published
    1. Check out https://github.com/sinonjs/eslint-config-sinon/pull/7 somewhere
    2. In that folder
        1. `npm link`
    3. In the `referee` repository
        1. `npm link @sinonjs/eslint-config`
        4. `npm install eslint-plugin-compat`
        5. `npm install eslint-plugin-jsdoc` 
        6. `npm install eslint-plugin-mocha`
3. `npm run lint`
4. Observe that the only warnings are `jsdoc/*`
5. Try creating an `async` function without an `await` statement
6. Observe that the linter complains about it
7. Add an `await` statement
8. Observe that the linter allows `async` functions

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
