### PR TITLE
Add support for Node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,14 @@ jobs:
     steps:
       - *attach-step
       - run:
+          name: Test
+          command: npm test
+  node-16:
+    docker:
+      - image: circleci/node:16
+    steps:
+      - *attach-step
+      - run:
           name: Test with coverage
           command: npm run test-check-coverage
       - run:
@@ -91,5 +99,8 @@ workflows:
           requires:
             - install-dependencies
       - node-14:
+          requires:
+            - install-dependencies
+      - node-16:
           requires:
             - install-dependencies

--- a/lib/assertions/is-intl-collator.test.js
+++ b/lib/assertions/is-intl-collator.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
+var inspect = require("util").inspect;
 
 describe("assert.isIntlCollator", function () {
   it("should pass for Intl.Collator", function () {
@@ -104,15 +105,19 @@ describe("assert.isIntlCollator", function () {
 
 describe("refute.isIntlCollator", function () {
   it("should fail for Intl.Collator", function () {
+    var object = new Intl.Collator();
+
     assert.throws(
       function () {
-        referee.refute.isIntlCollator(new Intl.Collator());
+        referee.refute.isIntlCollator(object);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlCollator] Expected Collator [Object] {} not to be an Intl.Collator"
+          `[refute.isIntlCollator] Expected ${inspect(
+            object
+          )} not to be an Intl.Collator`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlCollator");
@@ -139,15 +144,19 @@ describe("refute.isIntlCollator", function () {
 
   it("should fail with custom message", function () {
     var message = "0d6ff45e-4794-41d2-90ce-41b554580bb6";
+    var object = new Intl.Collator();
+
     assert.throws(
       function () {
-        referee.refute.isIntlCollator(new Intl.Collator(), message);
+        referee.refute.isIntlCollator(object, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isIntlCollator] ${message}: Expected Collator [Object] {} not to be an Intl.Collator`
+          `[refute.isIntlCollator] ${message}: Expected ${inspect(
+            object
+          )} not to be an Intl.Collator`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlCollator");

--- a/lib/assertions/is-intl-date-time-format.test.js
+++ b/lib/assertions/is-intl-date-time-format.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
+var inspect = require("util").inspect;
 
 describe("assert.isIntlDateTimeFormat", function () {
   it("should pass for Intl.DateTimeFormat", function () {
@@ -104,15 +105,19 @@ describe("assert.isIntlDateTimeFormat", function () {
 
 describe("refute.isIntlDateTimeFormat", function () {
   it("should fail for Intl.DateTimeFormat", function () {
+    var object = new Intl.DateTimeFormat();
+
     assert.throws(
       function () {
-        referee.refute.isIntlDateTimeFormat(new Intl.DateTimeFormat());
+        referee.refute.isIntlDateTimeFormat(object);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlDateTimeFormat] Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat"
+          `[refute.isIntlDateTimeFormat] Expected ${inspect(
+            object
+          )} not to be an Intl.DateTimeFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlDateTimeFormat");
@@ -139,15 +144,19 @@ describe("refute.isIntlDateTimeFormat", function () {
 
   it("should fail with custom message", function () {
     var message = "c485cacd-b75c-4c2c-8903-c2e7f9b16766";
+    var object = new Intl.DateTimeFormat();
+
     assert.throws(
       function () {
-        referee.refute.isIntlDateTimeFormat(new Intl.DateTimeFormat(), message);
+        referee.refute.isIntlDateTimeFormat(object, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isIntlDateTimeFormat] ${message}: Expected DateTimeFormat [Object] {} not to be an Intl.DateTimeFormat`
+          `[refute.isIntlDateTimeFormat] ${message}: Expected ${inspect(
+            object
+          )} not to be an Intl.DateTimeFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlDateTimeFormat");

--- a/lib/assertions/is-intl-number-format.test.js
+++ b/lib/assertions/is-intl-number-format.test.js
@@ -3,6 +3,7 @@
 var assert = require("assert");
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
+var inspect = require("util").inspect;
 
 describe("assert.isIntlNumberFormat", function () {
   it("should pass for Intl.NumberFormat", function () {
@@ -104,15 +105,18 @@ describe("assert.isIntlNumberFormat", function () {
 
 describe("refute.isIntlNumberFormat", function () {
   it("should fail for Intl.NumberFormat", function () {
+    const object = new Intl.NumberFormat();
     assert.throws(
       function () {
-        referee.refute.isIntlNumberFormat(new Intl.NumberFormat());
+        referee.refute.isIntlNumberFormat(object);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isIntlNumberFormat] Expected NumberFormat [Object] {} not to be an Intl.NumberFormat"
+          `[refute.isIntlNumberFormat] Expected ${inspect(
+            object
+          )} not to be an Intl.NumberFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlNumberFormat");
@@ -139,15 +143,18 @@ describe("refute.isIntlNumberFormat", function () {
 
   it("should fail with custom message", function () {
     var message = "f84e51dd-d5af-4ef0-81ec-2d575eadd735";
+    var object = new Intl.NumberFormat();
     assert.throws(
       function () {
-        referee.refute.isIntlNumberFormat(new Intl.NumberFormat(), message);
+        referee.refute.isIntlNumberFormat(object, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isIntlNumberFormat] ${message}: Expected NumberFormat [Object] {} not to be an Intl.NumberFormat`
+          `[refute.isIntlNumberFormat] ${message}: Expected ${inspect(
+            object
+          )} not to be an Intl.NumberFormat`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isIntlNumberFormat");


### PR DESCRIPTION
This PR adds support for Node 16

#### Purpose

Sinon's pledge is to support all LTS Node versions, so we need to also run the tests in Node 16


#### Solution 

* Fix tests that were failing in Node 16
* Run tests in CI in Node 16

#### How to verify - mandatory

1. Observe that CI runs tests in Node 16
2. Observe that CI still runs tests in Node 12 and 14

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
