### PR TITLE
Verify lockfile version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Node CI
 on: [push]
 
 jobs:
-  prettier:
+  static-analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,26 +25,6 @@ jobs:
       - name: Prettier
         run: |
           npm run prettier:check
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      - name: Cache modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install dependencies
-        run: |
-          npm ci
-        env:
-          HUSKY_SKIP_INSTALL: 1
       - name: ESLint
         run: |
           npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: mansona/npm-lockfile-version@v1
       - uses: actions/setup-node@v2
         with:
           node-version: "16"


### PR DESCRIPTION
#### Purpose

This PR improves the GitHub Actions workflow to check if `package-lock.json` has the expected `lockfileVersion` value (spoiler: `2`).


#### Background

In #236 I managed to overwrite `package-lock.json` with a file using the old schema. So I had to revert that, and make another PR.

That just makes for a messy git history.

#### Solution 

See https://github.com/mansona/npm-lockfile-version


#### How to verify - mandatory

1. Observe that the `static-analysis` check fails for this branch
2. Delete the `DELETE ME` commit and force push the changes
3. Observe that the `static-analysis` check passes for this branch
