### PR TITLE
Fix typo in isUndefined docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -258,7 +258,7 @@ refute.less.message =
 assert.isUndefined(object[, message])
 ```
 
-Fails if `object` is not `null`.
+Fails if `object` is not `undefined`.
 
 ```js
 assert.isUndefined(undefined); // Passes


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Typo fix in isUndefined

https://sinonjs.github.io/referee/#isundefined

#### How to verify - mandatory

1. Install mkdocs
2. mkdocs serve
3. Go to http://127.0.0.1:8000/#isundefined

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
