### PR TITLE
Fix tests in node 12.14.1

### DIFF
--- a/lib/assertions/is-float-32-array.test.js
+++ b/lib/assertions/is-float-32-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
@@ -10,15 +11,19 @@ describe("assert.isFloat32Array", function () {
   });
 
   it("should fail for Float64Array", function () {
+    const actual = new Float64Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isFloat32Array(new Float64Array(2));
+        referee.assert.isFloat32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFloat32Array] Expected Float64Array(2) [ 0, 0 ] to be a Float32Array"
+          `[assert.isFloat32Array] Expected ${inspect(
+            actual
+          )} to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat32Array");
@@ -83,16 +88,19 @@ describe("assert.isFloat32Array", function () {
 
   it("should fail with custom message", function () {
     var message = "b547be3f-9453-4034-a3ee-e6dfe0f26fa1";
+    const actual = new Float64Array(2);
 
     assert.throws(
       function () {
-        referee.assert.isFloat32Array(new Float64Array(2), message);
+        referee.assert.isFloat32Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[assert.isFloat32Array] ${message}: Expected Float64Array(2) [ 0, 0 ] to be a Float32Array`
+          `[assert.isFloat32Array] ${message}: Expected ${inspect(
+            actual
+          )} to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat32Array");
@@ -104,15 +112,19 @@ describe("assert.isFloat32Array", function () {
 
 describe("refute.isFloat32Array", function () {
   it("should fail for Float32Array", function () {
+    const actual = new Float32Array(2);
+
     assert.throws(
       function () {
-        referee.refute.isFloat32Array(new Float32Array(2));
+        referee.refute.isFloat32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFloat32Array] Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array"
+          `[refute.isFloat32Array] Expected ${inspect(
+            actual
+          )} not to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat32Array");
@@ -139,16 +151,19 @@ describe("refute.isFloat32Array", function () {
 
   it("should fail with custom message", function () {
     var message = "2cc86fd1-dd39-44ed-a7c6-e5b83a16e27e";
+    const actual = new Float32Array(2);
 
     assert.throws(
       function () {
-        referee.refute.isFloat32Array(new Float32Array(2), message);
+        referee.refute.isFloat32Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isFloat32Array] ${message}: Expected Float32Array(2) [ 0, 0 ] not to be a Float32Array`
+          `[refute.isFloat32Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be a Float32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat32Array");

--- a/lib/assertions/is-float-64-array.test.js
+++ b/lib/assertions/is-float-64-array.test.js
@@ -1,20 +1,25 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
 describe("assert.isFloat64Array", function () {
   it("should fail for Float32Array", function () {
+    const actual = new Float32Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isFloat64Array(new Float32Array(2));
+        referee.assert.isFloat64Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isFloat64Array] Expected Float32Array(2) [ 0, 0 ] to be a Float64Array"
+          `[assert.isFloat64Array] Expected ${inspect(
+            actual
+          )} to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat64Array");
@@ -83,16 +88,19 @@ describe("assert.isFloat64Array", function () {
 
   it("should fail with custom message", function () {
     var message = "b547be3f-9453-4034-a3ee-e6dfe0f26fa1";
+    const actual = new Float32Array(2);
 
     assert.throws(
       function () {
-        referee.assert.isFloat64Array(new Float32Array(2), message);
+        referee.assert.isFloat64Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[assert.isFloat64Array] ${message}: Expected Float32Array(2) [ 0, 0 ] to be a Float64Array`
+          `[assert.isFloat64Array] ${message}: Expected ${inspect(
+            actual
+          )} to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isFloat64Array");
@@ -108,15 +116,19 @@ describe("refute.isFloat64Array", function () {
   });
 
   it("should fail for Float64Array", function () {
+    const actual = new Float64Array(2);
+
     assert.throws(
       function () {
-        referee.refute.isFloat64Array(new Float64Array(2));
+        referee.refute.isFloat64Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isFloat64Array] Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array"
+          `[refute.isFloat64Array] Expected ${inspect(
+            actual
+          )} not to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat64Array");
@@ -139,16 +151,19 @@ describe("refute.isFloat64Array", function () {
 
   it("should fail with custom message", function () {
     var message = "2cc86fd1-dd39-44ed-a7c6-e5b83a16e27e";
+    const actual = new Float64Array(2);
 
     assert.throws(
       function () {
-        referee.refute.isFloat64Array(new Float64Array(2), message);
+        referee.refute.isFloat64Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isFloat64Array] ${message}: Expected Float64Array(2) [ 0, 0 ] not to be a Float64Array`
+          `[refute.isFloat64Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be a Float64Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isFloat64Array");

--- a/lib/assertions/is-int-16-array.test.js
+++ b/lib/assertions/is-int-16-array.test.js
@@ -1,20 +1,25 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
 describe("assert.isInt16Array", function () {
   it("should fail for Int8Array", function () {
+    const actual = new Int8Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt16Array(new Int8Array(2));
+        referee.assert.isInt16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt16Array] Expected Int8Array(2) [ 0, 0 ] to be an Int16Array"
+          `[assert.isInt16Array] Expected ${inspect(
+            actual
+          )} to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt16Array");
@@ -28,15 +33,19 @@ describe("assert.isInt16Array", function () {
   });
 
   it("should fail for Int32Array", function () {
+    const actual = new Int32Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt16Array(new Int32Array(2));
+        referee.assert.isInt16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt16Array] Expected Int32Array(2) [ 0, 0 ] to be an Int16Array"
+          `[assert.isInt16Array] Expected ${inspect(
+            actual
+          )} to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt16Array");
@@ -126,15 +135,19 @@ describe("refute.isInt16Array", function () {
   });
 
   it("should fail for Int16Array", function () {
+    const actual = new Int16Array(2);
+
     assert.throws(
       function () {
-        referee.refute.isInt16Array(new Int16Array(2));
+        referee.refute.isInt16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt16Array] Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array"
+          `[refute.isInt16Array] Expected ${inspect(
+            actual
+          )} not to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt16Array");
@@ -161,16 +174,19 @@ describe("refute.isInt16Array", function () {
 
   it("should fail with custom message", function () {
     var message = "1cf37727-f020-4ce8-840d-acb7ffc2ac21";
+    const actual = new Int16Array(2);
 
     assert.throws(
       function () {
-        referee.refute.isInt16Array(new Int16Array(2), message);
+        referee.refute.isInt16Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isInt16Array] ${message}: Expected Int16Array(2) [ 0, 0 ] not to be an Int16Array`
+          `[refute.isInt16Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be an Int16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt16Array");

--- a/lib/assertions/is-int-32-array.test.js
+++ b/lib/assertions/is-int-32-array.test.js
@@ -1,20 +1,25 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
 describe("assert.isInt32Array", function () {
   it("should fail for Int8Array", function () {
+    const actual = new Int8Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt32Array(new Int8Array(2));
+        referee.assert.isInt32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt32Array] Expected Int8Array(2) [ 0, 0 ] to be an Int32Array"
+          `[assert.isInt32Array] Expected ${inspect(
+            actual
+          )} to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt32Array");
@@ -24,15 +29,19 @@ describe("assert.isInt32Array", function () {
   });
 
   it("should fail for Int16Array", function () {
+    const actual = new Int16Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt32Array(new Int16Array(2));
+        referee.assert.isInt32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt32Array] Expected Int16Array(2) [ 0, 0 ] to be an Int32Array"
+          `[assert.isInt32Array] Expected ${inspect(
+            actual
+          )} to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt32Array");
@@ -130,15 +139,19 @@ describe("refute.isInt32Array", function () {
   });
 
   it("should fail for Int32Array", function () {
+    const actual = new Int32Array(2);
+
     assert.throws(
       function () {
-        referee.refute.isInt32Array(new Int32Array(2));
+        referee.refute.isInt32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt32Array] Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array"
+          `[refute.isInt32Array] Expected ${inspect(
+            actual
+          )} not to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt32Array");
@@ -161,16 +174,19 @@ describe("refute.isInt32Array", function () {
 
   it("should fail with custom message", function () {
     var message = "82576420-8e5d-4618-b6eb-87bcf00b9170";
+    const actual = new Int32Array(2);
 
     assert.throws(
       function () {
-        referee.refute.isInt32Array(new Int32Array(2), message);
+        referee.refute.isInt32Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isInt32Array] ${message}: Expected Int32Array(2) [ 0, 0 ] not to be an Int32Array`
+          `[refute.isInt32Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be an Int32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt32Array");

--- a/lib/assertions/is-int-8-array.test.js
+++ b/lib/assertions/is-int-8-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var referee = require("../referee");
 var captureArgs = require("../test-helper/capture-args");
 
@@ -10,15 +11,17 @@ describe("assert.isInt8Array", function () {
   });
 
   it("should fail for Int16Array", function () {
+    const actual = new Int16Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt8Array(new Int16Array(2));
+        referee.assert.isInt8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt8Array] Expected Int16Array(2) [ 0, 0 ] to be an Int8Array"
+          `[assert.isInt8Array] Expected ${inspect(actual)} to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt8Array");
@@ -28,15 +31,17 @@ describe("assert.isInt8Array", function () {
   });
 
   it("should fail for Int32Array", function () {
+    const actual = new Int32Array(2);
+
     assert.throws(
       function () {
-        referee.assert.isInt8Array(new Int32Array(2));
+        referee.assert.isInt8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isInt8Array] Expected Int32Array(2) [ 0, 0 ] to be an Int8Array"
+          `[assert.isInt8Array] Expected ${inspect(actual)} to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isInt8Array");
@@ -122,15 +127,19 @@ describe("assert.isInt8Array", function () {
 
 describe("refute.isInt8Array", function () {
   it("should fail for Int8Array", function () {
+    const actual = new Int8Array(2);
+
     assert.throws(
       function () {
-        referee.refute.isInt8Array(new Int8Array(2));
+        referee.refute.isInt8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isInt8Array] Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array"
+          `[refute.isInt8Array] Expected ${inspect(
+            actual
+          )} not to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt8Array");
@@ -161,16 +170,19 @@ describe("refute.isInt8Array", function () {
 
   it("should fail with custom message", function () {
     var message = "dcd0c656-65a3-4117-8bd2-444b6e64d94c";
+    const actual = new Int8Array(2);
 
     assert.throws(
       function () {
-        referee.refute.isInt8Array(new Int8Array(2), message);
+        referee.refute.isInt8Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isInt8Array] ${message}: Expected Int8Array(2) [ 0, 0 ] not to be an Int8Array`
+          `[refute.isInt8Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be an Int8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isInt8Array");

--- a/lib/assertions/is-u-int-16-array.test.js
+++ b/lib/assertions/is-u-int-16-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var captureArgs = require("../test-helper/capture-args");
 var referee = require("../referee");
 
@@ -10,15 +11,19 @@ describe("assert.isUint16Array", function () {
   });
 
   it("should fail for Uint32Array", function () {
+    const actual = new Uint32Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint16Array(new Uint32Array());
+        referee.assert.isUint16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint16Array] Expected Uint32Array(0) [] to be a Uint16Array"
+          `[assert.isUint16Array] Expected ${inspect(
+            actual
+          )} to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint16Array");
@@ -28,15 +33,19 @@ describe("assert.isUint16Array", function () {
   });
 
   it("should fail for Uint8Array", function () {
+    const actual = new Uint8Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint16Array(new Uint8Array());
+        referee.assert.isUint16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint16Array] Expected Uint8Array(0) [] to be a Uint16Array"
+          `[assert.isUint16Array] Expected ${inspect(
+            actual
+          )} to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint16Array");
@@ -121,15 +130,19 @@ describe("assert.isUint16Array", function () {
 
 describe("refute.isUint16Array", function () {
   it("should fail for isUint16Array", function () {
+    const actual = new Uint16Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint16Array(new Uint16Array());
+        referee.refute.isUint16Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint16Array] Expected Uint16Array(0) [] not to be a Uint16Array"
+          `[refute.isUint16Array] Expected ${inspect(
+            actual
+          )} not to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint16Array");
@@ -140,15 +153,19 @@ describe("refute.isUint16Array", function () {
 
   it("should fail with custom message", function () {
     var message = "7a548ba3-6efc-4300-8af5-7ff42eb9c064";
+    const actual = new Uint16Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint16Array(new Uint16Array(), message);
+        referee.refute.isUint16Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isUint16Array] ${message}: Expected Uint16Array(0) [] not to be a Uint16Array`
+          `[refute.isUint16Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be a Uint16Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint16Array");

--- a/lib/assertions/is-u-int-32-array.test.js
+++ b/lib/assertions/is-u-int-32-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var captureArgs = require("../test-helper/capture-args");
 var referee = require("../referee");
 
@@ -10,15 +11,19 @@ describe("assert.isUint32Array", function () {
   });
 
   it("should fail for Uint16Array", function () {
+    const actual = new Uint8Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint32Array(new Uint16Array());
+        referee.assert.isUint32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint32Array] Expected Uint16Array(0) [] to be a Uint32Array"
+          `[assert.isUint32Array] Expected ${inspect(
+            actual
+          )} to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint32Array");
@@ -28,15 +33,19 @@ describe("assert.isUint32Array", function () {
   });
 
   it("should fail for Uint8Array", function () {
+    const actual = new Uint8Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint32Array(new Uint8Array());
+        referee.assert.isUint32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint32Array] Expected Uint8Array(0) [] to be a Uint32Array"
+          `[assert.isUint32Array] Expected ${inspect(
+            actual
+          )} to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint32Array");
@@ -121,15 +130,19 @@ describe("assert.isUint32Array", function () {
 
 describe("refute.isUint32Array", function () {
   it("should fail for isUint32Array", function () {
+    const actual = new Uint32Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint32Array(new Uint32Array());
+        referee.refute.isUint32Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint32Array] Expected Uint32Array(0) [] not to be a Uint32Array"
+          `[refute.isUint32Array] Expected ${inspect(
+            actual
+          )} not to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint32Array");
@@ -140,15 +153,19 @@ describe("refute.isUint32Array", function () {
 
   it("should fail with custom message", function () {
     var message = "7a548ba3-6efc-4300-8af5-7ff42eb9c064";
+    const actual = new Uint32Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint32Array(new Uint32Array(), message);
+        referee.refute.isUint32Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isUint32Array] ${message}: Expected Uint32Array(0) [] not to be a Uint32Array`
+          `[refute.isUint32Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be a Uint32Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint32Array");

--- a/lib/assertions/is-u-int-8-array.test.js
+++ b/lib/assertions/is-u-int-8-array.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var inspect = require("util").inspect;
 var captureArgs = require("../test-helper/capture-args");
 var referee = require("../referee");
 
@@ -10,15 +11,17 @@ describe("assert.isUint8Array", function () {
   });
 
   it("should fail for Uint16Array", function () {
+    const actual = new Uint16Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint8Array(new Uint16Array());
+        referee.assert.isUint8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint8Array] Expected Uint16Array(0) [] to be a Uint8Array"
+          `[assert.isUint8Array] Expected ${inspect(actual)} to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint8Array");
@@ -28,15 +31,17 @@ describe("assert.isUint8Array", function () {
   });
 
   it("should fail for Uint32Array", function () {
+    const actual = new Uint32Array();
+
     assert.throws(
       function () {
-        referee.assert.isUint8Array(new Uint32Array());
+        referee.assert.isUint8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[assert.isUint8Array] Expected Uint32Array(0) [] to be a Uint8Array"
+          `[assert.isUint8Array] Expected ${inspect(actual)} to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "assert.isUint8Array");
@@ -121,15 +126,19 @@ describe("assert.isUint8Array", function () {
 
 describe("refute.isUint8Array", function () {
   it("should fail for isUint8Array", function () {
+    const actual = new Uint8Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint8Array(new Uint8Array());
+        referee.refute.isUint8Array(actual);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          "[refute.isUint8Array] Expected Uint8Array(0) [] not to be a Uint8Array"
+          `[refute.isUint8Array] Expected ${inspect(
+            actual
+          )} not to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint8Array");
@@ -140,15 +149,19 @@ describe("refute.isUint8Array", function () {
 
   it("should fail with custom message", function () {
     var message = "9ddf1b4c-4382-4744-ae88-d14c69f20626";
+    const actual = new Uint8Array();
+
     assert.throws(
       function () {
-        referee.refute.isUint8Array(new Uint8Array(), message);
+        referee.refute.isUint8Array(actual, message);
       },
       function (error) {
         assert.equal(error.code, "ERR_ASSERTION");
         assert.equal(
           error.message,
-          `[refute.isUint8Array] ${message}: Expected Uint8Array(0) [] not to be a Uint8Array`
+          `[refute.isUint8Array] ${message}: Expected ${inspect(
+            actual
+          )} not to be a Uint8Array`
         );
         assert.equal(error.name, "AssertionError");
         assert.equal(error.operator, "refute.isUint8Array");


### PR DESCRIPTION
Some tests were failing in node 12.14.1, because of changes (likely
improvements) to object formatting. By using `util.inspect` in tests, we
can match the strings correctly, no matter the node version.

#### How to verify - mandatory

1. `git checkout fde76f796baddf2d48edaffed835a0cb966b99ef` (current `master`)
2. `nvm install 12.14.1`
3. `npm ci`
4. `npm test`
5. Observe failing tests
6. Check out this branch
2. `nvm install 12.14.1`
3. `npm ci`
4. `npm test`
5. Observe no failing tests

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
