### PR TITLE
Remove obviated deps

### DIFF
--- a/lib/assertions/class-name.js
+++ b/lib/assertions/class-name.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var includes = require("lodash.includes");
-
 var noClassNameMessage =
   "${customMessage}Expected object to have className property";
 
@@ -16,7 +14,7 @@ module.exports = function (referee) {
       var actual = element.className.split(" ");
       var i, l;
       for (i = 0, l = expected.length; i < l; i++) {
-        if (!includes(actual, expected[i])) {
+        if (!actual.includes(expected[i])) {
           return false;
         }
       }

--- a/lib/assertions/contains.js
+++ b/lib/assertions/contains.js
@@ -1,12 +1,11 @@
 "use strict";
 
-var includes = require("lodash.includes");
 var actualAndExpectedMessageValues = require("../actual-and-expected-message-values");
 
 module.exports = function (referee) {
   referee.add("contains", {
     assert: function (haystack, needle) {
-      return includes(haystack, needle);
+      return haystack.includes(needle);
     },
     assertMessage: "${customMessage}Expected ${actual} to contain ${expected}",
     refuteMessage:

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,15 +1,14 @@
 "use strict";
 
-var objectAssign = require("object-assign");
 var arrayFrom = require("array-from");
 
 function expect(actual) {
-  var expectation = objectAssign(Object.create(expect.expectation), {
+  var expectation = Object.assign(Object.create(expect.expectation), {
     actual: actual,
     assertMode: true,
   });
 
-  expectation.not = objectAssign(Object.create(expectation), {
+  expectation.not = Object.assign(Object.create(expectation), {
     assertMode: false,
   });
 

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var arrayFrom = require("array-from");
-
 function expect(actual) {
   var expectation = Object.assign(Object.create(expect.expectation), {
     actual: actual,
@@ -19,7 +17,7 @@ expect.expectation = Object.create(null);
 
 expect.wrapAssertion = function wrapAssertion(assertion, expectation, referee) {
   expect.expectation[expectation] = function () {
-    var args = [this.actual].concat(arrayFrom(arguments));
+    var args = [this.actual].concat(Array.from(arguments));
     var type = this.assertMode ? "assert" : "refute";
     var callFunc;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -504,11 +504,6 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
-    },
     "ast-metadata-inferer": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2505,11 +2505,6 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3113,11 +3113,6 @@
         }
       }
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@sinonjs/commons": "^1.4.0",
     "@sinonjs/samsam": "^5.0.2",
-    "array-from": "2.1.1",
     "event-emitter": "^0.3.5",
     "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "event-emitter": "^0.3.5",
     "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",
-    "object-assign": "^4.1.1",
     "util": "^0.12.3"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@sinonjs/commons": "^1.4.0",
     "@sinonjs/samsam": "^5.0.2",
     "event-emitter": "^0.3.5",
-    "lodash.includes": "^4.3.0",
     "lodash.isarguments": "^3.1.0",
     "util": "^0.12.3"
   },


### PR DESCRIPTION
This PR removes polyfills that have been obviated by `referee@8.0.0`, where we dropped support for legacy runtimes.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`
4. Observe that all tests pass
