### PR TITLE
Fix resolves and rejects arity

### DIFF
--- a/lib/assertions/rejects.test.js
+++ b/lib/assertions/rejects.test.js
@@ -25,6 +25,11 @@ describe("rejects factory", function () {
     throw new Error("Unexpected then");
   }
 
+  it("should be a function with arity 1", function () {
+    assert.equal(typeof this.options.assert, "function");
+    assert.equal(this.options.assert.length, 1);
+  });
+
   it("calls referee.add with 'rejects' as name", function () {
     assert(this.fakeReferee.add.calledWith("rejects"));
   });

--- a/lib/assertions/resolves.test.js
+++ b/lib/assertions/resolves.test.js
@@ -25,6 +25,11 @@ describe("resolves factory", function () {
     throw new Error("Unexpected then");
   }
 
+  it("should be a function with arity 1", function () {
+    assert.equal(typeof this.options.assert, "function");
+    assert.equal(this.options.assert.length, 1);
+  });
+
   it("calls referee.add with 'resolves' as name", function () {
     assert(this.fakeReferee.add.calledWith("resolves"));
   });

--- a/lib/create-async-assertion.js
+++ b/lib/create-async-assertion.js
@@ -3,9 +3,9 @@
 var samsam = require("@sinonjs/samsam");
 
 function createAsyncAssertion(thenFunc, catchFunc) {
-  function asyncAssertion(promise, expected) {
+  function asyncAssertion(promise) {
     var self = this;
-    this.expected = arguments.length === 1 ? samsam.match.any : expected;
+    this.expected = arguments.length === 1 ? samsam.match.any : arguments[1];
     function applyCallback(callback, context) {
       return function (actual) {
         self.actual = actual;

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -7,9 +7,10 @@ var createAsyncAssertion = require("./create-async-assertion");
 var noop = function () {};
 
 describe("createAsyncAssertion", function () {
-  it("should return a Function", function () {
+  it("should return a Function with arity 1", function () {
     var func = createAsyncAssertion(noop, noop);
     referee.assert.isFunction(func);
+    referee.assert.hasArity(func, 1);
   });
 
   it("should result in a promise", function () {


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Make second argument to `assert.resolves` and `assert.rejects` optional by setting the function arity to 1.

#### Background (Problem in detail)  - optional

The change suggested in #115 to make the second argument for `assert.resolves` and `assert.rejects` optional was implemented as part of #214. However, as noticed in #219 the function arity isn't correct and therefore an exception is thrown when attempting to call these assertions with just one argument.

Fixed #219 

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
