### PR TITLE
Fix pending promise in async assertion on error

### DIFF
--- a/lib/create-async-assertion.js
+++ b/lib/create-async-assertion.js
@@ -9,7 +9,11 @@ function createAsyncAssertion(thenFunc, catchFunc) {
     function applyCallback(callback, context) {
       return function (actual) {
         self.actual = actual;
-        callback.apply(context, [actual, self.expected]);
+        try {
+          callback.apply(context, [actual, self.expected]);
+        } catch (error) {
+          context.reject(error.message);
+        }
       };
     }
     var assertionPromise = new Promise(function (resolve, reject) {

--- a/lib/create-async-assertion.test.js
+++ b/lib/create-async-assertion.test.js
@@ -65,4 +65,33 @@ describe("createAsyncAssertion", function () {
       });
     });
   });
+
+  describe("applyCallback exception handling", function () {
+    /* eslint-disable mocha/no-setup-in-describe */
+    var reject = function () {
+      throw new Error("Ouch!");
+    };
+    var func = createAsyncAssertion(reject, reject);
+    var fail = sinon.spy();
+    /* eslint-enable mocha/no-setup-in-describe */
+
+    beforeEach(function () {
+      fail.resetHistory();
+    });
+
+    it("should fail the test if thenCallback throws", function () {
+      var promise = func.call({ fail: fail }, Promise.resolve("test"), "test");
+      return promise.then(function () {
+        referee.assert.isTrue(fail.calledOnceWith("Ouch!"));
+      });
+    });
+
+    it("should fail the test if catchCallback throws", function () {
+      // eslint-disable-next-line prefer-promise-reject-errors -- temporary, long term this should use Error
+      var promise = func.call({ fail: fail }, Promise.reject("test"), "test");
+      return promise.then(function () {
+        referee.assert.isTrue(fail.calledOnceWith("Ouch!"));
+      });
+    });
+  });
 });


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

If an exception is thrown in one of the async assertion callbacks, the corresponding promise wasn't resolved. A test case awaiting the promise would hang and timeout.

Example:

```js
const { assert, match } = require('@sinonjs/referee');

describe('test', () => {
  it('hangs', async () => {
    const promise = Promise.resolve('test');
    const matcher = match(() => {
      throw new Error('Ouch!');
    });

    await assert.resolves(promise, matcher);
  });
});
```

#### Solution  - optional

Fail the test with the thrown error message by rejecting the internal assertion promise. Without handling the exception, the assertion promise wouldn't be resolved or rejected and a test case awaiting the promise would hang.

#### How to verify - mandatory

0. Run the above example with mocha and verify that the test case times out.
1. Check out this branch
2. `npm install`
3. `npm test`
4. Run the above example with mocha and verify that the test case fails with the message "Ouch!".

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
